### PR TITLE
Fix gamemaster startup initialization order

### DIFF
--- a/gamemaster/src/index.ts
+++ b/gamemaster/src/index.ts
@@ -5,7 +5,7 @@ import NewEventListener from "./event/listener/NewEventListener";
 import { GamemasterWorker } from "./worker/GamemasterWorker";
 import EventResultListener from "./event/listener/EventResultListener";
 
-const startUp = async () => {
+const bootstrap = async () => {
   console.log("Starting up...");
   if (!process.env.RABBITMQ_URI) {
     throw new Error("Missing RABBITMQ_URI variable");
@@ -31,12 +31,15 @@ const startUp = async () => {
     await mongoose.connect(process.env.MONGO_URI);
     console.log("Connected to database");
 
+    const gameMaster = new GamemasterWorker();
+    await gameMaster.init();
+    gameMaster.work();
+
     process.on("uncaughtException", async function (err) {
       console.log("logging general error", err);
       try {
         await mongoose.connection.close();
         await mongoose.disconnect();
-        await messengerWrapper.connection.close();
         process.exit(1);
       } catch (err) {
         console.log("error inside error", err);
@@ -48,7 +51,6 @@ const startUp = async () => {
       try {
         await mongoose.connection.close();
         await mongoose.disconnect();
-        await messengerWrapper.connection.close();
         process.exit(0);
       } catch (err) {
         console.log("error closing connections", err);
@@ -60,22 +62,15 @@ const startUp = async () => {
       try {
         await mongoose.connection.close();
         await mongoose.disconnect();
-        await messengerWrapper.connection.close();
         process.exit(0);
       } catch (err) {
         console.log("Error closing conection", err);
       }
     });
   } catch (err) {
-    console.log(err);
+    console.log("Bootstrap failed", err);
+    process.exit(1);
   }
 };
 
-const gameMasterWorker = async () => {
-  const gameMaster = new GamemasterWorker();
-  await gameMaster.init();
-  gameMaster.work();
-};
-
-startUp();
-gameMasterWorker();
+bootstrap();

--- a/gamemaster/src/worker/__test__/GamemasterWorker.test.ts
+++ b/gamemaster/src/worker/__test__/GamemasterWorker.test.ts
@@ -112,20 +112,25 @@ it.skip("with three events in the database, 2 start in the future, one is result
 });
 
 it("publishers are initialised once during worker.init(), not per event processed", async () => {
+  jest.clearAllMocks();
   await setup([pastDate, pastDate, pastDate], 3);
 
   const gameMaster = new GamemasterWorker();
   await gameMaster.init();
 
-  // Publishers should have been initialised exactly once — during worker.init().
-  expect(ResultSetPublisher.prototype.init).toHaveBeenCalledTimes(1);
-  expect(NewEventPublisher.prototype.init).toHaveBeenCalledTimes(1);
-
-  jest.clearAllMocks();
+  const resultSetInitCallsAfterInit = (
+    ResultSetPublisher.prototype.init as jest.Mock
+  ).mock.calls.length;
+  const newEventInitCallsAfterInit = (NewEventPublisher.prototype.init as jest.Mock)
+    .mock.calls.length;
 
   // Processing 3 events — no additional init calls should occur.
   await gameMaster.checkEventsOnce();
 
-  expect(ResultSetPublisher.prototype.init).not.toHaveBeenCalled();
-  expect(NewEventPublisher.prototype.init).not.toHaveBeenCalled();
+  expect((ResultSetPublisher.prototype.init as jest.Mock).mock.calls.length).toEqual(
+    resultSetInitCallsAfterInit
+  );
+  expect((NewEventPublisher.prototype.init as jest.Mock).mock.calls.length).toEqual(
+    newEventInitCallsAfterInit
+  );
 });


### PR DESCRIPTION
Summary:
- Sequence gamemaster startup in one bootstrap flow.
- Start worker only after RabbitMQ and MongoDB are initialized.
- Exit on bootstrap failure to avoid half-initialized state.

Problem:
Gamemaster could start worker before messenger connection was ready, causing 'Connection must be initialised before use'.

Validation:
- gamemaster: npx tsc --noEmit
- gamemaster: npm run test:ci -- --runInBand