### PR TITLE
Recover deployment path and restore ingress API fallback

### DIFF
--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -187,7 +187,7 @@ If `dns-check-stan.sh` prints `status=MATCH`, DNS is pointing to current ingress
 ## CI/CD and data-safety posture
 
 - `build-push` runs on `master` and tags each image with `${GITHUB_SHA}`.
-- `build-push` pull requests now run `ingress-routing-guard-stan.sh` and block unsafe ingress host/path edits before merge.
+- `build-push` pull requests run `ingress-routing-guard-stan.sh` and block unsafe ingress host/path edits before merge.
 - `deploy-manifests` runs only after successful `build-push` on `master` and deploys that exact SHA image set.
 - Deploy workflow blocks when mongo PVC count is unexpectedly low, avoiding deployment against unsafe DB storage state.
 - Deploy workflow now runs `deploy-validation-loop-stan.sh` as required post-rollout gate and uploads diagnostics artifacts on failure.


### PR DESCRIPTION
Split from #41: deploy-recovery scope only.\n\nIncludes:\n- deploy/runtime validation loop hardening\n- diagnostics scripts and runbook updates\n- ingress hostless /api fallback restoration\n- smoke/e2e alignment for deployed UI\n\nExcludes coverage/test-harness hardening work, which remains in a separate PR.