### PR TITLE
Enforce exact rollback provenance and auth compatibility

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -57,6 +57,7 @@ Before deployment:
 - run `ingress-routing-guard-stan.sh`;
 - confirm at least eight Mongo PVCs exist and are bound;
 - check production health and rollback readiness;
+- for an auth rollback, run `rollback-readiness-stan.sh` with the exact target SHA and honor its normalized-account compatibility result;
 - ensure no unresolved workflow or manifest conflict exists.
 
 During deployment:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -74,6 +74,7 @@ jobs:
           bash -n infra/azure/agents/post-merge-verification-stan.sh
           bash -n infra/azure/agents/rollback-readiness-stan.sh
           bash -n infra/azure/agents/workflow-trigger-guard-stan.sh
+          bash -n infra/azure/agents/workflow-run-provenance-stan.sh
 
   workflow-trigger-guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-manifests.yml
+++ b/.github/workflows/deploy-manifests.yml
@@ -1,4 +1,5 @@
 name: deploy-manifests
+run-name: deploy-manifests ${{ github.event.workflow_run.head_sha || github.sha }}
 
 on:
   workflow_run:

--- a/infra/azure/LESSONS_LEARNED.md
+++ b/infra/azure/LESSONS_LEARNED.md
@@ -137,4 +137,4 @@ Checks deployments, statefulsets, pod status, endpoints, restart counts, and rec
 Confirms workflow runs succeeded for the exact merge SHA, validates API on both hosts, checks workload readiness, and confirms RabbitMQ consumer presence.
 
 ### Use `rollback-readiness-stan.sh` before taking rollback action
-Emits `rollback_readiness=GO` or `NO_GO` with explicit reasons. Checks production baseline health, queue pressure, rollout history depth, and optionally validates target-SHA workflow provenance.
+Emits `rollback_readiness=GO` or `NO_GO` with explicit reasons. Checks production baseline health, queue pressure, rollout history depth, target-SHA workflow provenance, and whether normalized auth accounts are compatible with the requested rollback target.

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -20,6 +20,7 @@
 - `validation-loop-stan.sh` — repeats health + HTTPS + E2E checks until pass/fail limit.
 - `ingress-routing-guard-stan.sh` — static guard that fails when prod ingress host/path routing is unsafe.
 - `workflow-trigger-guard-stan.sh` — blocks untrusted workflow-run deployments and automatic legacy service deploys.
+- `workflow-run-provenance-stan.sh` — resolves successful build/deploy runs that verifiably used an exact SHA.
 - `provision-stage-stan.sh` — creates isolated `betstan-rg-stage` AKS and configures autoscaler 1→3 with a larger baseline node size for 1-node stage operation.
 - `park-stage-stan.sh` — stops stage AKS compute while keeping the stage resource group.
 - `resume-stage-stan.sh` — starts stage AKS and runs quick readiness checks.
@@ -160,14 +161,18 @@ Verify all 17 queues have consumers before considering recovery complete.
 Use this before taking rollback action in production:
 
 ```bash
-./infra/azure/agents/rollback-readiness-stan.sh
-# optional provenance check
 TARGET_SHA=<candidate-sha> ./infra/azure/agents/rollback-readiness-stan.sh
 ```
 
 The script outputs:
 - `rollback_readiness=GO` when safety preconditions are met;
 - `rollback_readiness=NO_GO` with concrete reasons when rollback would be risky.
+
+When `TARGET_SHA` points to an auth version that cannot log in normalized identifiers,
+the gate queries the production auth database. Any normalized account blocks a full
+rollback. Once a different auth image is active, the incompatible target remains
+blocked even while the count is zero, preventing signup from racing the check. Keep
+the current auth image and roll back only compatible services, or forward-fix.
 
 ## GoDaddy `A www` error fix (`Invalid data provided for record data`)
 

--- a/infra/azure/agents/post-merge-verification-stan.sh
+++ b/infra/azure/agents/post-merge-verification-stan.sh
@@ -15,6 +15,7 @@ HOSTS="${HOSTS:-www.betstan.xyz,betstan.xyz}"
 REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-20}"
 RABBIT_SELECTOR="${RABBIT_SELECTOR:-app=gaming-rabbitmq}"
 REQUIRED_QUEUES="${REQUIRED_QUEUES:-event_new_event,gamemaster_new_event,event_result,bet_place_bet}"
