### PR TITLE
Centralize automatic production deployments

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -34,7 +34,7 @@ Inspect the current git graph and remote default branch. Do not infer that a mer
 ## Build and image provenance
 
 - A green PR validates infrastructure safety but does not mean production was deployed.
-- Inventory every production-capable workflow before reasoning about triggers. The repository contains centralized and legacy per-service deploy workflows; do not assume only `build-push` and `deploy-manifests` can mutate production.
+- Inventory every production-capable workflow before reasoning about triggers. The centralized chain deploys automatically; legacy per-service workflows are manual-only but can still mutate production.
 - Before merge or direct push, evaluate workflow branch and path filters against the exact diff and list every production-capable workflow that will run. If approval does not cover that complete trigger set, return `NO_GO`.
 - A successful `build-push` run must produce immutable images tagged with its exact commit SHA.
 - Treat a manual dispatch or rerun of `build-push` on `master` as a production deployment action because its successful completion triggers `deploy-manifests`.

--- a/.github/workflows/deploy-auth.yaml
+++ b/.github/workflows/deploy-auth.yaml
@@ -1,11 +1,6 @@
 name: deploy-auth
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'auth/**'
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-backoffice.yaml
+++ b/.github/workflows/deploy-backoffice.yaml
@@ -1,11 +1,6 @@
 name: deploy-backoffice
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "backoffice/**"
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-bet.yaml
+++ b/.github/workflows/deploy-bet.yaml
@@ -1,11 +1,6 @@
 name: deploy-bet
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "bet/**"
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-client.yaml
+++ b/.github/workflows/deploy-client.yaml
@@ -1,11 +1,6 @@
 name: deploy-client
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "client/**"
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-event.yaml
+++ b/.github/workflows/deploy-event.yaml
@@ -1,11 +1,6 @@
 name: deploy-event
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "event/**"
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-gamemaster.yaml
+++ b/.github/workflows/deploy-gamemaster.yaml
@@ -1,11 +1,6 @@
 name: deploy-gamemaster
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "gamemaster/**"
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-moderation.yaml
+++ b/.github/workflows/deploy-moderation.yaml
@@ -1,11 +1,6 @@
 name: deploy-moderation
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "moderation/**"
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-resulting.yaml
+++ b/.github/workflows/deploy-resulting.yaml
@@ -1,11 +1,6 @@
 name: deploy-resulting
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "resulting/**"
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-slip.yaml
+++ b/.github/workflows/deploy-slip.yaml
@@ -1,11 +1,6 @@
 name: deploy-slip
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "slip/**"
   workflow_dispatch:
     inputs:
       environment:

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -189,6 +189,7 @@ If `dns-check-stan.sh` prints `status=MATCH`, DNS is pointing to current ingress
 - `build-push` runs on `master` and tags each image with `${GITHUB_SHA}`.
 - `build-push` pull requests run `ingress-routing-guard-stan.sh` and block unsafe ingress host/path edits before merge.
 - `deploy-manifests` runs only after successful `build-push` on `master` and deploys that exact SHA image set.
+- Legacy per-service `deploy-*.yaml` workflows are manual-only fallbacks and require explicit approval for the exact workflow and SHA.
 - Deploy workflow blocks when mongo PVC count is unexpectedly low, avoiding deployment against unsafe DB storage state.
 - Deploy workflow now runs `deploy-validation-loop-stan.sh` as required post-rollout gate and uploads diagnostics artifacts on failure.
 - `build-push` now includes `ingress-routing-guard-stan.sh` so PRs fail if prod ingress misses required host/api routes.


### PR DESCRIPTION
## Purpose

Eliminate concurrent production rollout races by making `build-push -> deploy-manifests` the sole automatic deployment chain.

## Changes

- remove `push: master` from all nine legacy per-service `deploy-*.yaml` workflows;
- retain each workflow's explicit `workflow_dispatch` fallback;
- document that legacy workflows are manual-only production actions requiring approval for the exact workflow and SHA;
- leave centralized `build-push.yml` and `deploy-manifests.yml` unchanged.

## Resulting trigger model

- merge to `master`: `build-push` validates and builds exact-SHA images;
- successful `build-push` on `master`: `deploy-manifests` deploys that exact SHA sequentially;
- legacy service deploys: no automatic trigger; manual dispatch only.

## Validation

- exactly nine legacy workflows retain one `workflow_dispatch` trigger and no `push` trigger;
- centralized master trigger and exact-SHA `workflow_run` deployment remain present;
- all workflow YAML parses;
- `git diff --check` passes;
- focused code review found no trigger, security, or documentation defects.

No workflow was dispatched while preparing or validating this PR. Do not open or merge a `dev -> master` production promotion until this PR is merged and all required checks pass.
