### PR TITLE
Guard privileged workflow-run deployments

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -37,6 +37,7 @@ Inspect the current git graph and remote default branch. Do not infer that a mer
 - Inventory every production-capable workflow before reasoning about triggers. The centralized chain deploys automatically; legacy per-service workflows are manual-only but can still mutate production.
 - Before merge or direct push, evaluate workflow branch and path filters against the exact diff and list every production-capable workflow that will run. If approval does not cover that complete trigger set, return `NO_GO`.
 - A successful `build-push` run must produce immutable images tagged with its exact commit SHA.
+- Require `deploy-manifests` to accept only successful `push` or `workflow_dispatch` build runs from this repository's `master`; a source branch name alone is not a trust boundary.
 - Treat a manual dispatch or rerun of `build-push` on `master` as a production deployment action because its successful completion triggers `deploy-manifests`.
 - Treat manual dispatch or rerun of any legacy per-service `deploy-*.yaml` workflow as a production action. Do not invoke one unless the user approved that exact workflow and SHA.
 - Prefer the centralized `build-push` to `deploy-manifests` chain only after confirming it is the current authoritative path. Never silently invoke a legacy workflow as a fallback.

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -73,6 +73,17 @@ jobs:
           bash -n infra/azure/agents/pre-commit-infra-check-stan.sh
           bash -n infra/azure/agents/post-merge-verification-stan.sh
           bash -n infra/azure/agents/rollback-readiness-stan.sh
+          bash -n infra/azure/agents/workflow-trigger-guard-stan.sh
+
+  workflow-trigger-guard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate production workflow triggers
+        run: ./infra/azure/agents/workflow-trigger-guard-stan.sh
 
   coverage-gate:
     runs-on: ubuntu-latest
@@ -148,7 +159,7 @@ jobs:
           "
 
   build:
-    needs: [manifest-static-validate, ingress-routing-guard, deploy-runtime-script-validate, coverage-gate]
+    needs: [manifest-static-validate, ingress-routing-guard, deploy-runtime-script-validate, workflow-trigger-guard, coverage-gate]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-manifests.yml
+++ b/.github/workflows/deploy-manifests.yml
@@ -6,6 +6,9 @@ on:
     types: [completed]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   RESOURCE_GROUP: ${{ secrets.RESOURCE_GROUP }}
   CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
@@ -23,6 +26,11 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
+        (
+          github.event.workflow_run.event == 'push' ||
+          github.event.workflow_run.event == 'workflow_dispatch'
+        ) &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
         github.event.workflow_run.head_branch == 'master'
       )
     runs-on: ubuntu-latest

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -19,6 +19,7 @@
 - `deploy-validation-loop-stan.sh` — retries smoke+functional validation and captures diagnostics artifacts on failure.
 - `validation-loop-stan.sh` — repeats health + HTTPS + E2E checks until pass/fail limit.
 - `ingress-routing-guard-stan.sh` — static guard that fails when prod ingress host/path routing is unsafe.
+- `workflow-trigger-guard-stan.sh` — blocks untrusted workflow-run deployments and automatic legacy service deploys.
 - `provision-stage-stan.sh` — creates isolated `betstan-rg-stage` AKS and configures autoscaler 1→3 with a larger baseline node size for 1-node stage operation.
 - `park-stage-stan.sh` — stops stage AKS compute while keeping the stage resource group.
 - `resume-stage-stan.sh` — starts stage AKS and runs quick readiness checks.
@@ -189,6 +190,7 @@ If `dns-check-stan.sh` prints `status=MATCH`, DNS is pointing to current ingress
 - `build-push` runs on `master` and tags each image with `${GITHUB_SHA}`.
 - `build-push` pull requests run `ingress-routing-guard-stan.sh` and block unsafe ingress host/path edits before merge.
 - `deploy-manifests` runs only after successful `build-push` on `master` and deploys that exact SHA image set.