+PROVENANCE_SCRIPT="${PROVENANCE_SCRIPT:-infra/azure/agents/workflow-run-provenance-stan.sh}"
 
 fail() {
   echo "ERROR: $*" >&2
@@ -57,22 +58,11 @@ fi
 echo "merge_sha=$MERGE_SHA"
 
 for workflow in ${WORKFLOWS//,/ }; do
-  run_json="$(mktemp)"
-  add_tmp "$run_json"
-  gh run list --repo "$REPO" --workflow "$workflow" --commit "$MERGE_SHA" --limit 1 --json databaseId,status,conclusion,url > "$run_json"
-  read -r run_id run_status run_conclusion run_url <<<"$(python3 - "$run_json" <<'PY'
-import json,sys
-runs=json.load(open(sys.argv[1]))
-if not runs:
-  print("", "", "", "")
-else:
-  run=runs[0]
-  print(run.get("databaseId",""), run.get("status",""), run.get("conclusion",""), run.get("url",""))
-PY
-)"
-  [[ -n "$run_id" ]] || fail "workflow '$workflow' not found for commit $MERGE_SHA"
-  [[ "$run_status" == "completed" ]] || fail "workflow '$workflow' status is $run_status"
-  [[ "$run_conclusion" == "success" ]] || fail "workflow '$workflow' conclusion is $run_conclusion"
+  provenance="$(
+    REPO="$REPO" WORKFLOW="$workflow" TARGET_SHA="$MERGE_SHA" \
+      "$PROVENANCE_SCRIPT"
+  )" || fail "workflow '$workflow' lacks a verifiable successful run for $MERGE_SHA"
+  read -r run_id run_status run_conclusion run_url <<<"$provenance"
   echo "workflow_ok=$workflow run_id=$run_id url=$run_url"
 done
 

--- a/infra/azure/agents/rollback-readiness-stan.sh
+++ b/infra/azure/agents/rollback-readiness-stan.sh
@@ -15,6 +15,14 @@ MAX_MESSAGES_READY="${MAX_MESSAGES_READY:-200}"
 MAX_MESSAGES_UNACK="${MAX_MESSAGES_UNACK:-200}"
 MIN_ROLLOUT_REVISIONS="${MIN_ROLLOUT_REVISIONS:-2}"
 TARGET_SHA="${TARGET_SHA:-}"
+AUTH_MONGO_SELECTOR="${AUTH_MONGO_SELECTOR:-app=gaming-auth-mongo}"
+AUTH_DB_NAME="${AUTH_DB_NAME:-gaming_auth}"
+AUTH_USER_COLLECTION="${AUTH_USER_COLLECTION:-users}"
+AUTH_DEPLOYMENT="${AUTH_DEPLOYMENT:-gaming-auth-depl}"
+AUTH_POD_SELECTOR="${AUTH_POD_SELECTOR:-app=gaming-auth}"
+AUTH_CONTAINER="${AUTH_CONTAINER:-gaming-auth}"
+AUTH_IMAGE_REPOSITORY="${AUTH_IMAGE_REPOSITORY:-stanvasilyev/gaming_auth}"
+PROVENANCE_SCRIPT="${PROVENANCE_SCRIPT:-infra/azure/agents/workflow-run-provenance-stan.sh}"
 
 failures_file="$(mktemp)"
 images_file="$(mktemp)"
@@ -33,7 +41,7 @@ add_failure() {
   printf '%s\n' "$*" >> "$failures_file"
 }
 
-for bin in gh kubectl curl awk python3; do
+for bin in gh git kubectl curl awk python3; do
   if ! command -v "$bin" >/dev/null 2>&1; then
     add_failure "required binary missing: $bin"
   fi
@@ -46,8 +54,20 @@ if [[ -s "$failures_file" ]]; then
   exit 1
 fi
 
