### PR TITLE
Bind required checks to head and merge

### DIFF
--- a/.github/scripts/publish-pr-policy.js
+++ b/.github/scripts/publish-pr-policy.js
@@ -1,7 +1,8 @@
 "use strict";
 
-const BRANCH_CONTEXT = "branch-policy";
-const QUALITY_CONTEXT = "pr-quality-gates";
+const BRANCH_CONTEXT_PREFIX = "branch-policy";
+const QUALITY_CONTEXT_PREFIX = "pr-quality-gates";
+const QUALITY_JOB = "pr-quality-gates";
 const QUALITY_WORKFLOW = "production-build.yml";
 const QUALITY_WORKFLOW_PATH = `.github/workflows/${QUALITY_WORKFLOW}`;
 
@@ -231,7 +232,7 @@ async function qualityDecision({
     per_page: 100,
   });
   const aggregate = jobsResponse.data.jobs.find(
-    (job) => job.name === QUALITY_CONTEXT,
+    (job) => job.name === QUALITY_JOB,
   );
   if (
     !aggregate ||
@@ -273,6 +274,12 @@ async function publishStatus(
     description,
     target_url: targetUrl,
   });
+}
+
+function statusTargets(pull) {
+  return pull.baseRef === "master"
+    ? [pull.headSha, pull.mergeSha]
+    : [pull.mergeSha];
 }
 
 function eventPullIdentity(eventPull) {
@@ -343,29 +350,36 @@ module.exports = async function publishPrPolicy({ github, context, core }) {
       candidateRun: item.candidateRun,
       fallbackUrl: policyRunUrl,
     });
+    const branchContext = `${BRANCH_CONTEXT_PREFIX}/${pull.baseRef}`;
+    const qualityContext = `${QUALITY_CONTEXT_PREFIX}/${pull.baseRef}`;
+    const targets = statusTargets(pull);
 
     if (context.eventName !== "workflow_run") {
+      for (const target of targets) {
+        await publishStatus(
+          github,
+          owner,
+          repo,
+          target,
+          branchContext,
+          branch.allowed ? "success" : "failure",
+          `PR #${pull.number}: ${branch.description}`,
+          policyRunUrl,
+        );
+      }
+    }
+    for (const target of targets) {
       await publishStatus(
         github,
         owner,
         repo,
-        pull.mergeSha,
-        BRANCH_CONTEXT,
-        branch.allowed ? "success" : "failure",
-        `PR #${pull.number}: ${branch.description}`,
-        policyRunUrl,
+        target,
+        qualityContext,
+        quality.state,
+        quality.description,
+        quality.targetUrl,
       );
     }
-    await publishStatus(
-      github,
-      owner,
-      repo,
-      pull.mergeSha,
-      QUALITY_CONTEXT,
-      quality.state,
-      quality.description,
-      quality.targetUrl,
-    );
 
     const finalPull = pullIdentity(
       (

--- a/.github/scripts/test-publish-pr-policy.js
+++ b/.github/scripts/test-publish-pr-policy.js
@@ -120,8 +120,14 @@ async function main() {
       sha,
     })),
     [
-      { context: "branch-policy", state: "success", sha: MERGE_SHA },
-      { context: "pr-quality-gates", state: "success", sha: MERGE_SHA },
+      { context: "branch-policy/master", state: "success", sha: HEAD_SHA },
+      { context: "branch-policy/master", state: "success", sha: MERGE_SHA },
+      { context: "pr-quality-gates/master", state: "success", sha: HEAD_SHA },
+      {
+        context: "pr-quality-gates/master",
+        state: "success",
+        sha: MERGE_SHA,
+      },
     ],
   );
 
