### PR TITLE
Promote exact workflow bootstrap policy

### DIFF
--- a/.github/scripts/publish-pr-policy.js
+++ b/.github/scripts/publish-pr-policy.js
@@ -5,6 +5,10 @@ const QUALITY_CONTEXT_PREFIX = "pr-quality-gates";
 const QUALITY_JOB = "pr-quality-gates";
 const QUALITY_WORKFLOW = "production-build.yml";
 const QUALITY_WORKFLOW_PATH = `.github/workflows/${QUALITY_WORKFLOW}`;
+// Remove this one-use authorization after the exact workflow blob reaches master.
+const APPROVED_QUALITY_WORKFLOW_BLOBS = new Set([
+  "8c6df3ddf1f9cca0a551efc74012a9435b2d0295",
+]);
 
 const sleep = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -173,7 +177,10 @@ async function qualityDecision({
     };
   }
 
-  if (trustedBlob !== headBlob) {
+  if (
+    trustedBlob !== headBlob &&
+    !APPROVED_QUALITY_WORKFLOW_BLOBS.has(headBlob)
+  ) {
     return {
       state: "failure",
       description: `PR #${pull.number} changes the trusted quality workflow`,

--- a/.github/scripts/test-publish-pr-policy.js
+++ b/.github/scripts/test-publish-pr-policy.js
@@ -150,6 +150,12 @@ async function main() {
   assert.equal(changedWorkflow.statuses[2].state, "failure");
   assert.equal(changedWorkflow.statuses[3].state, "failure");
 
+  const approvedWorkflow = await execute({
+    headBlob: "8c6df3ddf1f9cca0a551efc74012a9435b2d0295",
+  });
+  assert.equal(approvedWorkflow.statuses[2].state, "success");
+  assert.equal(approvedWorkflow.statuses[3].state, "success");
+
   const qualityCompletion = await execute({ eventName: "workflow_run" });
   assert.deepEqual(
     qualityCompletion.statuses.map(({ context, state, sha }) => ({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,10 @@ Do not rewrite or force-push `master` or `dev`. Preserve unrelated tracked, stag
 
 ## Trusted-check bootstrap
 
-Do not require a new check before its trusted workflow exists on `dev`, the repository's default branch. Roll out check changes in two phases:
+Do not change the protected quality workflow before its exact Git blob is authorized by the trusted publisher on the default branch. Roll out quality-workflow changes in two phases:
 
-1. Merge the trusted workflow and publisher into `dev` under the currently enforced checks.
-2. Trigger a fresh PR snapshot (or dispatch `branch-policy.yml` with its PR number), verify the new statuses come from the expected workflow IDs, and only then replace branch-protection contexts or disable the retired workflow identity.
+1. Add only the intended workflow blob SHA to `APPROVED_QUALITY_WORKFLOW_BLOBS`, merge that policy change through `dev`, and promote it to protected `master`.
+2. Merge the exact workflow update through `dev`, remove the one-use authorization before promotion, and verify fresh statuses come from the expected workflow IDs.
 
 The trusted publisher binds both required status targets to the same current PR head SHA, base SHA, repository, trusted workflow runs, and unique test-merge SHA. Head-only or merge-only evidence is not a promotion gate.
 


### PR DESCRIPTION
## Scope

Policy-only promotion required to unblock the exact reviewed `production-build.yml` blob in PR #71.

- authorizes only Git blob `8c6df3ddf1f9cca0a551efc74012a9435b2d0295`;
- adds regression coverage for unauthorized versus exact authorized workflow changes;
- documents the two-phase protected bootstrap;
- contains no application, manifest, production workflow, or deployment changes.

## Production behavior

Merging this PR emits a `master` push under the currently deployed workflow definition. Server-side controls already require reviewer approval on the master-only production environment before any image build. `production-deploy` remains disabled, so this policy promotion cannot deploy production.

The pending image build should not be approved; it exists only because the current workflow still triggers on every master push.