-if [[ -n "$TARGET_SHA" ]] && ! [[ "$TARGET_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+target_sha_valid=true
+if [[ -z "$TARGET_SHA" ]]; then
+  add_failure "TARGET_SHA is required before rollback action"
+  target_sha_valid=false
+elif ! [[ "$TARGET_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
   add_failure "TARGET_SHA must be 7..40 hex characters"
+  target_sha_valid=false
+fi
+
+auth_names_valid=true
+if ! [[ "$AUTH_DB_NAME" =~ ^[A-Za-z0-9_-]+$ ]] ||
+  ! [[ "$AUTH_USER_COLLECTION" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  add_failure "auth database and collection names must contain only letters, numbers, underscores, or hyphens"
+  auth_names_valid=false
 fi
 
 ready_nodes="$(kubectl get nodes --no-headers 2>/dev/null | awk '$2=="Ready"{c++} END{print c+0}' || echo 0)"
@@ -95,6 +115,94 @@ else
   fi
 fi
 
+if [[ -n "$TARGET_SHA" && "$target_sha_valid" == true && "$auth_names_valid" == true ]]; then
+  target_sha_full="$(git rev-parse "${TARGET_SHA}^{commit}" 2>/dev/null || true)"
+  target_login="$(git show "${TARGET_SHA}:auth/src/route/LogIn.ts" 2>/dev/null || true)"
+  if [[ -z "$target_sha_full" || -z "$target_login" ]]; then
+    add_failure "unable to inspect auth login compatibility at target sha $TARGET_SHA"
+  elif ! grep -q "normalizeIdentifier" <<<"$target_login" ||
+    ! grep -q "User.findOne({ identifierNormalized })" <<<"$target_login"; then
+    auth_rollout_state="$(
+      kubectl get deployment "$AUTH_DEPLOYMENT" -n "$NAMESPACE" -o jsonpath='{.metadata.generation}|{.status.observedGeneration}|{.spec.replicas}|{.status.updatedReplicas}|{.status.readyReplicas}|{.status.availableReplicas}' 2>/dev/null || true
+    )"
+    IFS='|' read -r auth_generation auth_observed auth_replicas auth_updated auth_ready auth_available <<<"$auth_rollout_state"
+    auth_generation="${auth_generation:-0}"
+    auth_observed="${auth_observed:-0}"
+    auth_replicas="${auth_replicas:-0}"
+    auth_updated="${auth_updated:-0}"
+    auth_ready="${auth_ready:-0}"
+    auth_available="${auth_available:-0}"
+
+    auth_rollout_observed=true
+    if [[ "$auth_generation" -eq 0 ||
+      "$auth_observed" -lt "$auth_generation" ||
+      "$auth_updated" -ne "$auth_replicas" ||
+      "$auth_ready" -ne "$auth_replicas" ||
+      "$auth_available" -ne "$auth_replicas" ]]; then
+      auth_rollout_observed=false
+      add_failure "auth rollout is not fully observed: generation=$auth_generation observed=$auth_observed replicas=$auth_replicas updated=$auth_updated ready=$auth_ready available=$auth_available"
+    fi
+
+    auth_pod_rows="$(
+      kubectl get pods -n "$NAMESPACE" -l "$AUTH_POD_SELECTOR" \
+        -o jsonpath="{range .items[*]}{.metadata.name}|{.status.phase}|{.status.conditions[?(@.type=='Ready')].status}|{.spec.containers[?(@.name=='${AUTH_CONTAINER}')].image}{'\\n'}{end}" 2>/dev/null || true
+    )"
+    serving_auth_images=()
+    ready_auth_pod_count=0
+    missing_auth_container=false
+    while IFS='|' read -r auth_pod auth_phase auth_pod_ready auth_pod_image; do
+      if [[ "$auth_phase" == "Running" && "$auth_pod_ready" == "True" ]]; then
+        ready_auth_pod_count=$((ready_auth_pod_count + 1))
+        if [[ -z "$auth_pod_image" ]]; then
+          missing_auth_container=true
+          add_failure "ready auth pod $auth_pod is missing container $AUTH_CONTAINER"
+        else
+          serving_auth_images+=("$auth_pod_image")
+        fi
+      fi
+    done <<<"$auth_pod_rows"
+
+    incompatible_serving_image="$missing_auth_container"
+    expected_auth_image="${AUTH_IMAGE_REPOSITORY}:${target_sha_full}"
+    if [[ "$ready_auth_pod_count" -eq 0 ]]; then
+      incompatible_serving_image=true
+      add_failure "no ready auth pods found for selector: $AUTH_POD_SELECTOR"
+    else
+      for serving_auth_image in "${serving_auth_images[@]}"; do
+        if [[ "$serving_auth_image" != "$expected_auth_image" ]]; then
+          incompatible_serving_image=true
+        fi
+      done
+    fi
+
+    auth_mongo_pod="$(kubectl get pod -n "$NAMESPACE" -l "$AUTH_MONGO_SELECTOR" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    if [[ -z "$auth_mongo_pod" ]]; then
+      add_failure "auth mongo pod missing for selector: $AUTH_MONGO_SELECTOR"
+    else
+      mongo_query="db.getCollection('${AUTH_USER_COLLECTION}').countDocuments({identifierNormalized: {\$type: 'string'}})"
+      if ! normalized_count="$(
+        kubectl exec -n "$NAMESPACE" "$auth_mongo_pod" -- \
+          mongosh --quiet "mongodb://localhost:27017/${AUTH_DB_NAME}" --eval "$mongo_query" 2>/dev/null
+      )"; then
+        add_failure "unable to count normalized auth identifiers before rollback"
+      else
+        normalized_count="$(tail -n 1 <<<"$normalized_count" | tr -d '\r')"
+        if ! [[ "$normalized_count" =~ ^[0-9]+$ ]]; then
+          add_failure "unexpected normalized auth identifier count: $normalized_count"
+        elif [[ "$normalized_count" -gt 0 ]]; then
+          add_failure "target auth at $TARGET_SHA is not identifier-compatible; found $normalized_count normalized account(s). Keep the current auth image and roll back only compatible services, or forward-fix"
+        elif [[ "$auth_rollout_observed" != true || "$incompatible_serving_image" == true ]]; then
+          add_failure "target auth at $TARGET_SHA is not identifier-compatible and serving auth images are: ${serving_auth_images[*]:-none}. Keep the current auth image during rollback; a zero account count is not an atomic rollback window"
+        else
+          echo "auth_identifier_rollback_check=PASS normalized_accounts=0 target_supports_identifiers=false"
+        fi
+      fi
+    fi
+  else
+    echo "auth_identifier_rollback_check=PASS target_supports_identifiers=true"
+  fi
+fi
+
 deploy_names="$(kubectl get deploy -n "$NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' || true)"
 for d in $deploy_names; do
   rev_count="$(kubectl rollout history "deploy/${d}" -n "$NAMESPACE" 2>/dev/null | awk '/^[0-9]+/ {c++} END{print c+0}')"
@@ -105,27 +213,17 @@ done
 
 kubectl get deploy -n "$NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.template.spec.containers[*]}{.image}{" "}{end}{"\n"}{end}' > "$images_file" || true
 
-if [[ -n "$TARGET_SHA" ]]; then
+if [[ "$target_sha_valid" == true ]]; then
   for workflow in build-push deploy-manifests; do
-    wf_json="$(mktemp)"
-    add_tmp "$wf_json"
-    gh run list --repo "$REPO" --workflow "$workflow" --commit "$TARGET_SHA" --limit 1 --json status,conclusion > "$wf_json" || true
-    read -r wf_status wf_conclusion <<<"$(python3 - "$wf_json" <<'PY'
-import json,sys
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
-  raw=fh.read().strip()
-runs=json.loads(raw) if raw else []
-if not runs:
-  print("", "")
-else:
-  run=runs[0]
-  print(run.get("status",""), run.get("conclusion",""))
-PY
-)"
-    if [[ "$wf_status" != "completed" || "$wf_conclusion" != "success" ]]; then
-      add_failure "target sha $TARGET_SHA lacks successful $workflow run"
+    if ! provenance="$(
+      REPO="$REPO" WORKFLOW="$workflow" TARGET_SHA="$TARGET_SHA" \
+        "$PROVENANCE_SCRIPT" 2>/dev/null
+    )"; then
+      add_failure "target sha $TARGET_SHA lacks a verifiable successful $workflow run"
+    else
+      read -r run_id run_status run_conclusion run_url <<<"$provenance"
+      echo "rollback_provenance_ok=$workflow run_id=$run_id url=$run_url"
     fi
-    rm -f "$wf_json"
   done
 fi
 

--- a/infra/azure/agents/workflow-run-provenance-stan.sh
+++ b/infra/azure/agents/workflow-run-provenance-stan.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Purpose: find a successful workflow run that verifiably built or deployed TARGET_SHA.
+
+REPO="${REPO:-vasilyevstan/betstan}"
+WORKFLOW="${WORKFLOW:-}"
+TARGET_SHA="${TARGET_SHA:-}"
+
+for bin in gh git python3; do
+  command -v "$bin" >/dev/null 2>&1 || {
+    echo "ERROR: required binary missing: $bin" >&2
+    exit 1
+  }
+done
+
+case "$WORKFLOW" in
+  build-push)
+    workflow_file="build-push.yml"
+    ;;
+  deploy-manifests)
+    workflow_file="deploy-manifests.yml"
+    ;;
+  *)
+    echo "ERROR: WORKFLOW must be build-push or deploy-manifests" >&2
+    exit 1
+    ;;
+esac
+
+if ! [[ "$TARGET_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+  echo "ERROR: TARGET_SHA must be 7..40 hex characters" >&2
+  exit 1
+fi
+
+if ! target_sha_full="$(git rev-parse "${TARGET_SHA}^{commit}" 2>/dev/null)"; then
+  echo "ERROR: TARGET_SHA is not available in the local repository: $TARGET_SHA" >&2
+  exit 1
+fi
+
+runs_file="$(mktemp)"
+run_metadata_file="$(mktemp)"
+run_log_file="$(mktemp)"
+cleanup() {
+  rm -f "$runs_file" "$run_metadata_file" "$run_log_file"
+}
+trap cleanup EXIT
+
+if [[ "$WORKFLOW" == "build-push" ]]; then
+  gh run list \
+    --repo "$REPO" \
+    --workflow "$workflow_file" \
+    --commit "$target_sha_full" \
+    --limit 100 \
+    --json databaseId,displayTitle,event,headSha,status,conclusion,url > "$runs_file"
+else
+  gh run list \
+    --repo "$REPO" \
+    --workflow "$workflow_file" \
+    --limit 100 \
+    --json databaseId,displayTitle,event,headSha,status,conclusion,url > "$runs_file"
+fi
+
+exact_record="$(
+  python3 - "$runs_file" "$WORKFLOW" "$target_sha_full" <<'PY'
+import json
+import sys
+
+runs_file, workflow, target_sha = sys.argv[1:]
+with open(runs_file, "r", encoding="utf-8") as handle:
+    runs = json.load(handle)
+
+expected_title = f"deploy-manifests {target_sha}"
+for run in runs:
+    if run.get("status") != "completed" or run.get("conclusion") != "success":
+        continue
+    if workflow == "build-push":
+        if run.get("event") not in {"push", "workflow_dispatch"}:
+            continue
+        if run.get("headSha") != target_sha:
+            continue
+    else:
+        if run.get("event") not in {"workflow_run", "workflow_dispatch"}:
+            continue
+        if run.get("displayTitle") != expected_title:
+            continue
+    print(
+        run.get("databaseId", ""),
+        run.get("status", ""),
+        run.get("conclusion", ""),
+        run.get("url", ""),
+        sep="\t",
+    )
+    break
+PY
+)"
+
+if [[ -n "$exact_record" ]]; then
+  echo "$exact_record"
+  exit 0
+fi
+
+if [[ "$WORKFLOW" != "deploy-manifests" ]]; then
+  exit 1
+fi
+
+# Runs created before SHA-specific run names are restricted to audited immutable pairs.
+case "$target_sha_full" in
+  463c9247ea50166686ab5e3956e5294de4e6931b)
+    legacy_run_id=30565277544
+    ;;
+  4630d76dca8b5707a0648693c75605c49f311ec2)
+    legacy_run_id=30565249116
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+
+gh run view "$legacy_run_id" \
+  --repo "$REPO" \
+  --json databaseId,displayTitle,event,status,conclusion,url,workflowName \
+  > "$run_metadata_file"
+
+legacy_record="$(
+  python3 - "$run_metadata_file" "$legacy_run_id" <<'PY'
+import json
+import sys
+
+metadata_file, expected_run_id = sys.argv[1:]
+with open(metadata_file, "r", encoding="utf-8") as handle:
+    run = json.load(handle)
+
+if (
+    str(run.get("databaseId", "")) == expected_run_id
+    and run.get("workflowName") == "deploy-manifests"
+    and run.get("displayTitle") == "deploy-manifests"
+    and run.get("event") == "workflow_run"
+    and run.get("status") == "completed"
+    and run.get("conclusion") == "success"
+):
+    print(
+        run.get("databaseId", ""),
+        run.get("status", ""),
+        run.get("conclusion", ""),
+        run.get("url", ""),
+        sep="\t",
+    )
+PY
+)"
+
+[[ -n "$legacy_record" ]] || exit 1
+
+if gh run view "$legacy_run_id" --repo "$REPO" --log > "$run_log_file" 2>/dev/null &&
+  python3 - "$run_log_file" "$target_sha_full" <<'PY'
+import sys
+
+log_file, target_sha = sys.argv[1:]
+expected_payload = f"IMAGE_TAG: {target_sha}"
+
+with open(log_file, "r", encoding="utf-8", errors="replace") as handle:
+    for line in handle:
+        fields = line.rstrip("\r\n").split("\t", 2)
+        if len(fields) != 3:
+            continue
+        timestamp_and_payload = fields[2].split(maxsplit=1)
+        if len(timestamp_and_payload) != 2:
+            continue
+        if timestamp_and_payload[1].strip() == expected_payload:
+            sys.exit(0)
+
+sys.exit(1)
+PY
+then
+  echo "$legacy_record"
+  exit 0
+fi
+
+exit 1

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -73,6 +73,9 @@ require_literal "$deploy_workflow" \
   'github.event.workflow_run.head_sha' \
   "exact-SHA deployment"
 require_literal "$deploy_workflow" \