+- `deploy-manifests` rejects pull-request and foreign-repository workflow runs before any production secret or runner is exposed.
 - Legacy per-service `deploy-*.yaml` workflows are manual-only fallbacks and require explicit approval for the exact workflow and SHA.
 - Deploy workflow blocks when mongo PVC count is unexpectedly low, avoiding deployment against unsafe DB storage state.
 - Deploy workflow now runs `deploy-validation-loop-stan.sh` as required post-rollout gate and uploads diagnostics artifacts on failure.

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Purpose: keep production automation on the trusted exact-SHA deployment chain.
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "ERROR: $1" >&2
+  exit 1
+}
+
+require_literal() {
+  local file="$1"
+  local value="$2"
+  local label="$3"
+
+  grep -Fq "$value" "$file" || fail "$file is missing $label"
+}
+
+require_in_block() {
+  local block="$1"
+  local value="$2"
+  local label="$3"
+
+  grep -Fq "$value" <<<"$block" || fail "deployment condition is missing $label"
+}
+
+build_workflow=".github/workflows/build-push.yml"
+deploy_workflow=".github/workflows/deploy-manifests.yml"
+legacy_workflows=(
+  .github/workflows/deploy-auth.yaml
+  .github/workflows/deploy-backoffice.yaml
+  .github/workflows/deploy-bet.yaml
+  .github/workflows/deploy-client.yaml
+  .github/workflows/deploy-event.yaml
+  .github/workflows/deploy-gamemaster.yaml
+  .github/workflows/deploy-moderation.yaml
+  .github/workflows/deploy-resulting.yaml
+  .github/workflows/deploy-slip.yaml
+)
+
+push_trigger="$(
+  awk '
+    /^  push:$/ { in_push=1; print; next }
+    in_push && /^  [[:alnum:]_-]+:$/ { exit }
+    in_push { print }
+  ' "$build_workflow"
+)"
+grep -q '^  push:' <<<"$push_trigger" ||
+  fail "$build_workflow must define a push trigger"
+grep -q '^      - master$' <<<"$push_trigger" ||
+  fail "$build_workflow must run on master"
+
+deploy_condition="$(sed -n '/^    if: >/,/^    runs-on:/p' "$deploy_workflow")"
+require_in_block "$deploy_condition" \
+  "github.event.workflow_run.event == 'push'" \
+  "trusted push-event guard"
+require_in_block "$deploy_condition" \
+  "github.event.workflow_run.event == 'workflow_dispatch'" \
+  "trusted manual build-event guard"
+require_in_block "$deploy_condition" \
+  "github.event.workflow_run.head_repository.full_name == github.repository" \
+  "head-repository guard"
+require_in_block "$deploy_condition" \
+  "github.event.workflow_run.head_branch == 'master'" \
+  "master-branch guard"
+require_in_block "$deploy_condition" \
+  "github.event.workflow_run.conclusion == 'success'" \
+  "successful-build guard"
+require_literal "$deploy_workflow" \
+  'github.event.workflow_run.head_sha' \
+  "exact-SHA deployment"
+require_literal "$deploy_workflow" \
+  'contents: read' \
+  "read-only GitHub token permissions"
+
+for workflow in "${legacy_workflows[@]}"; do
+  trigger_block="$(sed -n '/^on:/,/^env:/p' "$workflow")"
+  grep -q '^  workflow_dispatch:' <<<"$trigger_block" ||
+    fail "$workflow must retain its manual fallback"
+
+  if grep -q '^  push:' <<<"$trigger_block"; then
+    fail "$workflow must not deploy automatically"
+  fi
+done
+
+echo "workflow_trigger_guard=PASS legacy_manual_only=${#legacy_workflows[@]}"


### PR DESCRIPTION
## Security issue

`deploy-manifests` trusted only a successful `build-push` run whose `head_branch` was named `master`. A pull-request run from an untrusted source branch named `master` could therefore reach the privileged deployment job, which checks out the supplied SHA and uses Azure/AKS secrets.

## Fix

- accept automatic deployment only from successful `push` or `workflow_dispatch` build runs;
- require `workflow_run.head_repository.full_name == github.repository`;
- continue requiring `head_branch == master` and exact `head_sha` deployment;
- restrict the workflow token to `contents: read`;
- add `workflow-trigger-guard-stan.sh` as a required build gate;
- keep all nine legacy deploy workflows manual-only.

Direct manual dispatch of `deploy-manifests` remains an explicitly trusted production action.

## Validation

- valid centralized trigger configuration passes;
- removing the trusted push-event guard fails;
- restoring a legacy automatic push trigger fails;
- changing the central push branch away from `master` fails;
- shell syntax, workflow YAML, and `git diff --check` pass;
- focused security review found no bypass or new vulnerability.

This PR targets `dev` and does not deploy to production.
