### PR TITLE
Fix logo contrast and scoreboard layout

### DIFF
--- a/client/src/pages/account/Statistics.js
+++ b/client/src/pages/account/Statistics.js
@@ -41,19 +41,19 @@ const HandleUserStatistics = ({ uiVariant }) => {
 
     const renderedStats = stats.map(stat => {
       return <div className="card stat-card mb-2" key={stat.userId}>
-        <div className="card-body row stat-row">
-          <div className="col-6">{stat.user}</div>
-          <div className="col-3 text-end">{stat.betamount}</div>
-          <div className="col-3 text-end fw-semibold">{stat.wageramount}</div>
+        <div className="card-body stat-row">
+          <div className="stat-row__user">{stat.user}</div>
+          <div className="stat-row__count">{stat.betamount}</div>
+          <div className="stat-row__wager fw-semibold">{stat.wageramount}</div>
         </div>
       </div>
     })
 
     const statHeader = <div className="card stat-card mb-2" key="stat_header">
-    <div className="card-body row stat-row stat-row--header text-secondary">
-      <div className="col-6">User</div>
-      <div className="col-3 text-end">Bets</div>
-      <div className="col-3 text-end">Wager</div>
+    <div className="card-body stat-row stat-row--header text-secondary">
+      <div className="stat-row__user">User</div>
+      <div className="stat-row__count">Bets</div>
+      <div className="stat-row__wager">Wager</div>
     </div>
   </div>
     

--- a/client/src/styles/ui.css
+++ b/client/src/styles/ui.css
@@ -252,7 +252,58 @@ body {
 }
 
 .scoreboard .stat-card .card-body {
-  row-gap: 0.35rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 3.25rem 3.75rem;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.72rem 0.82rem;
+}
+
+.scoreboard .stat-card {
+  background: color-mix(in srgb, var(--surface-soft) 94%, var(--surface-elevated));
+  border-color: color-mix(in srgb, var(--border-subtle) 88%, var(--accent) 12%);
+  box-shadow: 0 10px 20px rgba(4, 10, 26, 0.1);
+}
+
+.scoreboard .stat-card:hover {
+  border-color: color-mix(in srgb, var(--border-subtle) 72%, var(--accent) 28%);
+}
+
+.stat-row__user,
+.stat-row__count,
+.stat-row__wager {
+  min-width: 0;
+  line-height: 1.2;
+}
+
+.stat-row__user {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stat-row__count,
+.stat-row__wager {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.stat-row--header {
+  font-size: 0.7rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.stat-row--header .stat-row__wager,
+.stat-row--header .stat-row__count {
+  justify-self: end;
+}
+
+.scoreboard--v1 .stat-row__user,
+.scoreboard--v2 .stat-row__user,
+.scoreboard--v3 .stat-row__user {
+  font-weight: 600;
 }
 
 .my-bets-card {


### PR DESCRIPTION
Polishes the V2 UI by:
- making the header logo readable in light and dark themes
- improving light-mode odds contrast
- tightening the scoreboard card layout
- removing the UI/mode badges from the header

This branch has already been built and checked locally.