### PR TITLE
Remove UI version selector and retitle slip

### DIFF
--- a/client/src/Header.js
+++ b/client/src/Header.js
@@ -3,7 +3,6 @@ import { Link, useLocation } from 'react-router-dom';
 
 const Header = ({ currentUser, uiVariant, theme }) => {
     const location = useLocation();
-    const variants = ['v1', 'v2', 'v3'];
     const themeOptions = ['dark', 'light'];
     const isV2 = uiVariant === 'v2';
 
@@ -36,10 +35,6 @@ const Header = ({ currentUser, uiVariant, theme }) => {
     });
 
     const logoLink = linkTo('/', { ui: uiVariant, theme });
-    const variantLink = (variant) => ({
-       pathname: location.pathname,
-       search: buildSearch({ ui: variant }),
-    });
     const themeLink = (nextTheme) => ({
        pathname: location.pathname,
        search: buildSearch({ theme: nextTheme }),
@@ -61,17 +56,6 @@ const Header = ({ currentUser, uiVariant, theme }) => {
                    <span className="text-uppercase navbar-meta__badge">Mode {theme}</span>
                </div>
                <div className="d-flex flex-column flex-lg-row align-items-lg-center gap-2">
-                   <div className="btn-group ui-switcher" role="group" aria-label="Prototype variant switcher">
-                       {variants.map((variant) => (
-                           <Link
-                               key={variant}
-                               to={variantLink(variant)}
-                               className={`btn btn-sm ${uiVariant === variant ? 'btn-primary' : 'btn-shell'}`}
-                           >
-                               {variant.toUpperCase()}
-                           </Link>
-                       ))}
-                   </div>
                    <div className="btn-group ui-switcher" role="group" aria-label="Theme switcher">
                        {themeOptions.map((themeOption) => (
                            <Link

--- a/client/src/pages/Slip.js
+++ b/client/src/pages/Slip.js
@@ -24,12 +24,11 @@ const HandleSlip = ({ sliprefresh, statsrefresh, currentUser, uiVariant }) => {
 
     if (slipRows.length === 0) {
         return currentUser ? <div className={`card card-body empty-state-card slip-board slip-board--${uiVariant}`}>
-            <div className="slip-board__title">Bet Ticket</div>
-            <div className="slip-board__empty-main">Make your slip!</div>
-            <small className="text-secondary">Pick odds from live events to compose your ticket.</small>
+            <div className="slip-board__title">BET SLIP</div>
+            <small className="text-secondary">Pick odds from events to compose your slip.</small>
         </div> :
         <div className={`card card-body empty-state-card slip-board slip-board--${uiVariant}`}>
-            <div className="slip-board__title">Bet Ticket</div>
+            <div className="slip-board__title">BET SLIP</div>
             <div className="slip-board__empty-main">Login and bet!</div>
             <small className="text-secondary">Sign in to track selections and place slips.</small>
         </div>;
@@ -108,7 +107,7 @@ const HandleSlip = ({ sliprefresh, statsrefresh, currentUser, uiVariant }) => {
     </div>
 
     return <div className={`slip-board slip-board--${uiVariant}`}>
-        <div className="slip-board__title">Bet Ticket</div>
+        <div className="slip-board__title">BET SLIP</div>
         {renderedSlip}
         {oddAndPossibleWin}
         {wagerAndBet}


### PR DESCRIPTION
Cleanup after the merged V2 UI branch:
- remove the accidental V1/V2/V3 selector from the live UI
- rename the slip label to BET SLIP
- update the empty-state copy to the approved wording

Live checks were rerun against the updated branch.