### PR TITLE
feat: professional login and account creation

### DIFF
--- a/auth/src/index.ts
+++ b/auth/src/index.ts
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import { app } from "./app";
+import { User } from "./model/User";
 
 const startUp = async () => {
   if (!process.env.JWT_KEY) {
@@ -12,6 +13,7 @@ const startUp = async () => {
 
   try {
     await mongoose.connect(process.env.MONGO_URI);
+    await User.init();
     console.log("Connected to database");
   } catch (err) {
     throw new Error();

--- a/auth/src/model/User.ts
+++ b/auth/src/model/User.ts
@@ -6,6 +6,10 @@ const userSchema = new Schema({
     type: String,
     required: true,
   },
+  identifierNormalized: {
+    type: String,
+    required: false,
+  },
   password: {
     type: String,
     required: true,
@@ -17,6 +21,25 @@ const userSchema = new Schema({
   lastLogin: {
     type: String,
     required: false,
+  },
+});
+
+userSchema.index(
+  { identifierNormalized: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      identifierNormalized: { $type: "string" },
+    },
+  }
+);
+
+userSchema.set("toJSON", {
+  transform: (_document, returnedObject) => {
+    delete returnedObject.password;
+    delete returnedObject.identifierNormalized;
+    delete returnedObject.__v;
+    return returnedObject;
   },
 });
 

--- a/auth/src/route/LogIn.ts
+++ b/auth/src/route/LogIn.ts
@@ -5,8 +5,15 @@ import { Password } from "../service/Password";
 import jwt from "jsonwebtoken";
 import { BadRequestError, validateRequest } from "@betstan/common";
 import { LoginAttempt } from "../model/LoginAttempt";
+import { normalizeIdentifier, toPublicUser } from "../service/Identifier";
 
 const router = express.Router();
+const identifierPattern = /^[\x21-\x7E]+$/;
+
+type LoginBody = {
+  email: string;
+  password: string;
+};
 
 const logLoginAttempt = async (req: Request, email: string) => {
   const loginAttempt = new LoginAttempt({
@@ -21,26 +28,43 @@ const logLoginAttempt = async (req: Request, email: string) => {
 router.post(
   "/api/auth/login",
   [
-    body("email").isEmail().withMessage("Email must be valid"),
-    body("password").trim().notEmpty().withMessage("Password must be provided"),
+    body("email")
+      .isString()
+      .withMessage("Username or email must be text")
+      .bail()
+      .trim()
+      .isLength({ min: 3, max: 254 })
+      .withMessage("Username or email must be between 3 and 254 characters")
+      .bail()
+      .matches(identifierPattern)
+      .withMessage("Username or email cannot contain spaces"),
+    body("password")
+      .isString()
+      .withMessage("Password must be provided")
+      .bail()
+      .trim()
+      .notEmpty()
+      .withMessage("Password must be provided"),
   ],
   validateRequest,
-  async (req: Request, res: Response) => {
-    const { email, password } = req.body;
+  async (req: Request<{}, {}, LoginBody>, res: Response) => {
+    const { email: identifier, password } = req.body;
+    const identifierNormalized = normalizeIdentifier(identifier);
 
-    const existingUser = await User.findOne({ email });
+    const existingUser =
+      (await User.findOne({ identifierNormalized })) ||
+      (await User.findOne({ email: identifier }));
 
     if (!existingUser) {
-      logLoginAttempt(req, email);
+      await logLoginAttempt(req, identifier);
       throw new BadRequestError("Invalid credentials");
     }
 
     if (!(await Password.compare(existingUser.password, password))) {
-      logLoginAttempt(req, email);
+      await logLoginAttempt(req, identifier);
       throw new BadRequestError("Invalid credentials");
     }
 
-    // generate jwt
     const userJwt = jwt.sign(
       {
         id: existingUser.id,
@@ -50,7 +74,6 @@ router.post(
       process.env.JWT_KEY!
     );
 
-    // store jwt in session object
     req.session = {
       jwt: userJwt,
     };
@@ -58,7 +81,7 @@ router.post(
     existingUser.set({ lastLogin: new Date().toISOString() });
     await existingUser.save();
 
-    res.status(200).send(existingUser);
+    res.status(200).send(toPublicUser(existingUser));
   }
 );
 

--- a/auth/src/route/NewUser.ts
+++ b/auth/src/route/NewUser.ts
@@ -3,51 +3,85 @@ import { body } from "express-validator";
 import { User } from "../model/User";
 import jwt from "jsonwebtoken";
 import { validateRequest, BadRequestError } from "@betstan/common";
+import {
+  isDuplicateKeyError,
+  normalizeIdentifier,
+  toPublicUser,
+} from "../service/Identifier";
 
 const router = express.Router();
+const identifierPattern = /^[A-Za-z0-9][A-Za-z0-9._%+@-]*$/;
+
+type NewUserBody = {
+  email: string;
+  password: string;
+};
 
 router.post(
   "/api/auth/new",
   [
-    body("email").isEmail().withMessage("email must be provided"),
+    body("email")
+      .isString()
+      .withMessage("Username must be text")
+      .bail()
+      .trim()
+      .isLength({ min: 3, max: 40 })
+      .withMessage("Username must be between 3 and 40 characters")
+      .bail()
+      .matches(identifierPattern)
+      .withMessage(
+        "Username may contain letters, numbers, dots, underscores, hyphens, +, %, and @"
+      ),
     body("password")
+      .isString()
+      .withMessage("Password must be provided")
+      .bail()
       .trim()
       .isLength({ min: 4, max: 20 })
       .withMessage("Password must be between 4 and 20 characters"),
   ],
   validateRequest,
-  async (req: Request, res: Response) => {
-    const { email, password } = req.body;
-    const existingUser = await User.findOne({ email });
+  async (req: Request<{}, {}, NewUserBody>, res: Response) => {
+    const { email: identifier, password } = req.body;
+    const identifierNormalized = normalizeIdentifier(identifier);
+    const existingUser = await User.findOne({
+      $or: [{ identifierNormalized }, { email: identifier }],
+    }).collation({ locale: "en", strength: 2 });
 
     if (existingUser) {
-      throw new BadRequestError("Email is in use");
+      throw new BadRequestError("That username is already in use");
     }
 
-    const user = await User.create({
-      email,
-      password,
-      timestamp: new Date().toISOString(),
-      lastLogin: new Date().toISOString(),
-    });
-    await user.save();
+    try {
+      const user = await User.create({
+        email: identifier,
+        identifierNormalized,
+        password,
+        timestamp: new Date().toISOString(),
+        lastLogin: new Date().toISOString(),
+      });
 
-    // generate jwt
-    const userJwt = jwt.sign(
-      {
-        id: user.id,
-        email: user.email,
-        timestamp: new Date(),
-      },
-      process.env.JWT_KEY!
-    );
+      const userJwt = jwt.sign(
+        {
+          id: user.id,
+          email: user.email,
+          timestamp: new Date(),
+        },
+        process.env.JWT_KEY!
+      );
 
-    // store jwt in session object
-    req.session = {
-      jwt: userJwt,
-    };
+      req.session = {
+        jwt: userJwt,
+      };
 
-    res.status(201).send(user);
+      return res.status(201).send(toPublicUser(user));
+    } catch (error) {
+      if (isDuplicateKeyError(error)) {
+        throw new BadRequestError("That username is already in use");
+      }
+
+      throw error;
+    }
   }
 );
 

--- a/auth/src/route/__test__/LogIn.test.ts
+++ b/auth/src/route/__test__/LogIn.test.ts
@@ -1,61 +1,75 @@
 import request from "supertest";
 import { app } from "../../app";
+import { User } from "../../model/User";
 
-const createUser = async () => {
+const createUser = async (identifier = "test@test.com") => {
   await request(app)
     .post("/api/auth/new")
-    .send({ email: "test@test.com", password: "password" })
+    .send({ email: identifier, password: "password" })
     .expect(201);
 };
 
-it("returns 200 on successful login", async () => {
-  await createUser();
+it("logs in with a non-email username regardless of case", async () => {
+  await createUser("Stan_1");
 
   const response = await request(app)
     .post("/api/auth/login")
-    .send({ email: "test@test.com", password: "password" })
+    .send({ email: "stan_1", password: "password" })
     .expect(200);
 
+  expect(response.body).toEqual({
+    id: expect.any(String),
+    email: "Stan_1",
+  });
+  expect(response.body.password).toBeUndefined();
+  expect(response.body.identifierNormalized).toBeUndefined();
   expect(response.get("Set-Cookie")).toBeDefined();
 });
 
-it("returns 400 with an invalid email", async () => {
-  await request(app)
-    .post("/api/auth/login")
-    .send({ email: "not-an-email", password: "password" })
-    .expect(400);
-});
-
-it("returns 400 with missing password", async () => {
-  await request(app)
-    .post("/api/auth/login")
-    .send({ email: "test@test.com" })
-    .expect(400);
-});
-
-it("returns 400 when email does not exist", async () => {
-  await request(app)
-    .post("/api/auth/login")
-    .send({ email: "nonexistent@test.com", password: "password" })
-    .expect(400);
-});
-
-it("returns 400 with wrong password", async () => {
-  await createUser();
+it("continues to log in a legacy email record", async () => {
+  await User.create({
+    email: "Legacy@Test.com",
+    password: "password",
+    timestamp: new Date().toISOString(),
+    lastLogin: new Date().toISOString(),
+  });
 
   await request(app)
     .post("/api/auth/login")
-    .send({ email: "test@test.com", password: "wrongpassword" })
-    .expect(400);
-});
-
-it("sets a cookie after successful login", async () => {
-  await createUser();
-
-  const response = await request(app)
-    .post("/api/auth/login")
-    .send({ email: "test@test.com", password: "password" })
+    .send({ email: "Legacy@Test.com", password: "password" })
     .expect(200);
+});
 
-  expect(response.get("Set-Cookie")).toBeDefined();
+it.each([
+  ["an object identifier", { $gt: "" }],
+  ["an array identifier", ["testuser"]],
+  ["an identifier containing spaces", "test user"],
+])("returns 400 with %s", async (_description, email) => {
+  await request(app)
+    .post("/api/auth/login")
+    .send({ email, password: "password" })
+    .expect(400);
+});
+
+it("returns 400 with a missing password", async () => {
+  await request(app)
+    .post("/api/auth/login")
+    .send({ email: "testuser" })
+    .expect(400);
+});
+
+it("returns 400 when the username does not exist", async () => {
+  await request(app)
+    .post("/api/auth/login")
+    .send({ email: "missing-user", password: "password" })
+    .expect(400);
+});
+
+it("returns 400 with the wrong password", async () => {
+  await createUser("testuser");
+
+  await request(app)
+    .post("/api/auth/login")
+    .send({ email: "testuser", password: "wrongpassword" })
+    .expect(400);
 });

--- a/auth/src/route/__test__/NewUser.test.ts
+++ b/auth/src/route/__test__/NewUser.test.ts
@@ -1,7 +1,25 @@
 import request from "supertest";
 import { app } from "../../app";
+import { User } from "../../model/User";
 
-it("returns 201 on successful signup", async () => {
+it("creates an account with a non-email username", async () => {
+  const response = await request(app)
+    .post("/api/auth/new")
+    .send({ email: "stan_1", password: "password" })
+    .expect(201);
+
+  expect(response.body).toEqual({
+    id: expect.any(String),
+    email: "stan_1",
+  });
+  expect(response.body.password).toBeUndefined();
+  expect(response.body.identifierNormalized).toBeUndefined();
+
+  const user = await User.findOne({ email: "stan_1" });
+  expect(user?.identifierNormalized).toEqual("stan_1");
+});
+
+it("continues to accept an email-shaped username", async () => {
   const response = await request(app)
     .post("/api/auth/new")
     .send({ email: "test@test.com", password: "password" })
@@ -10,48 +28,85 @@ it("returns 201 on successful signup", async () => {
   expect(response.body.email).toEqual("test@test.com");
 });
 
-it("returns 400 with an invalid email", async () => {
+it.each([
+  ["a username that is too short", "ab"],
+  ["a username containing spaces", "stan user"],
+  ["a username containing unsupported punctuation", "stan!"],
+  ["an object identifier", { $gt: "" }],
+  ["an array identifier", ["stan"]],
+])("returns 400 with %s", async (_description, email) => {
   await request(app)
     .post("/api/auth/new")
-    .send({ email: "not-an-email", password: "password" })
+    .send({ email, password: "password" })
+    .expect(400);
+});
+
+it("returns 400 with a username that is too long", async () => {
+  await request(app)
+    .post("/api/auth/new")
+    .send({ email: `s${"a".repeat(40)}`, password: "password" })
     .expect(400);
 });
 
 it("returns 400 with a password that is too short", async () => {
   await request(app)
     .post("/api/auth/new")
-    .send({ email: "test@test.com", password: "ab" })
+    .send({ email: "testuser", password: "ab" })
     .expect(400);
 });
 
 it("returns 400 with a password that is too long", async () => {
   await request(app)
     .post("/api/auth/new")
-    .send({ email: "test@test.com", password: "a".repeat(21) })
+    .send({ email: "testuser", password: "a".repeat(21) })
     .expect(400);
 });
 
-it("returns 400 with missing email or password", async () => {
-  await request(app).post("/api/auth/new").send({ email: "test@test.com" }).expect(400);
-  await request(app).post("/api/auth/new").send({ password: "password" }).expect(400);
-});
-
-it("disallows duplicate emails", async () => {
+it("returns 400 with a missing username or password", async () => {
   await request(app)
     .post("/api/auth/new")
-    .send({ email: "test@test.com", password: "password" })
+    .send({ email: "testuser" })
+    .expect(400);
+  await request(app)
+    .post("/api/auth/new")
+    .send({ password: "password" })
+    .expect(400);
+});
+
+it("rejects usernames that differ only by case", async () => {
+  await request(app)
+    .post("/api/auth/new")
+    .send({ email: "Stan_1", password: "password" })
     .expect(201);
 
   await request(app)
     .post("/api/auth/new")
-    .send({ email: "test@test.com", password: "password" })
+    .send({ email: "stan_1", password: "password" })
     .expect(400);
+});
+
+it("enforces username uniqueness for concurrent requests", async () => {
+  await User.init();
+
+  const responses = await Promise.all([
+    request(app)
+      .post("/api/auth/new")
+      .send({ email: "concurrent-user", password: "password" }),
+    request(app)
+      .post("/api/auth/new")
+      .send({ email: "concurrent-user", password: "password" }),
+  ]);
+
+  expect(responses.map(({ status }) => status).sort()).toEqual([201, 400]);
+  expect(
+    await User.countDocuments({ identifierNormalized: "concurrent-user" })
+  ).toEqual(1);
 });
 
 it("sets a cookie after successful signup", async () => {
   const response = await request(app)
     .post("/api/auth/new")
-    .send({ email: "test@test.com", password: "password" })
+    .send({ email: "testuser", password: "password" })
     .expect(201);
 
   expect(response.get("Set-Cookie")).toBeDefined();

--- a/auth/src/service/Identifier.ts
+++ b/auth/src/service/Identifier.ts
@@ -1,0 +1,18 @@
+type PublicUserSource = {
+  _id: unknown;
+  email: string;
+};
+
+export const normalizeIdentifier = (identifier: string) =>
+  identifier.trim().toLowerCase();
+
+export const toPublicUser = (user: PublicUserSource) => ({
+  id: String(user._id),
+  email: user.email,
+});
+
+export const isDuplicateKeyError = (error: unknown) =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  error.code === 11000;

--- a/client/src/hook/UseRequest.js
+++ b/client/src/hook/UseRequest.js
@@ -35,8 +35,8 @@ import { useState } from 'react';
         } catch (err) {
             const messages = buildErrorMessages(err);
             setErrors(
-                <div className="alert alert-danger">
-                    <h4>Ooops...</h4>
+                <div className="alert alert-danger" role="alert">
+                    <h4>Please check your details</h4>
                     <ul className="my-0">
                         {messages.map((message, index) => <li key={`${message}-${index}`}>{message}</li>)}
                     </ul>

--- a/client/src/pages/auth/AuthPanel.js
+++ b/client/src/pages/auth/AuthPanel.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const AuthPanel = ({ icon, title, subtitle, children, footer }) => (
+  <section className="card auth-card" aria-labelledby="auth-panel-title">
+    <div className="card-body">
+      <header className="auth-card__header">
+        <span className="auth-card__icon" aria-hidden="true">
+          <img src={icon} alt="" />
+        </span>
+        <h1 className="auth-card__title" id="auth-panel-title">{title}</h1>
+        <p className="auth-card__subtitle">{subtitle}</p>
+      </header>
+      {children}
+      <footer className="auth-card__footer">{footer}</footer>
+    </div>
+  </section>
+);
+
+export default AuthPanel;

--- a/client/src/pages/auth/LogIn.js
+++ b/client/src/pages/auth/LogIn.js
@@ -1,50 +1,85 @@
 
-import React,  { useState }  from "react";
-import { useNavigate } from 'react-router-dom';
+import React, { useState } from "react";
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import UseRequest from "../../hook/UseRequest";
+import AuthPanel from "./AuthPanel";
 
 const HandleLogIn = ({callback}) => {
-
-  const [ email, setEmail ] = useState('') ;
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+  const location = useLocation();
   const { doRequest, errors } = UseRequest({
     url: '/api/auth/login',
     method: 'post',
     body: {
-        email, password
+      email: identifier,
+      password,
     },
     onSuccess: () => {
-      navigate('/');
+      navigate({ pathname: '/', search: location.search });
       callback();
     }
-});
+  });
 
-  const navigate = useNavigate();
-
-  const onSubmit = async (event) => {
+  const onSubmit = (event) => {
     event.preventDefault();
-
     doRequest();
+  };
 
-  }
-
-  return <div className="card auth-card">
-    <div className="card-body">
-      <h1 className="h4 mb-3">Sign in</h1> 
-      <form onSubmit={onSubmit}>
-        <div className="form-group mb-2">
-            <label>Email Address</label>
-            <input value={email} onChange={e => setEmail(e.target.value)} className="form-control"/>
+  return (
+    <AuthPanel
+      icon="/icons/login.svg"
+      title="Log in to your account"
+      subtitle="Enter your username or email and password to continue."
+      footer={(
+        <>
+          <span>New to BetStan?</span>
+          <Link
+            className="auth-card__link"
+            to={{ pathname: '/signup', search: location.search }}
+          >
+            Create an account
+          </Link>
+        </>
+      )}
+    >
+      <form className="auth-form" onSubmit={onSubmit}>
+        <div className="auth-field">
+          <label className="auth-label" htmlFor="login-identifier">Username or email</label>
+          <input
+            id="login-identifier"
+            name="username"
+            type="text"
+            value={identifier}
+            onChange={(event) => setIdentifier(event.target.value)}
+            className="form-control auth-control"
+            autoComplete="username"
+            autoCapitalize="none"
+            spellCheck={false}
+            minLength={3}
+            maxLength={254}
+            required
+          />
         </div>
-        <div className="form-group mb-3">
-            <label>Password</label>
-            <input value={password} onChange={e => setPassword(e.target.value)} type="password" className="form-control"/>
+        <div className="auth-field">
+          <label className="auth-label" htmlFor="login-password">Password</label>
+          <input
+            id="login-password"
+            name="password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="form-control auth-control"
+            autoComplete="current-password"
+            required
+          />
         </div>
-        {errors}
-        <button className="btn auth-submit w-100">Sign In</button>
+        <div className="auth-errors" aria-live="polite">{errors}</div>
+        <button className="btn auth-submit w-100" type="submit">Log in</button>
       </form>
-    </div>
-  </div>;
+    </AuthPanel>
+  );
 };
 
 export default HandleLogIn;

--- a/client/src/pages/auth/LogIn.test.js
+++ b/client/src/pages/auth/LogIn.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import LogIn from './LogIn';
@@ -18,28 +19,42 @@ describe('LogIn page', () => {
     jest.clearAllMocks();
   });
 
-  it('submits login form using UseRequest', () => {
+  it('renders and submits an accessible login form', () => {
     const doRequest = jest.fn();
     UseRequest.mockReturnValue({
       doRequest,
       errors: null,
     });
 
-    const { container } = render(
-      <MemoryRouter>
+    render(
+      <MemoryRouter initialEntries={['/login?ui=v2&theme=light']}>
         <LogIn callback={jest.fn()} />
       </MemoryRouter>
     );
 
-    const inputs = container.querySelectorAll('input');
-    fireEvent.change(inputs[0], { target: { value: 'qa@betstan.xyz' } });
-    fireEvent.change(inputs[1], { target: { value: 'Password123!Password123!' } });
+    expect(screen.getByRole('heading', { name: 'Log in to your account' })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
+    const identifier = screen.getByLabelText('Username or email');
+    const password = screen.getByLabelText('Password');
+    expect(identifier).toHaveAttribute('autocomplete', 'username');
+    expect(password).toHaveAttribute('autocomplete', 'current-password');
+
+    fireEvent.change(identifier, { target: { value: 'stan_1' } });
+    fireEvent.change(password, { target: { value: 'Password123!' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
+
     expect(doRequest).toHaveBeenCalledTimes(1);
+    expect(UseRequest).toHaveBeenLastCalledWith(expect.objectContaining({
+      body: {
+        email: 'stan_1',
+        password: 'Password123!',
+      },
+    }));
+    expect(screen.getByRole('link', { name: 'Create an account' }))
+      .toHaveAttribute('href', '/signup?ui=v2&theme=light');
   });
 
-  it('navigates home and triggers callback on successful login', () => {
+  it('preserves the selected UI and triggers callback on successful login', () => {
     const callback = jest.fn();
     let hookConfig;
     UseRequest.mockImplementation((config) => {
@@ -48,14 +63,17 @@ describe('LogIn page', () => {
     });
 
     render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={['/login?ui=v3&theme=dark']}>
         <LogIn callback={callback} />
       </MemoryRouter>
     );
 
     hookConfig.onSuccess();
 
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/',
+      search: '?ui=v3&theme=dark',
+    });
     expect(callback).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/pages/auth/NewUser.js
+++ b/client/src/pages/auth/NewUser.js
@@ -1,53 +1,96 @@
 
-import React,  { useState }  from "react";
-import { useNavigate } from 'react-router-dom';
+import React, { useState } from "react";
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import UseRequest from "../../hook/UseRequest";
+import AuthPanel from "./AuthPanel";
 
-const HandleNewUser = (props) => {
-
-  const [ email, setEmail ] = useState('') ;
+const HandleNewUser = ({ callback }) => {
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+  const location = useLocation();
   const { doRequest, errors } = UseRequest({
     url: '/api/auth/new',
     method: 'post',
     body: {
-        email, password
+      email: identifier,
+      password,
     },
     onSuccess: () => {
-      navigate('/');
-      props.callback();
+      navigate({ pathname: '/', search: location.search });
+      callback();
     }
-});
+  });
 
-  const navigate = useNavigate();
-
-  const onSubmit = async (event) => {
+  const onSubmit = (event) => {
     event.preventDefault();
-
     doRequest();
-    // await axios.post('/api/auth/new', {email, password }).then((response) => {
-    //   navigate('/', {replace: true});
-    // });
-    // callback();
-  }
+  };
 
-  return <div className="card auth-card">
-    <div className="card-body">
-      <h1 className="h4 mb-3">Sign up</h1> 
-      <form onSubmit={onSubmit}>
-        <div className="form-group mb-2">
-            <label>Email Address</label>
-            <input value={email} onChange={e => setEmail(e.target.value)} className="form-control"/>
+  return (
+    <AuthPanel
+      icon="/icons/signup.svg"
+      title="Create an account"
+      subtitle="Choose a username and password to get started."
+      footer={(
+        <>
+          <span>Already have an account?</span>
+          <Link
+            className="auth-card__link"
+            to={{ pathname: '/login', search: location.search }}
+          >
+            Log in
+          </Link>
+        </>
+      )}
+    >
+      <form className="auth-form" onSubmit={onSubmit}>
+        <div className="auth-field">
+          <label className="auth-label" htmlFor="signup-identifier">Username</label>
+          <input
+            id="signup-identifier"
+            name="username"
+            type="text"
+            value={identifier}
+            onChange={(event) => setIdentifier(event.target.value)}
+            className="form-control auth-control"
+            aria-describedby="signup-identifier-hint"
+            autoComplete="username"
+            autoCapitalize="none"
+            spellCheck={false}
+            minLength={3}
+            maxLength={40}
+            pattern="[A-Za-z0-9][A-Za-z0-9._%+@-]*"
+            required
+          />
+          <span className="auth-field__hint" id="signup-identifier-hint">
+            3–40 characters, no spaces
+          </span>
         </div>
-        <div className="form-group mb-3">
-            <label>Password</label>
-            <input value={password} onChange={e => setPassword(e.target.value)} type="password" className="form-control"/>
+        <div className="auth-field">
+          <label className="auth-label" htmlFor="signup-password">Password</label>
+          <input
+            id="signup-password"
+            name="password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="form-control auth-control"
+            aria-describedby="signup-password-hint"
+            autoComplete="new-password"
+            minLength={4}
+            maxLength={20}
+            required
+          />
+          <span className="auth-field__hint" id="signup-password-hint">
+            4–20 characters
+          </span>
         </div>
-        {errors}
-        <button className="btn auth-submit w-100">Sign Up</button>
+        <div className="auth-errors" aria-live="polite">{errors}</div>
+        <button className="btn auth-submit w-100" type="submit">Create account</button>
       </form>
-    </div>
-  </div>;
+    </AuthPanel>
+  );
 };
 
 export default HandleNewUser;

--- a/client/src/pages/auth/NewUser.test.js
+++ b/client/src/pages/auth/NewUser.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import NewUser from './NewUser';
@@ -18,28 +19,44 @@ describe('NewUser page', () => {
     jest.clearAllMocks();
   });
 
-  it('submits signup form using UseRequest', () => {
+  it('renders and submits an accessible account creation form', () => {
     const doRequest = jest.fn();
     UseRequest.mockReturnValue({
       doRequest,
       errors: null,
     });
 
-    const { container } = render(
-      <MemoryRouter>
+    render(
+      <MemoryRouter initialEntries={['/signup?ui=v2&theme=light']}>
         <NewUser callback={jest.fn()} />
       </MemoryRouter>
     );
 
-    const inputs = container.querySelectorAll('input');
-    fireEvent.change(inputs[0], { target: { value: 'new@betstan.xyz' } });
-    fireEvent.change(inputs[1], { target: { value: 'Password123!Password123!' } });
+    expect(screen.getByRole('heading', { name: 'Create an account' })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Sign Up' }));
+    const identifier = screen.getByLabelText('Username');
+    const password = screen.getByLabelText('Password');
+    expect(identifier).toHaveAttribute('autocomplete', 'username');
+    expect(identifier).toHaveAttribute('minlength', '3');
+    expect(identifier).toHaveAttribute('maxlength', '40');
+    expect(password).toHaveAttribute('autocomplete', 'new-password');
+
+    fireEvent.change(identifier, { target: { value: 'new-user' } });
+    fireEvent.change(password, { target: { value: 'Password123!' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
     expect(doRequest).toHaveBeenCalledTimes(1);
+    expect(UseRequest).toHaveBeenLastCalledWith(expect.objectContaining({
+      body: {
+        email: 'new-user',
+        password: 'Password123!',
+      },
+    }));
+    expect(screen.getByRole('link', { name: 'Log in' }))
+      .toHaveAttribute('href', '/login?ui=v2&theme=light');
   });
 
-  it('navigates home and triggers callback on successful signup', () => {
+  it('preserves the selected UI and triggers callback on successful signup', () => {
     const callback = jest.fn();
     let hookConfig;
     UseRequest.mockImplementation((config) => {
@@ -48,14 +65,17 @@ describe('NewUser page', () => {
     });
 
     render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={['/signup?ui=v3&theme=dark']}>
         <NewUser callback={callback} />
       </MemoryRouter>
     );
 
     hookConfig.onSuccess();
 
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: '/',
+      search: '?ui=v3&theme=dark',
+    });
     expect(callback).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/styles/ui.css
+++ b/client/src/styles/ui.css
@@ -7,6 +7,7 @@
   --text-main: #f8fbff;
   --text-subtle: #a4b5d6;
   --accent: #4fa79f;
+  --accent-contrast: #071520;
   --positive: #5bd4a4;
   --warning: #f4c26e;
   --danger: #ff7c8f;
@@ -24,6 +25,7 @@
   --text-main: #121b2f;
   --text-subtle: #61708d;
   --accent: #2f8078;
+  --accent-contrast: #ffffff;
   --positive: #178f61;
   --warning: #bd7a17;
   --danger: #cc2f4d;
@@ -226,24 +228,166 @@ body {
 }
 
 .auth-card {
-  max-width: 520px;
+  width: min(100%, 30rem);
+  margin-inline: auto;
+  overflow: hidden;
+  border-color: color-mix(in srgb, var(--border-subtle) 72%, var(--accent) 28%);
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--surface-soft) 96%, var(--accent) 4%), var(--surface-soft));
+  box-shadow: var(--shadow-elevated);
+}
+
+.auth-card .card-body {
+  padding: clamp(1.25rem, 4vw, 2.25rem);
+}
+
+.auth-card__header {
+  margin-bottom: 1.6rem;
+  text-align: center;
+}
+
+.auth-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  margin-bottom: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 44%, transparent);
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.auth-card__icon img {
+  width: 1.5rem;
+  height: 1.5rem;
+  filter: brightness(0) invert(1);
+}
+
+:root[data-bs-theme='light'] .auth-card__icon img {
+  filter: none;
+}
+
+.auth-card__title {
+  margin: 0;
+  font-size: clamp(1.45rem, 4vw, 1.8rem);
+  font-weight: 750;
+  letter-spacing: -0.025em;
+}
+
+.auth-card__subtitle {
+  max-width: 23rem;
+  margin: 0.55rem auto 0;
+  color: var(--text-subtle);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.auth-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.auth-label {
+  color: var(--text-main);
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.auth-control {
+  min-height: 3rem;
+  border-color: color-mix(in srgb, var(--border-subtle) 78%, var(--accent) 22%);
+  background: color-mix(in srgb, var(--surface-elevated) 88%, transparent);
+  color: var(--text-main);
+  font-size: 1rem;
+}
+
+.auth-control:focus {
+  border-color: var(--accent);
+  background: var(--surface-elevated);
+  color: var(--text-main);
+  box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+.auth-field__hint {
+  color: var(--text-subtle);
+  font-size: 0.76rem;
+  line-height: 1.35;
+}
+
+.auth-errors:empty {
+  display: none;
+}
+
+.auth-errors .alert {
+  margin: 0;
+  border-color: color-mix(in srgb, var(--danger) 42%, transparent);
+  background: color-mix(in srgb, var(--danger) 12%, var(--surface-soft));
+  color: var(--text-main);
+  font-size: 0.82rem;
+}
+
+.auth-errors .alert h4 {
+  margin-bottom: 0.35rem;
+  font-size: 0.9rem;
 }
 
 .auth-card .auth-submit {
-  border-color: rgba(77, 181, 173, 0.58);
-  background: linear-gradient(135deg, #11202f, #0b151f);
-  color: #e8fffb;
-  box-shadow: 0 10px 18px rgba(2, 10, 18, 0.24);
+  min-height: 3rem;
+  border-color: var(--accent);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent) 88%, #ffffff),
+    var(--accent)
+  );
+  color: var(--accent-contrast);
+  font-weight: 750;
+  box-shadow: 0 10px 22px color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
 .auth-card .auth-submit:hover {
-  border-color: rgba(77, 181, 173, 0.82);
-  background: linear-gradient(135deg, #152536, #0f1c27);
-  color: #ffffff;
+  border-color: color-mix(in srgb, var(--accent) 84%, #ffffff);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent) 78%, #ffffff),
+    color-mix(in srgb, var(--accent) 92%, #000000)
+  );
+  color: var(--accent-contrast);
+  transform: translateY(-1px);
 }
 
 .auth-card .auth-submit:focus-visible {
-  box-shadow: 0 0 0 0.2rem rgba(77, 181, 173, 0.24), 0 10px 18px rgba(2, 10, 18, 0.24);
+  box-shadow:
+    0 0 0 0.2rem color-mix(in srgb, var(--accent) 28%, transparent),
+    0 10px 22px color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+.auth-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.35rem;
+  margin-top: 1.35rem;
+  padding-top: 1.15rem;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-subtle);
+  font-size: 0.84rem;
+}
+
+.auth-card__link {
+  color: var(--accent);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.auth-card__link:hover {
+  color: color-mix(in srgb, var(--accent) 78%, var(--text-main));
+  text-decoration: underline;
 }
 
 .empty-state-card {


### PR DESCRIPTION
## Summary

Redesigns the login and signup pages and allows account identifiers that are not email addresses.

### UI

- **Log in to your account** with a `Username or email` field
- **Create an account** with a `Username` field
- shared responsive auth panel, themed focus states, helper text, accessible labels, 44px+ controls, and cross-page links
- preserves `ui` and `theme` query parameters during navigation
- clearer request-error heading

### Compatibility and security

- retains the existing `email` request/storage/JWT key so rolling consumers remain compatible
- validates identifier type before any Mongo query
- stores a normalized identifier behind a partial unique index and waits for the index before accepting traffic
- rejects concurrent/case-variant duplicate usernames
- continues to authenticate legacy email-only records
- returns explicit `{ id, email }` DTOs instead of leaking raw Mongoose documents/password hashes

### Coverage

- auth: 26 tests; 93.52% lines / 88.46% branches
- targeted client auth: 10 tests; 100% lines / 88.88% branches
- client production build succeeds
- dark/light renders checked at 375px and 1440px with no horizontal overflow and controls at least 44px high

## Deployment

This PR targets `dev`. It does not merge, deploy, alter existing data, rename the JWT claim, or change production cookie/JWT policy.
