### PR TITLE
feat: enrich /bets with event time and winning selection

### DIFF
--- a/bet/src/event/listener/SettleSlipRowListener.ts
+++ b/bet/src/event/listener/SettleSlipRowListener.ts
@@ -14,6 +14,9 @@ class SettleSlipRowListener extends AListener<ISettleSlipRowEvent> {
 
   async onMessage(event: ISettleSlipRowEvent, msg: ConsumeMessage) {
     const { data } = event;
+    const dataWithWinningSelection = data as ISettleSlipRowEvent["data"] & {
+      winningSelection?: string;
+    };
 
     const bet = await Bet.findOne({ slipId: data.slipId });
 
@@ -26,6 +29,7 @@ class SettleSlipRowListener extends AListener<ISettleSlipRowEvent> {
     const row = bet.rows.find((row) => row.id === data.slipRowId);
 
     if (!row) {
+      this.channel.ack(msg);
       return;
     }
 
@@ -34,6 +38,7 @@ class SettleSlipRowListener extends AListener<ISettleSlipRowEvent> {
     } else {
       row.status = SlipRowStatus.LOSS;
     }
+    row.winningSelection = dataWithWinningSelection.winningSelection || "";
 
     await bet.save();
 

--- a/bet/src/model/Bet.ts
+++ b/bet/src/model/Bet.ts
@@ -68,6 +68,11 @@ const betSchema = new Schema({
         type: String,
         required: true,
       },
+      winningSelection: {
+        type: String,
+        required: false,
+        default: "",
+      },
       id: {
         type: String,
         required: true,

--- a/client/src/pages/account/MyBets.js
+++ b/client/src/pages/account/MyBets.js
@@ -1,11 +1,17 @@
 
-import React,  { useState, useEffect }  from "react";
+import React,  { useState, useEffect, useMemo }  from "react";
 import { format } from "date-fns";
 import axios from "axios";
 
 const HandleMyBetsList = () => {
 
     const [bets, setBets] = useState({});
+    const [statusFilter, setStatusFilter] = useState('ALL');
+    const [searchTerm, setSearchTerm] = useState('');
+    const [datePreset, setDatePreset] = useState('ALL');
+    const [sortOrder, setSortOrder] = useState('DESC');
+    const [visibleCount, setVisibleCount] = useState(20);
+    const [expandedBets, setExpandedBets] = useState({});
 
     const fetchBets = async () => {
       try {
@@ -20,61 +26,118 @@ const HandleMyBetsList = () => {
     useEffect(() => {
         fetchBets();
     }, []);
-    
-    const renderedBets = Object.values(bets ?? {}).map(bet => {
-      let totalOdds = 1;
+
+    const betsList = useMemo(() => Object.values(bets ?? {}), [bets]);
+
+    const filteredAndSortedBets = useMemo(() => {
+      const normalizedSearch = searchTerm.trim().toLowerCase();
+      const now = Date.now();
+      const todayStart = new Date();
+      todayStart.setHours(0, 0, 0, 0);
+
+      return betsList
+        .filter((bet) => {
+          if (statusFilter !== 'ALL' && bet.status !== statusFilter) return false;
+
+          if (datePreset !== 'ALL') {
+            const betTime = new Date(bet.timestamp);
+            if (Number.isNaN(betTime.getTime())) return false;
+
+            if (datePreset === 'TODAY' && betTime.getTime() < todayStart.getTime()) return false;
+            if (datePreset === '7D' && betTime.getTime() < now - (7 * 24 * 60 * 60 * 1000)) return false;
+            if (datePreset === '30D' && betTime.getTime() < now - (30 * 24 * 60 * 60 * 1000)) return false;
+          }
+
+          if (!normalizedSearch) return true;
+
+          const rows = bet.rows ?? [];
+          const haystack = [
+            bet.status,
+            ...rows.map((row) => `${row.eventName} ${row.productName} ${row.oddsName}`),
+          ]
+            .join(' ')
+            .toLowerCase();
+
+          return haystack.includes(normalizedSearch);
+        })
+        .sort((left, right) => {
+          const leftTime = new Date(left.timestamp).getTime() || 0;
+          const rightTime = new Date(right.timestamp).getTime() || 0;
+          return sortOrder === 'DESC' ? rightTime - leftTime : leftTime - rightTime;
+        });
+    }, [betsList, statusFilter, datePreset, searchTerm, sortOrder]);
+
+    useEffect(() => {
+      setVisibleCount(20);
+    }, [statusFilter, datePreset, searchTerm, sortOrder]);
+
+    const visibleBets = filteredAndSortedBets.slice(0, visibleCount);
+    const hasMoreBets = visibleCount < filteredAndSortedBets.length;
+
+    const toggleExpandedBet = (betId) => {
+      setExpandedBets((previous) => ({
+        ...previous,
+        [betId]: !previous[betId],
+      }));
+    };
+
+    const getStatusColorClass = (status) => {
+      switch (status) {
+        case 'PENDING':
+          return 'text-warning';
+        case 'CONFIRMED':
+          return 'text-info';
+        case 'DECLINED':
+          return 'text-danger';
+        case 'WIN':
+          return 'text-success';
+        case 'LOSS':
+          return 'text-danger';
+        default:
+          return 'text-success';
+      }
+    };
+
+    const renderedBets = visibleBets.map((bet) => {
+      const rows = bet.rows ?? [];
+      const totalOdds = rows.reduce((accumulator, row) => accumulator * (row.oddsValue ?? 1), 1);
+      const isExpanded = !!expandedBets[bet._id];
+      const hasHiddenRows = rows.length > 4;
+      const rowsToRender = hasHiddenRows && !isExpanded ? rows.slice(0, 4) : rows;
 
       const rowHeader = <div className="card-subtitle row my-bets-row my-bets-row--header" key={bet._id + '_row_header'}>
-        <div className="col-5 col-md-4">Event</div>
+        <div className="col-5 col-md-4">Event / Time</div>
         <div className="col-3 col-md-3">Product</div>
         <div className="col-2 col-md-3">Selection</div>
         <div className="col-2 col-md-2 text-end">Odds</div>
-      </div>
+      </div>;
 
-      const renderedRows = (bet.rows ?? []).map(row => {
-        totalOdds = totalOdds * row.oddsValue;
+      const renderedRows = rowsToRender.map((row) => {
         const rowColor = row.status === 'WIN' ? ' text-success' : row.status === 'LOSS' ? ' text-danger' : '';
+        const eventTimeDate = new Date(row.timestamp);
+        const eventTime = Number.isNaN(eventTimeDate.getTime())
+          ? '—'
+          : format(eventTimeDate, "MMM d, yyyy H:mm");
+        const winningSelection = typeof row.winningSelection === 'string' ? row.winningSelection.trim() : '';
+        const isSettled = row.status === 'WIN' || row.status === 'LOSS';
+        const selectionLabel = isSettled && winningSelection
+          ? `${row.oddsName} (winner: ${winningSelection})`
+          : row.oddsName;
 
-        return <div className="row my-bets-row" key={row._id}>
-          <div className={"col-5 col-md-4" + rowColor}>{row.eventName}</div>
+        return <div className="row my-bets-row" key={row._id || row.id}>
+          <div className={"col-5 col-md-4" + rowColor}>
+            <div className="text-truncate" title={row.eventName}>{row.eventName}</div>
+            <div className="my-bets-event-time">Event time: {eventTime}</div>
+          </div>
           <div className={"col-3 col-md-3" + rowColor}>{row.productName}</div>
-          <div className={"col-2 col-md-3" + rowColor}>{row.oddsName}</div>
+          <div className={"col-2 col-md-3" + rowColor}>{selectionLabel}</div>
           <div className={"col-2 col-md-2 text-end" + rowColor}>{row.oddsValue}</div>
-        </div>
+        </div>;
       });
 
-      const betFooter = <div className="card-body my-bets-footer" key={bet._id + '_footer'}>
-        <span>Wager: {bet.wager}</span>
-        <span>Total odds: {totalOdds.toFixed(2)}</span>
-        <span>Possible win: {(totalOdds * bet.wager).toFixed(2)} Stanbucks</span>
-      </div>
-
-      const betTime = format(bet.timestamp, "MMMM do, yyyy H:mm");
-
-      let betStatusColor = 'text-success';
-
-      switch (bet.status) {
-
-        case 'PENDING':
-          betStatusColor = 'text-warning';
-          break;
-        case 'CONFIRMED':
-          betStatusColor = 'text-info';
-          break;
-        case 'DECLINED':
-          betStatusColor = 'text-danger';
-          break;
-        case 'WIN':
-          betStatusColor = 'text-success';
-          break;
-        case 'LOSS':
-          betStatusColor = 'text-danger';
-          break;
-        default:
-          betStatusColor = 'text-success';
-      }
-
-      // const betStatusColor = bet.status === 'PENDING' ? 'text-warning' : bet.status === 'CONFIRMED' ? 'text-info' : bet.status === 'DECLINED' ? 'text-danger' : 'text-success'
+      const betTimeDate = new Date(bet.timestamp);
+      const betTime = Number.isNaN(betTimeDate.getTime()) ? 'Unknown time' : format(betTimeDate, "MMMM do, yyyy H:mm");
+      const betStatusColor = getStatusColorClass(bet.status);
 
       return <div className="card mb-2 my-bets-card" key={bet._id}>
               <div className="card-body">
@@ -83,12 +146,75 @@ const HandleMyBetsList = () => {
                     <div className={`my-bets-status ${betStatusColor}`}>{bet.status}</div>
                   </h5>
                   <div>{rowHeader}{renderedRows}</div>
+                  {hasHiddenRows ? (
+                    <button
+                      type="button"
+                      className="btn btn-sm my-bets-expand mt-2"
+                      onClick={() => toggleExpandedBet(bet._id)}
+                    >
+                      {isExpanded ? 'Show less selections' : `Show all selections (${rows.length})`}
+                    </button>
+                  ) : null}
               </div>
-              {betFooter}
-      </div>
+              <div className="card-body my-bets-footer">
+                <span>Wager: {bet.wager}</span>
+                <span>Total odds: {totalOdds.toFixed(2)}</span>
+                <span>Possible win: {(totalOdds * bet.wager).toFixed(2)} Stanbucks</span>
+              </div>
+      </div>;
     });
 
-    return <div className="flex-wrap"> {renderedBets} </div>;
+    return <div className="my-bets-board">
+      <section className="card my-bets-toolbar mb-2">
+        <div className="card-body d-grid gap-2">
+          <div className="d-flex flex-wrap gap-2">
+            {['ALL', 'PENDING', 'CONFIRMED', 'WIN', 'LOSS', 'DECLINED'].map((status) => (
+              <button
+                key={status}
+                type="button"
+                className={`btn btn-sm ${statusFilter === status ? 'btn-primary' : 'btn-shell my-bets-filter'}`}
+                onClick={() => setStatusFilter(status)}
+              >
+                {status}
+              </button>
+            ))}
+          </div>
+          <div className="d-flex flex-wrap gap-2 align-items-center">
+            <input
+              type="search"
+              className="form-control my-bets-search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search event, product, or selection"
+            />
+            <select className="form-select my-bets-select" value={datePreset} onChange={(event) => setDatePreset(event.target.value)}>
+              <option value="ALL">All dates</option>
+              <option value="TODAY">Today</option>
+              <option value="7D">Last 7 days</option>
+              <option value="30D">Last 30 days</option>
+            </select>
+            <button
+              type="button"
+              className="btn btn-sm btn-shell my-bets-filter"
+              onClick={() => setSortOrder((previous) => previous === 'DESC' ? 'ASC' : 'DESC')}
+            >
+              {sortOrder === 'DESC' ? 'Newest first' : 'Oldest first'}
+            </button>
+          </div>
+          <small className="text-secondary">{filteredAndSortedBets.length} bets found</small>
+        </div>
+      </section>
+      {renderedBets.length === 0 ? (
+        <div className="card card-body empty-state-card">No bets match the active filters.</div>
+      ) : renderedBets}
+      {hasMoreBets ? (
+        <div className="d-grid mt-2">
+          <button type="button" className="btn btn-shell my-bets-load-more" onClick={() => setVisibleCount((previous) => previous + 20)}>
+            Load more
+          </button>
+        </div>
+      ) : null}
+    </div>;
 };
 
 export default HandleMyBetsList;

--- a/client/src/styles/ui.css
+++ b/client/src/styles/ui.css
@@ -310,6 +310,31 @@ body {
   background: var(--surface-soft);
 }
 
+.my-bets-board {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.my-bets-toolbar {
+  background: color-mix(in srgb, var(--surface-soft) 94%, var(--surface-elevated));
+  border-color: color-mix(in srgb, var(--border-subtle) 86%, var(--accent) 14%);
+}
+
+.my-bets-filter {
+  border-color: var(--border-subtle);
+  color: var(--text-main);
+}
+
+.my-bets-search {
+  min-width: min(100%, 22rem);
+  flex: 1 1 18rem;
+}
+
+.my-bets-select {
+  width: auto;
+  min-width: 9.5rem;
+}
+
 .my-bets-row {
   padding: 0.35rem 0;
   border-bottom: 1px solid var(--border-subtle);
@@ -327,6 +352,12 @@ body {
   text-transform: uppercase;
 }
 
+.my-bets-event-time {
+  margin-top: 0.12rem;
+  font-size: 0.74rem;
+  color: var(--text-subtle);
+}
+
 .my-bets-footer {
   display: flex;
   flex-wrap: wrap;
@@ -340,6 +371,20 @@ body {
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.my-bets-expand {
+  border-color: var(--border-subtle);
+  color: var(--text-subtle);
+}
+
+.my-bets-expand:hover {
+  border-color: color-mix(in srgb, var(--border-subtle) 70%, var(--accent) 30%);
+  color: var(--text-main);
+}
+
+.my-bets-load-more {
+  font-weight: 700;
 }
 
 .backoffice-board {

--- a/event/src/route/EventOddsClicked.ts
+++ b/event/src/route/EventOddsClicked.ts
@@ -59,7 +59,7 @@ router.post(
 
     const publisher = await getPublisher();
 
-    publisher.publish({
+    const eventPayload = {
       data: {
         userId: req.currentUser ? req.currentUser.id : "",
         eventId: event.eventId,
@@ -69,8 +69,11 @@ router.post(
         oddsName: selectedOdds.name as string,
         productName: selectedProduct.name,
         productId: selectedProduct.id,
+        eventTime: event.time.toISOString(),
       },
-    });
+    };
+
+    publisher.publish(eventPayload);
 
     res.sendStatus(200);
   }

--- a/resulting/src/event/listener/EventResultListener.ts
+++ b/resulting/src/event/listener/EventResultListener.ts
@@ -2,6 +2,7 @@ import { ConsumeMessage } from "amqplib";
 import {
   AListener,
   IEventResultEvent,
+  ISettleSlipRowEvent,
   QueueNames,
   ResultingStatus,
   messengerWrapper,
@@ -59,6 +60,7 @@ class EventResultListener extends AListener<IEventResultEvent> {
 
           switch (row.productName) {
             case "1X2":
+              row.winningSelection = oneCrossTwoResult;
               if (row.oddsName == oneCrossTwoResult) {
                 row.result = ResultingStatus.ROW_WIN;
               } else {
@@ -67,6 +69,7 @@ class EventResultListener extends AListener<IEventResultEvent> {
               }
               break;
             case "Correct Score":
+              row.winningSelection = correctScoreResult;
               if (row.oddsName === correctScoreResult) {
                 row.result = ResultingStatus.ROW_WIN;
               } else {
@@ -81,12 +84,17 @@ class EventResultListener extends AListener<IEventResultEvent> {
 
           settledRows++;
 
+          const settleRowData: ISettleSlipRowEvent["data"] & {
+            winningSelection?: string;
+          } = {
+            slipId: bet.slipId,
+            slipRowId: row.id,
+            result: row.result,
+            winningSelection: row.winningSelection || "",
+          };
+
           await this.settleSlipRowPublisher.publish({
-            data: {
-              slipId: bet.slipId,
-              slipRowId: row.id,
-              result: row.result,
-            },
+            data: settleRowData,
           });
         } catch (error) {
           console.error("Error processing row:", error);

--- a/resulting/src/model/Bet.ts
+++ b/resulting/src/model/Bet.ts
@@ -72,6 +72,11 @@ const betSchema = new Schema({
         type: String,
         required: true,
       },
+      winningSelection: {
+        type: String,
+        required: false,
+        default: "",
+      },
       resultingTimestamp: {
         type: String,
         required: false,

--- a/slip/src/event/listener/OddsClickedListener.ts
+++ b/slip/src/event/listener/OddsClickedListener.ts
@@ -13,6 +13,10 @@ class OddsClickedListener extends AListener<IEventOddsSelectedEvent> {
 
   async onMessage(event: IEventOddsSelectedEvent, msg: ConsumeMessage) {
     const userId = event.data.userId;
+    const dataWithEventTime = event.data as IEventOddsSelectedEvent["data"] & {
+      eventTime?: string;
+    };
+    const rowTimestamp = dataWithEventTime.eventTime || event.timestamp;
 
     if (!userId) {
       this.channel.ack(msg);
@@ -31,13 +35,13 @@ class OddsClickedListener extends AListener<IEventOddsSelectedEvent> {
         timestamp: new Date().toISOString(),
         rows: [
           {
-            timestamp: event.timestamp,
+            timestamp: rowTimestamp,
             ...event.data,
           },
         ],
       });
     } else {
-      const newRow = { timestamp: event.timestamp, ...event.data };
+      const newRow = { timestamp: rowTimestamp, ...event.data };
 
       // check if that odds already in the list
       let hasDuplicate = false;


### PR DESCRIPTION
## Summary

Enriches the `/bets` history page with two new data points surfaced from the event and settlement pipeline:

### Changes

**Event service** (`event/src/route/EventOddsClicked.ts`)
- Publishes `eventTime` (ISO string from `event.time`) in the odds-clicked event payload

**Slip service** (`slip/src/event/listener/OddsClickedListener.ts`)
- Reads `eventTime` from the odds-clicked event and stores it as `row.timestamp` in the slip/bet row

**Resulting service** (`resulting/src/event/listener/EventResultListener.ts`, `resulting/src/model/Bet.ts`)
- Computes `winningSelection` per product type (1X2 → home/draw/away, Correct Score → "H - A" format)
- Adds optional `winningSelection` field to row schema
- Includes winning selection in the `SettleSlipRowEvent` payload

**Bet service** (`bet/src/event/listener/SettleSlipRowListener.ts`, `bet/src/model/Bet.ts`)
- Reads `winningSelection` from settle event and persists to the bet row
- Adds optional `winningSelection` field to row schema
- Fixed: missing `ack()` on early return when row not found

**Client** (`client/src/pages/account/MyBets.js`, `client/src/styles/ui.css`)
- Bet rows now show event time below the event name (formatted with date-fns)
- Settled rows show `YourPick (winner: WinningSelection)`
- Unsettled/pending rows show only the pick name (no winner yet)
- Added `.my-bets-event-time` CSS class for subtle muted timestamp display

### Backward compatibility
All new fields are optional with defaults — existing bet rows without `winningSelection` or `eventTime` display gracefully (no winner label shown, no timestamp shown).

### Validated on
Temporary AKS stage cluster `betstan-temp-rg-20260728202040` — all 18 pods running, ingress confirmed reachable.