### PR TITLE
Add reusable Copilot setup and security guardrails

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,49 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            auth/package-lock.json
+            bet/package-lock.json
+            backoffice/package-lock.json
+            client/package-lock.json
+            event/package-lock.json
+            gamemaster/package-lock.json
+            moderation/package-lock.json
+            resulting/package-lock.json
+            slip/package-lock.json
+
+      - name: Install service dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          for dir in auth bet backoffice client event gamemaster moderation resulting slip; do
+            echo "Installing dependencies in ${dir}"
+            (cd "${dir}" && npm ci)
+          done
+
+      - name: Install Playwright browsers for client checks
+        working-directory: client
+        run: npx playwright install --with-deps chromium

--- a/docs/copilot-security-guardrails.md
+++ b/docs/copilot-security-guardrails.md
@@ -1,0 +1,47 @@
+# Copilot Security Guardrails
+
+This repository allows Copilot-assisted work. These rules keep automation useful and safe for a public repository.
+
+## 1. Never commit sensitive information
+
+Do **not** commit any of the following:
+
+- API keys, tokens, passwords, cookies, session IDs
+- kubeconfigs, private certificates, private keys, SSH keys
+- cloud credentials, connection strings, signing secrets
+- internal-only URLs, private hostnames, or customer-identifying data
+
+If sensitive data appears in local output, logs, screenshots, or examples, redact it before commit.
+
+## 2. Safe logs, screenshots, and examples
+
+- Do not paste full production logs in commits or docs.
+- Use synthetic/sample values in examples.
+- Avoid including auth headers, bearer tokens, secret query params, or private IPs.
+- Keep screenshots limited to UI states; avoid exposing secrets in dev tools or terminals.
+
+## 3. Copilot setup workflow rules
+
+- Keep `.github/workflows/copilot-setup-steps.yml` deterministic and minimal.
+- Use least privileges (for now: `contents: read`).
+- Store secrets only in GitHub environment/repository secrets, never inline in YAML.
+- Keep setup focused on tool/dependency bootstrap (no secret-bearing deployment steps).
+
+## 4. Pre-push hygiene checklist
+
+Before pushing:
+
+1. Confirm file scope: only intended files are staged.
+2. Run a quick secret check on staged changes (tokens/keys/password patterns).
+3. Verify no sensitive content in newly added docs/assets.
+4. Confirm the destination PR is open and correct.
+5. Push only after all above checks pass.
+
+## 5. Incident handling
+
+If sensitive data is committed by mistake:
+
+1. Stop and notify maintainers immediately.
+2. Revoke/rotate exposed secrets first.
+3. Remove the data from repository history using approved maintainer workflow.
+4. Document the incident and prevention update in this guardrail doc.


### PR DESCRIPTION
Adds reusable repository artifacts for safer and faster Copilot-assisted work.

- .github/workflows/copilot-setup-steps.yml for deterministic Node, dependency, and Playwright bootstrap
- docs/copilot-security-guardrails.md with no-secrets policy and pre-push hygiene checklist

This captures session learnings while reducing risk of sensitive data exposure in a public repository.