+  'run-name: deploy-manifests ${{ github.event.workflow_run.head_sha || github.sha }}' \
+  "SHA-specific deploy run name"
+require_literal "$deploy_workflow" \
   'contents: read' \
   "read-only GitHub token permissions"
 


### PR DESCRIPTION
## Purpose

Encode the approved single-release, constrained-auth rollback strategy in executable safety gates instead of relying on operator memory.

## Changes

- require `TARGET_SHA` for rollback readiness;
- resolve `build-push` only from trusted `push`/`workflow_dispatch` runs with the exact SHA;
- give future deploy runs a SHA-specific run name and require it for provenance;
- restrict historical deploy fallback to two audited immutable SHA/run-ID pairs and exact executed `IMAGE_TAG` evidence;
- query normalized auth-account count for identifier-incompatible targets;
- require a fully observed auth rollout and inspect every ready serving auth pod;
- require the exact approved auth image repository and full SHA;
- block a full incompatible auth rollback once another auth image is serving, even at count zero, eliminating the signup race;
- share exact provenance checks with post-merge production verification.

## Live validation

- current production `463c924` resolves build run `30565081910` and deploy run `30565277544` and returns `rollback_readiness=GO`;
- prior `4630d76` resolves deploy run `30565249116` but returns `NO_GO` because a different auth image is serving;
- targetless rollback is rejected;
- a green PR-only build is rejected as image provenance;
- unknown legacy deploy runs are rejected;
- a foreign auth repository using the same SHA tag is rejected;
- all 9 deployments, 8 Mongo StatefulSets/PVCs, public APIs, and RabbitMQ baseline checks pass;
- shell syntax, workflow YAML, trigger guard, and `git diff --check` pass;
- final blocker-only review found no issues.

This PR targets `dev` and cannot deploy production. `deploy-manifests` remains manually disabled until the guarded workflow is present on `master`.