@@ -141,12 +147,28 @@ async function main() {
   assert(invalid.messages.some((message) => message.startsWith("FAILED:")));
 
   const changedWorkflow = await execute({ headBlob: "changed-blob" });
-  assert.equal(changedWorkflow.statuses[1].state, "failure");
+  assert.equal(changedWorkflow.statuses[2].state, "failure");
+  assert.equal(changedWorkflow.statuses[3].state, "failure");
 
   const qualityCompletion = await execute({ eventName: "workflow_run" });
   assert.deepEqual(
-    qualityCompletion.statuses.map(({ context, state }) => ({ context, state })),
-    [{ context: "pr-quality-gates", state: "success" }],
+    qualityCompletion.statuses.map(({ context, state, sha }) => ({
+      context,
+      state,
+      sha,
+    })),
+    [
+      {
+        context: "pr-quality-gates/master",
+        state: "success",
+        sha: HEAD_SHA,
+      },
+      {
+        context: "pr-quality-gates/master",
+        state: "success",
+        sha: MERGE_SHA,
+      },
+    ],
   );
 
   const staleEvent = pull({

--- a/.github/skills/betstan-branch-governance/SKILL.md
+++ b/.github/skills/betstan-branch-governance/SKILL.md
@@ -12,7 +12,7 @@ Use this skill whenever a task involves branches, commits, pushes, pull requests
 - Never commit or push directly to `master`.
 - Normal changes enter `dev`, either directly or through a focused pull request.
 - Only an up-to-date `dev` branch may open a pull request into `master`.
-- A production promotion requires green trusted `branch-policy` and `pr-quality-gates` statuses on its current unique merge snapshot.
+- A production promotion requires green trusted `branch-policy/master` and `pr-quality-gates/master` statuses on both its current head and unique merge snapshot.
 - Before promotion, identify the exact head SHA and every production-capable workflow triggered by the diff. Require explicit approval covering that exact set.
 - Manual central production workflow dispatches are approval-gated through `production-emergency` and require an exact full master SHA. Legacy per-service deploy workflows are not manually dispatchable.
 - After a squash promotion, immediately merge `master` back into `dev` and verify `master` is an ancestor of `dev`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Use this flow:
 1. Make normal changes on a feature, fix, or operations branch and integrate them into `dev`.
 2. Validate the complete `dev` branch.
 3. Promote production only with an up-to-date pull request from `dev` to `master`.
-4. Require the trusted `branch-policy` and `pr-quality-gates` statuses on the PR's current merge snapshot to pass.
+4. Require the trusted, base-scoped `branch-policy/master` and `pr-quality-gates/master` statuses on both the promotion head and current merge snapshot to pass.
 5. Before merging a promotion, obtain explicit approval for the exact head SHA and every production-capable workflow the diff will trigger.
 6. After a squash promotion, immediately merge the new `master` commit back into `dev`.
 
@@ -28,7 +28,7 @@ Do not require a new check before its trusted workflow exists on `dev`, the repo
 1. Merge the trusted workflow and publisher into `dev` under the currently enforced checks.
 2. Trigger a fresh PR snapshot (or dispatch `branch-policy.yml` with its PR number), verify the new statuses come from the expected workflow IDs, and only then replace branch-protection contexts or disable the retired workflow identity.
 
-The trusted publisher binds both required statuses to the PR's current head SHA, base SHA, repository, and unique test-merge SHA. A status on a reusable branch-head SHA is not a promotion gate.
+The trusted publisher binds both required status targets to the same current PR head SHA, base SHA, repository, trusted workflow runs, and unique test-merge SHA. Head-only or merge-only evidence is not a promotion gate.
 
 Before proposing a production promotion:
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -79,7 +79,7 @@ cd resulting && npm ci && npm run test:ci
 
 - Never commit or push directly to `master`.
 - Normal work enters `dev`; production promotion is an up-to-date `dev`-to-`master` pull request.
-- Promotion requires statuses bound to the current PR head, base, repository, and unique merge snapshot. A branch-name run or reusable head-SHA status can be stale or unrelated.
+- Promotion requires base-scoped statuses whose head and unique merge-snapshot copies point to the same trusted runs and current PR head/base/repository. Head-only, merge-only, or branch-name evidence can be stale or unrelated.
 - Skipped, stale, pending, neutral, or unrelated runs are not green gates.
 - A squash promotion breaks shared ancestry until the new `master` commit is merged back into `dev`; perform that synchronization immediately.
 - Manual central production workflow dispatches and reruns are emergency operations requiring an exact full master SHA and `production-emergency` approval. Old central and per-service workflow identities stay disabled so historical definitions cannot be rerun.

--- a/infra/azure/LESSONS_LEARNED.md
+++ b/infra/azure/LESSONS_LEARNED.md
@@ -90,7 +90,7 @@ pre-commit-infra-check-stan.sh   ← before pushing branch
     ↓
 feature/hotfix branch → dev      ← normal integration
     ↓
-branch-policy + quality gates    ← exact current PR merge snapshot
+branch-policy + quality gates    ← matching head and merge snapshots
     ↓
 dev → master promotion PR       ← exact-SHA production approval required
     ↓

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -41,7 +41,7 @@ pre-commit-infra-check-stan.sh   ← run before git push on any infra/workflow c
     ↓
 feature/hotfix branch → dev      ← normal integration path
     ↓
-branch-policy + quality gates    ← exact current PR merge snapshot
+branch-policy + quality gates    ← matching head and merge snapshots
     ↓
 dev → master promotion PR       ← explicit exact-SHA production approval
     ↓
@@ -132,12 +132,12 @@ Use the merge-safety agent when you want a conservative yes/no recommendation:
 
 The validation agent:
 - binds the current PR head SHA, base SHA, and unique test-merge SHA;
-- accepts only statuses published by GitHub Actions on that merge snapshot;
+- accepts only base-scoped statuses published by GitHub Actions on both snapshots;
 - verifies the exact trusted workflow IDs, events, and PR relations behind both required statuses.
 
 The merge-safety agent:
 - rejects unsupported branch pairs;
-- runs exact current merge-snapshot validation;
+- requires matching trusted runs on the current head and merge snapshots;
 - recommends a `dev` merge only when validation is green;
 - requires `APPROVED_SHA` and `APPROVED_WORKFLOWS` before recommending a production promotion.
 
@@ -203,7 +203,7 @@ If `dns-check-stan.sh` prints `status=MATCH`, DNS is pointing to current ingress
 - `production-build` runs on `master` and tags each image with the exact approved SHA.
 - `production-build` pull requests into `dev` or `master` run the full quality gates.
 - `branch-policy` permits normal branches into `dev` and only `dev` into `master`.
-- Required statuses are published on the PR's unique current merge snapshot, not a reusable branch-head SHA.
+- Promotion statuses are base-scoped and published on both the current head and unique merge snapshot; validation requires both copies to point to the same trusted runs.
 - `production-deploy` runs only after successful `production-build` on `master` and deploys that exact SHA image set.
 - Emergency manual dispatch is limited to the central workflows, requires a full master SHA, and pauses at the reviewer-protected `production-emergency` environment.
 - Retired central and per-service workflow identities remain disabled so historical runs cannot be rerun.

--- a/infra/azure/agents/pr-validation-stan.sh
+++ b/infra/azure/agents/pr-validation-stan.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Purpose: validate trusted required statuses for a PR's exact current merge snapshot.
+# Purpose: validate trusted required statuses for a PR's exact head and merge snapshots.
 # Usage:
 #   ./infra/azure/agents/pr-validation-stan.sh 41
 #   PR=41 ./infra/azure/agents/pr-validation-stan.sh
@@ -19,10 +19,11 @@ fi
 
 tmp_meta="$(mktemp)"
 tmp_statuses="$(mktemp)"
+tmp_head_statuses="$(mktemp)"
 tmp_required="$(mktemp)"
 tmp_run="$(mktemp)"
 cleanup() {
-  rm -f "$tmp_meta" "$tmp_statuses" "$tmp_required" "$tmp_run"
+  rm -f "$tmp_meta" "$tmp_statuses" "$tmp_head_statuses" "$tmp_required" "$tmp_run"
 }
 trap cleanup EXIT
 
@@ -56,7 +57,7 @@ print(f"headRepository={(meta.get('headRepository') or {}).get('nameWithOwner', 
 print(f"mergeSnapshot={(meta.get('potentialMergeCommit') or {}).get('oid', '')}")
 PY
 
-read -r head_sha base_sha merge_sha <<<"$(
+read -r head_sha base_sha merge_sha base_ref <<<"$(
   python3 - "$tmp_meta" <<'PY'
 import json
 import sys
@@ -66,10 +67,11 @@ print(
     meta.get("headRefOid", ""),
     meta.get("baseRefOid", ""),
     (meta.get("potentialMergeCommit") or {}).get("oid", ""),
+    meta.get("baseRefName", ""),
 )
 PY
 )"
-[[ -n "$head_sha" && -n "$base_sha" && -n "$merge_sha" ]] || {
+[[ -n "$head_sha" && -n "$base_sha" && -n "$merge_sha" && -n "$base_ref" ]] || {
   echo "PR head, base, or merge snapshot SHA is missing" >&2
   exit 1
 }
@@ -88,7 +90,7 @@ PY
 
 section "required merge-snapshot statuses"
 gh api "repos/$REPO/commits/$merge_sha/status" > "$tmp_statuses"
-if ! python3 - "$tmp_statuses" "$tmp_required" "$TRUSTED_STATUS_APP_ID" <<'PY'
+if ! python3 - "$tmp_statuses" "$tmp_required" "$TRUSTED_STATUS_APP_ID" "$base_ref" <<'PY'
 import json
 import re
 import sys
@@ -96,13 +98,14 @@ import sys
 response = json.load(open(sys.argv[1], encoding="utf-8"))
 required_path = sys.argv[2]
 trusted_status_app_id = sys.argv[3]
+base_ref = sys.argv[4]
 required = {
-    "branch-policy": {
+    f"branch-policy/{base_ref}": {
         "workflow_file": "branch-policy.yml",
         "events": "pull_request_target,workflow_run,workflow_dispatch",
         "require_head_sha": "no",
     },
-    "pr-quality-gates": {
+    f"pr-quality-gates/{base_ref}": {
         "workflow_file": "production-build.yml",
         "events": "pull_request",
         "require_head_sha": "yes",
@@ -158,9 +161,60 @@ then
   exit 1
 fi
 
+if [[ "$base_ref" == "master" ]]; then
+  section "required head-snapshot statuses"
+  gh api "repos/$REPO/commits/$head_sha/status" > "$tmp_head_statuses"
+  if ! python3 - "$tmp_head_statuses" "$tmp_required" \
+    "$TRUSTED_STATUS_APP_ID" <<'PY'
+import json
+import re
+import sys
+
+response = json.load(open(sys.argv[1], encoding="utf-8"))
+required_runs = {}
+with open(sys.argv[2], encoding="utf-8") as handle:
+    for line in handle:
+        context, run_id, *_ = line.rstrip("\n").split("\t")
+        required_runs[context] = run_id
+trusted_status_app_id = sys.argv[3]
+statuses = response.get("statuses") or []
+failed = False
+
+for context, expected_run_id in required_runs.items():
+    matches = [status for status in statuses if status.get("context") == context]
+    if not matches:
+        print(f"{context}\tMISSING\t\t")
+        failed = True
+        continue
+
+    status = matches[0]
+    state = status.get("state") or ""
+    target_url = status.get("target_url") or ""
+    avatar_url = status.get("avatar_url") or ""
+    app_match = re.search(r"/in/(\d+)(?:\?|$)", avatar_url)
+    run_match = re.search(r"/actions/runs/(\d+)(?:/|$)", target_url)
+    app_id = app_match.group(1) if app_match else ""
+    run_id = run_match.group(1) if run_match else ""
+    print(f"{context}\t{state}\tapp_id={app_id}\t{target_url}")
+    if (
+        state != "success"
+        or app_id != trusted_status_app_id
+        or run_id != expected_run_id
+    ):
+        failed = True
+
+sys.exit(1 if failed else 0)
+PY
+  then
+    echo "required head statuses do not match the trusted merge snapshot" >&2
+    exit 1
+  fi
+fi
+
 section "trusted workflow provenance"
 quality_status_run_id="$(
-  awk -F $'\t' '$1 == "pr-quality-gates" { print $2 }' "$tmp_required"
+  awk -F $'\t' -v context="pr-quality-gates/$base_ref" \
+    '$1 == context { print $2 }' "$tmp_required"
 )"
 [[ -n "$quality_status_run_id" ]] || {
   echo "trusted quality status run ID is missing" >&2
@@ -215,7 +269,7 @@ if run.get("status") != "completed" or run.get("conclusion") != "success":
 if require_head_sha == "yes" and run.get("head_sha") != head_sha:
     failures.append("workflow run belongs to a different head SHA")
 
-if context == "branch-policy" and run.get("event") == "workflow_run":
+if context.startswith("branch-policy/") and run.get("event") == "workflow_run":
     relation_matches = (
         run.get("display_title") == f"branch-policy PR {quality_status_run_id}"
     )

--- a/infra/azure/agents/test-pr-validation-stan.sh
+++ b/infra/azure/agents/test-pr-validation-stan.sh
@@ -11,14 +11,21 @@ gh() {
   if [[ "$1 $2" == "pr view" ]]; then
     if [[ "$*" == *"number,title,state"* ]]; then
       printf '%s\n' \
-        "{\"number\":63,\"title\":\"policy\",\"state\":\"OPEN\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefName\":\"feature/policy\",\"headRefOid\":\"$HEAD_SHA\",\"headRepository\":{\"nameWithOwner\":\"example/repo\"},\"baseRefName\":\"dev\",\"baseRefOid\":\"$BASE_SHA\",\"potentialMergeCommit\":{\"oid\":\"$MERGE_SHA\"},\"url\":\"https://example.invalid/pr/63\"}"
+        "{\"number\":63,\"title\":\"policy\",\"state\":\"OPEN\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefName\":\"dev\",\"headRefOid\":\"$HEAD_SHA\",\"headRepository\":{\"nameWithOwner\":\"example/repo\"},\"baseRefName\":\"master\",\"baseRefOid\":\"$BASE_SHA\",\"potentialMergeCommit\":{\"oid\":\"$MERGE_SHA\"},\"url\":\"https://example.invalid/pr/63\"}"
     else
       printf '%s\n' \
         "{\"headRefOid\":\"$HEAD_SHA\",\"baseRefOid\":\"$BASE_SHA\",\"potentialMergeCommit\":{\"oid\":\"$MERGE_SHA\"}}"
     fi
-  elif [[ "$1" == "api" && "$2" == *"/commits/$MERGE_SHA/status" ]]; then
+  elif [[ "$1" == "api" &&
+    ( "$2" == *"/commits/$MERGE_SHA/status" || "$2" == *"/commits/$HEAD_SHA/status" ) ]]; then
+    local branch_run_id=101
+    local quality_run_id=102
+    if [[ "$2" == *"/commits/$HEAD_SHA/status" ]]; then
+      branch_run_id="${STUB_HEAD_BRANCH_RUN_ID:-101}"
+      quality_run_id="${STUB_HEAD_QUALITY_RUN_ID:-102}"
+    fi
     printf '%s\n' \
-      "{\"statuses\":[{\"context\":\"branch-policy\",\"state\":\"${STUB_BRANCH_STATE:-success}\",\"target_url\":\"https://example.invalid/actions/runs/101\",\"avatar_url\":\"https://avatars.example.invalid/in/${STUB_STATUS_APP_ID:-15368}?v=4\"},{\"context\":\"pr-quality-gates\",\"state\":\"success\",\"target_url\":\"https://example.invalid/actions/runs/102\",\"avatar_url\":\"https://avatars.example.invalid/in/15368?v=4\"}]}"
+      "{\"statuses\":[{\"context\":\"branch-policy/master\",\"state\":\"${STUB_BRANCH_STATE:-success}\",\"target_url\":\"https://example.invalid/actions/runs/$branch_run_id\",\"avatar_url\":\"https://avatars.example.invalid/in/${STUB_STATUS_APP_ID:-15368}?v=4\"},{\"context\":\"pr-quality-gates/master\",\"state\":\"success\",\"target_url\":\"https://example.invalid/actions/runs/$quality_run_id\",\"avatar_url\":\"https://avatars.example.invalid/in/15368?v=4\"}]}"
   elif [[ "$1" == "api" && "$2" == *"/actions/workflows/branch-policy.yml" ]]; then
     echo "201"
   elif [[ "$1" == "api" && "$2" == *"/actions/workflows/production-build.yml" ]]; then
@@ -72,6 +79,12 @@ fi
 if STUB_STATUS_APP_ID="999" REPO=example/repo \
   "$VALIDATOR" 63 >/dev/null 2>&1; then
   echo "validator accepted an untrusted status app" >&2
+  exit 1
+fi
+
+if STUB_HEAD_QUALITY_RUN_ID=999 REPO=example/repo \
+  "$VALIDATOR" 63 >/dev/null 2>&1; then
+  echo "validator accepted a head status from a different quality run" >&2
   exit 1
 fi
 

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -75,9 +75,10 @@ require_literal "$branch_workflow" 'workflows: ["production-build"]' "trusted qu
 require_literal "$branch_workflow" "pr_number:" "trusted bootstrap refresh input"
 require_literal "$branch_workflow" "statuses: write" "status publication permission"
 require_literal "$branch_workflow" "publish-pr-policy.js" "trusted policy publisher"
-require_literal "$policy_script" 'const BRANCH_CONTEXT = "branch-policy"' "stable branch context"
-require_literal "$policy_script" 'const QUALITY_CONTEXT = "pr-quality-gates"' "stable quality context"
+require_literal "$policy_script" 'const BRANCH_CONTEXT_PREFIX = "branch-policy"' "stable branch context"
+require_literal "$policy_script" 'const QUALITY_CONTEXT_PREFIX = "pr-quality-gates"' "stable quality context"
 require_literal "$policy_script" "pull.mergeSha" "unique PR merge snapshot status"
+require_literal "$policy_script" "? [pull.headSha, pull.mergeSha]" "promotion head and merge statuses"
 require_literal "$policy_script" "assertExpectedPull(finalPull, pull)" "final stale-event check"
 require_literal "$policy_script" "relation.base?.sha === pull.baseSha" "exact base snapshot relation"
 


### PR DESCRIPTION
## Summary
- publish base-scoped trusted statuses on both the promotion head and unique merge snapshot
- require both copies to identify the same GitHub Actions app and exact workflow runs
- avoid collisions with PR-controlled aggregate job names
- retain merge-only status publication for unprotected `dev` PRs

## Live finding
GitHub evaluated required checks on the PR head because head-attached check runs existed, leaving merge-only `branch-policy` status unrecognized. This change preserves the unique merge-snapshot audit while adding the exact matching head status that branch protection consumes. No production action is involved.