### PR TITLE
Validate trusted status app identity

### DIFF
--- a/.github/scripts/publish-pr-policy.js
+++ b/.github/scripts/publish-pr-policy.js
@@ -344,16 +344,18 @@ module.exports = async function publishPrPolicy({ github, context, core }) {
       fallbackUrl: policyRunUrl,
     });
 
-    await publishStatus(
-      github,
-      owner,
-      repo,
-      pull.mergeSha,
-      BRANCH_CONTEXT,
-      branch.allowed ? "success" : "failure",
-      `PR #${pull.number}: ${branch.description}`,
-      policyRunUrl,
-    );
+    if (context.eventName !== "workflow_run") {
+      await publishStatus(
+        github,
+        owner,
+        repo,
+        pull.mergeSha,
+        BRANCH_CONTEXT,
+        branch.allowed ? "success" : "failure",
+        `PR #${pull.number}: ${branch.description}`,
+        policyRunUrl,
+      );
+    }
     await publishStatus(
       github,
       owner,
@@ -382,6 +384,7 @@ module.exports = async function publishPrPolicy({ github, context, core }) {
     core.info(
       `pr=${pull.number} merge_sha=${pull.mergeSha} ` +
         `branch=${branch.allowed ? "success" : "failure"} ` +
+        `branch_published=${context.eventName !== "workflow_run"} ` +
         `quality=${quality.state} reason=${quality.reason}`,
     );
     failed ||= !branch.allowed || quality.state === "failure";

--- a/.github/scripts/test-publish-pr-policy.js
+++ b/.github/scripts/test-publish-pr-policy.js
@@ -50,6 +50,7 @@ async function execute({
   eventPull = pull(),
   run = workflowRun(),
   headBlob = "trusted-blob",
+  eventName = "pull_request_target",
 } = {}) {
   const statuses = [];
   const messages = [];
@@ -96,8 +97,11 @@ async function execute({
     setFailed: (message) => messages.push(`FAILED: ${message}`),
   };
   const context = {
-    eventName: "pull_request_target",
-    payload: { pull_request: eventPull },
+    eventName,
+    payload:
+      eventName === "workflow_run"
+        ? { workflow_run: run }
+        : { pull_request: eventPull },
     repo: { owner: "example", repo: "repo" },
     runId: 101,
     serverUrl: "https://example.invalid",
@@ -138,6 +142,12 @@ async function main() {
 
   const changedWorkflow = await execute({ headBlob: "changed-blob" });
   assert.equal(changedWorkflow.statuses[1].state, "failure");
+
+  const qualityCompletion = await execute({ eventName: "workflow_run" });
+  assert.deepEqual(
+    qualityCompletion.statuses.map(({ context, state }) => ({ context, state })),
+    [{ context: "pr-quality-gates", state: "success" }],
+  );
 
   const staleEvent = pull({
     head: {

--- a/infra/azure/agents/pr-validation-stan.sh
+++ b/infra/azure/agents/pr-validation-stan.sh
@@ -159,6 +159,13 @@ then
 fi
 
 section "trusted workflow provenance"
+quality_status_run_id="$(
+  awk -F $'\t' '$1 == "pr-quality-gates" { print $2 }' "$tmp_required"
+)"
+[[ -n "$quality_status_run_id" ]] || {
+  echo "trusted quality status run ID is missing" >&2
+  exit 1
+}
 while IFS=$'\t' read -r context run_id workflow_file expected_events require_head_sha; do
   [[ -n "${run_id:-}" ]] || continue
   trusted_workflow_id="$(
@@ -167,7 +174,7 @@ while IFS=$'\t' read -r context run_id workflow_file expected_events require_hea
   gh api "repos/$REPO/actions/runs/$run_id" > "$tmp_run"
   if ! python3 - "$tmp_run" "$context" "$trusted_workflow_id" \
     "$workflow_file" "$expected_events" "$require_head_sha" \
-    "$PR_NUMBER" "$head_sha" "$base_sha" <<'PY'
+    "$PR_NUMBER" "$head_sha" "$base_sha" "$quality_status_run_id" <<'PY'
 import json
 import sys
 
@@ -181,6 +188,7 @@ import sys
     pr_number,
     head_sha,
     base_sha,
+    quality_status_run_id,
 ) = sys.argv[1:]
 run = json.load(open(run_file, encoding="utf-8"))
 allowed_events = set(expected_events.split(","))
@@ -207,7 +215,11 @@ if run.get("status") != "completed" or run.get("conclusion") != "success":
 if require_head_sha == "yes" and run.get("head_sha") != head_sha:
     failures.append("workflow run belongs to a different head SHA")
 
-if run.get("event") == "workflow_dispatch":
+if context == "branch-policy" and run.get("event") == "workflow_run":
+    relation_matches = (
+        run.get("display_title") == f"branch-policy PR {quality_status_run_id}"
+    )
+elif run.get("event") == "workflow_dispatch":
     relation_matches = run.get("display_title") == f"branch-policy PR {pr_number}"
 else:
     relation_matches = any(

--- a/infra/azure/agents/pr-validation-stan.sh
+++ b/infra/azure/agents/pr-validation-stan.sh
@@ -10,6 +10,7 @@ REPO="${REPO:-vasilyevstan/betstan}"
 PR_NUMBER="${1:-${PR:-}}"
 EXPECTED_HEAD_SHA="${EXPECTED_HEAD_SHA:-}"
 EXPECTED_BASE_SHA="${EXPECTED_BASE_SHA:-}"
+TRUSTED_STATUS_APP_ID="${TRUSTED_STATUS_APP_ID:-15368}"
 
 if [[ -z "$PR_NUMBER" ]]; then
   echo "usage: $0 <pr-number>" >&2
@@ -87,13 +88,14 @@ PY
 
 section "required merge-snapshot statuses"
 gh api "repos/$REPO/commits/$merge_sha/status" > "$tmp_statuses"
-if ! python3 - "$tmp_statuses" "$tmp_required" <<'PY'
+if ! python3 - "$tmp_statuses" "$tmp_required" "$TRUSTED_STATUS_APP_ID" <<'PY'
 import json
 import re
 import sys
 
 response = json.load(open(sys.argv[1], encoding="utf-8"))
 required_path = sys.argv[2]
+trusted_status_app_id = sys.argv[3]
 required = {
     "branch-policy": {
         "workflow_file": "branch-policy.yml",
@@ -120,12 +122,14 @@ for context, spec in required.items():
     status = matches[0]
     state = status.get("state") or ""
     target_url = status.get("target_url") or ""
-    creator = (status.get("creator") or {}).get("login") or ""
-    print(f"{context}\t{state}\t{creator}\t{target_url}")
+    avatar_url = status.get("avatar_url") or ""
+    app_match = re.search(r"/in/(\d+)(?:\?|$)", avatar_url)
+    app_id = app_match.group(1) if app_match else ""
+    print(f"{context}\t{state}\tapp_id={app_id}\t{target_url}")
     if state != "success":
         failed = True
-    if creator != "github-actions[bot]":
-        print(f"{context}: unexpected status creator {creator!r}", file=sys.stderr)
+    if app_id != trusted_status_app_id:
+        print(f"{context}: unexpected status app ID {app_id!r}", file=sys.stderr)
         failed = True
 
     run_match = re.search(r"/actions/runs/(\d+)(?:/|$)", target_url)

--- a/infra/azure/agents/test-pr-validation-stan.sh
+++ b/infra/azure/agents/test-pr-validation-stan.sh
@@ -25,10 +25,10 @@ gh() {
     echo "202"
   elif [[ "$1" == "api" && "$2" == *"/actions/runs/101" ]]; then
     printf '%s\n' \
-      "{\"id\":101,\"workflow_id\":201,\"name\":\"branch-policy\",\"path\":\".github/workflows/branch-policy.yml\",\"event\":\"pull_request_target\",\"head_sha\":\"$BASE_SHA\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"https://example.invalid/actions/runs/101\",\"pull_requests\":[{\"number\":63,\"head\":{\"sha\":\"$HEAD_SHA\"},\"base\":{\"sha\":\"${STUB_RUN_BASE_SHA:-$BASE_SHA}\"}}]}"
+      "{\"id\":101,\"workflow_id\":201,\"name\":\"branch-policy\",\"path\":\".github/workflows/branch-policy.yml\",\"display_title\":\"branch-policy PR ${STUB_BRANCH_UPSTREAM_ID:-102}\",\"event\":\"workflow_run\",\"head_sha\":\"$BASE_SHA\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"https://example.invalid/actions/runs/101\",\"pull_requests\":[{\"number\":99,\"head\":{\"sha\":\"$BASE_SHA\"},\"base\":{\"sha\":\"$BASE_SHA\"}}]}"
   elif [[ "$1" == "api" && "$2" == *"/actions/runs/102" ]]; then
     printf '%s\n' \
-      "{\"id\":102,\"workflow_id\":${STUB_BUILD_WORKFLOW_ID:-202},\"name\":\"production-build\",\"path\":\".github/workflows/production-build.yml\",\"event\":\"pull_request\",\"head_sha\":\"${STUB_RUN_HEAD_SHA:-$HEAD_SHA}\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"https://example.invalid/actions/runs/102\",\"pull_requests\":[{\"number\":63,\"head\":{\"sha\":\"$HEAD_SHA\"},\"base\":{\"sha\":\"$BASE_SHA\"}}]}"
+      "{\"id\":102,\"workflow_id\":${STUB_BUILD_WORKFLOW_ID:-202},\"name\":\"production-build\",\"path\":\".github/workflows/production-build.yml\",\"event\":\"pull_request\",\"head_sha\":\"${STUB_RUN_HEAD_SHA:-$HEAD_SHA}\",\"status\":\"completed\",\"conclusion\":\"success\",\"html_url\":\"https://example.invalid/actions/runs/102\",\"pull_requests\":[{\"number\":63,\"head\":{\"sha\":\"$HEAD_SHA\"},\"base\":{\"sha\":\"${STUB_RUN_BASE_SHA:-$BASE_SHA}\"}}]}"
   else
     echo "unexpected gh invocation: $*" >&2
     return 1
@@ -60,6 +60,12 @@ fi
 if STUB_RUN_BASE_SHA="4444444444444444444444444444444444444444" \
   REPO=example/repo "$VALIDATOR" 63 >/dev/null 2>&1; then
   echo "validator accepted a status from a stale PR base" >&2
+  exit 1
+fi
+
+if STUB_BRANCH_UPSTREAM_ID=999 REPO=example/repo \
+  "$VALIDATOR" 63 >/dev/null 2>&1; then
+  echo "validator accepted a branch status from an unrelated quality run" >&2
   exit 1
 fi
 

--- a/infra/azure/agents/test-pr-validation-stan.sh
+++ b/infra/azure/agents/test-pr-validation-stan.sh
@@ -18,7 +18,7 @@ gh() {
     fi
   elif [[ "$1" == "api" && "$2" == *"/commits/$MERGE_SHA/status" ]]; then
     printf '%s\n' \
-      "{\"statuses\":[{\"context\":\"branch-policy\",\"state\":\"${STUB_BRANCH_STATE:-success}\",\"target_url\":\"https://example.invalid/actions/runs/101\",\"creator\":{\"login\":\"${STUB_CREATOR:-github-actions[bot]}\"}},{\"context\":\"pr-quality-gates\",\"state\":\"success\",\"target_url\":\"https://example.invalid/actions/runs/102\",\"creator\":{\"login\":\"github-actions[bot]\"}}]}"
+      "{\"statuses\":[{\"context\":\"branch-policy\",\"state\":\"${STUB_BRANCH_STATE:-success}\",\"target_url\":\"https://example.invalid/actions/runs/101\",\"avatar_url\":\"https://avatars.example.invalid/in/${STUB_STATUS_APP_ID:-15368}?v=4\"},{\"context\":\"pr-quality-gates\",\"state\":\"success\",\"target_url\":\"https://example.invalid/actions/runs/102\",\"avatar_url\":\"https://avatars.example.invalid/in/15368?v=4\"}]}"
   elif [[ "$1" == "api" && "$2" == *"/actions/workflows/branch-policy.yml" ]]; then
     echo "201"
   elif [[ "$1" == "api" && "$2" == *"/actions/workflows/production-build.yml" ]]; then
@@ -63,9 +63,9 @@ if STUB_RUN_BASE_SHA="4444444444444444444444444444444444444444" \
   exit 1
 fi
 
-if STUB_CREATOR="untrusted-user" REPO=example/repo \
+if STUB_STATUS_APP_ID="999" REPO=example/repo \
   "$VALIDATOR" 63 >/dev/null 2>&1; then
-  echo "validator accepted an untrusted status creator" >&2
+  echo "validator accepted an untrusted status app" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- identify GitHub Actions commit statuses through their App avatar ID
- keep exact workflow-run provenance checks unchanged
- cover rejection of a status from an unexpected App ID

Observed against the live trusted statuses on PR #67; no production action is involved.