### PR TITLE
ci: enforce quality gates on dev pull requests

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -6,6 +6,7 @@ on:
       - master
   pull_request:
     branches:
+      - dev
       - master
   workflow_dispatch:
 
@@ -123,8 +124,8 @@ jobs:
               --collectCoverageFrom=src/hook/UseRequest.js \
               --collectCoverageFrom=src/pages/auth/NewUser.js \
               --collectCoverageFrom=src/pages/auth/LogIn.js \
-              --collectCoverageFrom=src/pages/auth/LogOut.js \
-            || echo "client_no_tests=true" >> "$GITHUB_ENV"
+              --collectCoverageFrom=src/pages/auth/LogOut.js
+            npm run build
           else
             npm run test:ci -- --runInBand --coverage --coverageReporters=json-summary
           fi
@@ -133,7 +134,6 @@ jobs:
         working-directory: ./${{ matrix.service }}
         run: |
           node -e "
-            if (process.env.client_no_tests === 'true') { console.log('Skipping gate: client has no tests'); process.exit(0); }
             const fs = require('fs');
             const p = 'coverage/coverage-summary.json';
             if (!fs.existsSync(p)) { console.error('Missing ' + p); process.exit(1); }
@@ -144,7 +144,7 @@ jobs:
             const branches = t.branches?.pct ?? 0;
             console.log('lines=' + lines + ' branches=' + branches + ' branchTotal=' + branchTotal);
             if (lines < 80) { console.error('Line coverage gate failed (<80%)'); process.exit(1); }
-            if (branchTotal > 0 && branches > 0 && branches < 80) { console.error('Branch coverage gate failed (<80%)'); process.exit(1); }
+            if (branchTotal > 0 && branches < 80) { console.error('Branch coverage gate failed (<80%)'); process.exit(1); }
           "
 
   build:

--- a/gamemaster/src/event/listener/__test__/EventResultListener.test.ts
+++ b/gamemaster/src/event/listener/__test__/EventResultListener.test.ts
@@ -108,3 +108,34 @@ it("when event is resulted and moved to archive", async () => {
   expect(archievedEvent?.status).toEqual(EventStatus.RESULTED);
   expect(NewEventPublisher.prototype.publish).not.toHaveBeenCalled();
 });
+
+it("acknowledges self-emitted result events without changing stored events", async () => {
+  const { listener, events, message } = await setup();
+  const data = {
+    ...getData(3, 0, events[0].eventId, "Team 1", "Team 2"),
+    sender: listener.serviceName,
+  };
+
+  await listener.onMessage(data, message);
+
+  expect(await Event.countDocuments()).toEqual(1);
+  expect(await EventArchive.countDocuments()).toEqual(0);
+  expect(listener.ack).toHaveBeenCalledWith(message);
+});
+
+it("acknowledges result events when the stored event is missing", async () => {
+  const { listener, message } = await setup();
+  const data = getData(
+    3,
+    0,
+    new mongoose.Types.ObjectId().toHexString(),
+    "Missing",
+    "Event"
+  );
+
+  await listener.onMessage(data, message);
+
+  expect(await Event.countDocuments()).toEqual(1);
+  expect(await EventArchive.countDocuments()).toEqual(0);
+  expect(listener.ack).toHaveBeenCalledWith(message);
+});


### PR DESCRIPTION
## Summary

Makes the existing centralized quality matrix apply to the repository's normal feature-branch workflow:

- runs `build-push` validation for pull requests targeting `dev` as well as `master`
- removes the client test-failure bypass
- requires a production client build after client tests
- fixes the branch gate so 0% coverage fails when branches exist

## Deployment safety

Pull requests still cannot build or push images because the `build` job excludes `pull_request` events. `deploy-manifests` also remains restricted to successful `master` workflow runs.

## Deliberately deferred

Per-service workflow consolidation, broader client coverage, Playwright gating, Docker productionization, legacy deploy cleanup, branch protection, and security scanning remain separate changes requiring their own baselines and approval.
