### PR TITLE
Fix production API routing for betstan.xyz host

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -4,10 +4,27 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:
+  ingress-routing-guard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate prod ingress host/path safety
+        run: |
+          chmod +x infra/azure/agents/ingress-routing-guard-stan.sh
+          ./infra/azure/agents/ingress-routing-guard-stan.sh
+
   build:
+    if: github.event_name != 'pull_request'
+    needs: [ingress-routing-guard]
     runs-on: ubuntu-latest
 
     strategy:

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -15,6 +15,7 @@
 - `smoke-liveness-stan.sh` — ingress + homepage + auth API + endpoint liveness checks.
 - `deploy-validation-loop-stan.sh` — retries smoke+functional validation and captures diagnostics artifacts on failure.
 - `validation-loop-stan.sh` — repeats health + HTTPS + E2E checks until pass/fail limit.
+- `ingress-routing-guard-stan.sh` — static guard that fails when prod ingress host/path routing is unsafe.
 - `provision-stage-stan.sh` — creates isolated `betstan-rg-stage` AKS and configures autoscaler 1→3 with a larger baseline node size for 1-node stage operation.
 - `park-stage-stan.sh` — stops stage AKS compute while keeping the stage resource group.
 - `resume-stage-stan.sh` — starts stage AKS and runs quick readiness checks.
@@ -110,6 +111,7 @@ If `dns-check-stan.sh` prints `status=MATCH`, DNS is pointing to current ingress
 ## CI/CD and data-safety posture
 
 - `build-push` runs on `master` and tags each image with `${GITHUB_SHA}`.
+- `build-push` pull requests now run `ingress-routing-guard-stan.sh` and block unsafe ingress host/path edits before merge.
 - `deploy-manifests` runs only after successful `build-push` on `master` and deploys that exact SHA image set.
 - Deploy workflow blocks when mongo PVC count is unexpectedly low, avoiding deployment against unsafe DB storage state.
 - Deploy workflow now runs `deploy-validation-loop-stan.sh` as required post-rollout gate and uploads diagnostics artifacts on failure.

--- a/infra/azure/agents/ingress-routing-guard-stan.sh
+++ b/infra/azure/agents/ingress-routing-guard-stan.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Purpose: fail fast when prod ingress host/path routing is unsafe.
+
+INGRESS_FILE="${INGRESS_FILE:-infra/k8s-prod/ingress-srv.yaml}"
+
+if [[ ! -f "$INGRESS_FILE" ]]; then
+  echo "ERROR: ingress file not found: $INGRESS_FILE" >&2
+  exit 1
+fi
+
+require_in_file() {
+  local pattern="$1"
+  local label="$2"
+  if ! grep -qE "$pattern" "$INGRESS_FILE"; then
+    echo "ERROR: missing $label in $INGRESS_FILE" >&2
+    exit 1
+  fi
+}
+
+host_block() {
+  local host="$1"
+  awk -v h="$host" '
+    $0 ~ "^    - host: " h "$" {in_block=1; print; next}
+    in_block && $0 ~ "^    - host: " {exit}
+    in_block && $0 ~ "^    - http:" {exit}
+    in_block {print}
+  ' "$INGRESS_FILE"
+}
+
+assert_host_has_paths() {
+  local host="$1"
+  local block
+  block="$(host_block "$host")"
+  if [[ -z "$block" ]]; then
+    echo "ERROR: host block missing for $host" >&2
+    exit 1
+  fi
+
+  for path in "/api/auth/?(.*)" "/api/event/?(.*)" "/api/slip/?(.*)" "/api/bet/?(.*)" "/api/backoffice/?(.*)"; do
+    if ! grep -Fq "$path" <<<"$block"; then
+      echo "ERROR: host $host missing path $path" >&2
+      exit 1
+    fi
+  done
+}
+
+require_in_file "secretName:[[:space:]]*betstan-tls" "TLS secret betstan-tls"
+require_in_file "^[[:space:]]*-[[:space:]]*betstan\\.xyz$" "TLS host betstan.xyz"
+require_in_file "^[[:space:]]*-[[:space:]]*www\\.betstan\\.xyz$" "TLS host www.betstan.xyz"
+
+assert_host_has_paths "betstan.xyz"
+assert_host_has_paths "www.betstan.xyz"
+echo "ingress_routing_guard=PASS"
+

--- a/infra/k8s-prod/ingress-srv.yaml
+++ b/infra/k8s-prod/ingress-srv.yaml
@@ -10,9 +10,55 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
+        - betstan.xyz
         - www.betstan.xyz
       secretName: betstan-tls
   rules:
+    - host: betstan.xyz
+      http:
+        paths:
+          - path: /api/auth/?(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gaming-auth-srv
+                port:
+                  number: 3000
+          - path: /api/event/?(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gaming-event-srv
+                port:
+                  number: 3000
+          - path: /api/slip/?(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gaming-slip-srv
+                port:
+                  number: 3000
+          - path: /api/bet/?(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gaming-bet-srv
+                port:
+                  number: 3000
+          - path: /api/backoffice/?(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gaming-backoffice-srv
+                port:
+                  number: 3000
+          - path: /?(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: gaming-client-srv
+                port:
+                  number: 3000
     - host: www.betstan.xyz
       http:
         paths:


### PR DESCRIPTION
## Why
Production users on betstan.xyz could see no events because /api/* traffic for the bare host could fall through to the client fallback instead of backend services.

## What
- add betstan.xyz host rule to prod ingress with same API routes as www.betstan.xyz
- include betstan.xyz in TLS hosts list

## Validation
- /api/event returns 200 on www.betstan.xyz
- /api/event returns 200 with Host: betstan.xyz