### PR TITLE
Fix production auth smoke validation

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -18,9 +18,9 @@ env:
   BUILD_RUN_ID: ${{ inputs.build_run_id }}
   RESOURCE_GROUP: ${{ secrets.RESOURCE_GROUP }}
   CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
-  APP_DOMAIN: ${{ vars.APP_DOMAIN || '48.206.235.122.nip.io' }}
-  APP_CERT_NAME: ${{ vars.APP_CERT_NAME || 'betstan-nip-tls' }}
-  APP_E2E_BASE_URL: ${{ vars.APP_E2E_BASE_URL || '' }}
+  APP_DOMAIN: ${{ vars.APP_DOMAIN || 'betstan.xyz' }}
+  APP_CERT_NAME: ${{ vars.APP_CERT_NAME || 'betstan-tls' }}
+  APP_E2E_BASE_URL: ${{ vars.APP_E2E_BASE_URL || 'https://betstan.xyz' }}
   DEPLOY_VALIDATION_ATTEMPTS: ${{ vars.DEPLOY_VALIDATION_ATTEMPTS || '3' }}
   DEPLOY_VALIDATION_SLEEP_SECONDS: ${{ vars.DEPLOY_VALIDATION_SLEEP_SECONDS || '30' }}
   DEPLOY_VALIDATION_MAX_LOOPS: ${{ vars.DEPLOY_VALIDATION_MAX_LOOPS || '3' }}

--- a/client/src/pages/auth/LogIn.js
+++ b/client/src/pages/auth/LogIn.js
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import UseRequest from "../../hook/UseRequest";
 import AuthPanel from "./AuthPanel";
+import authCopy from "./authCopy.json";
 
 const HandleLogIn = ({callback}) => {
   const [identifier, setIdentifier] = useState('');
@@ -30,7 +31,7 @@ const HandleLogIn = ({callback}) => {
   return (
     <AuthPanel
       icon="/icons/login.svg"
-      title="Log in to your account"
+      title={authCopy.login.title}
       subtitle="Enter your username or email and password to continue."
       footer={(
         <>
@@ -76,7 +77,7 @@ const HandleLogIn = ({callback}) => {
           />
         </div>
         <div className="auth-errors" aria-live="polite">{errors}</div>
-        <button className="btn auth-submit w-100" type="submit">Log in</button>
+        <button className="btn auth-submit w-100" type="submit">{authCopy.login.submit}</button>
       </form>
     </AuthPanel>
   );

--- a/client/src/pages/auth/NewUser.js
+++ b/client/src/pages/auth/NewUser.js
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import UseRequest from "../../hook/UseRequest";
 import AuthPanel from "./AuthPanel";
+import authCopy from "./authCopy.json";
 
 const HandleNewUser = ({ callback }) => {
   const [identifier, setIdentifier] = useState('');
@@ -30,7 +31,7 @@ const HandleNewUser = ({ callback }) => {
   return (
     <AuthPanel
       icon="/icons/signup.svg"
-      title="Create an account"
+      title={authCopy.signup.title}
       subtitle="Choose a username and password to get started."
       footer={(
         <>
@@ -87,7 +88,7 @@ const HandleNewUser = ({ callback }) => {
           </span>
         </div>
         <div className="auth-errors" aria-live="polite">{errors}</div>
-        <button className="btn auth-submit w-100" type="submit">Create account</button>
+        <button className="btn auth-submit w-100" type="submit">{authCopy.signup.submit}</button>
       </form>
     </AuthPanel>
   );

--- a/client/src/pages/auth/authCopy.json
+++ b/client/src/pages/auth/authCopy.json
@@ -1,0 +1,10 @@
+{
+  "login": {
+    "title": "Log in to your account",
+    "submit": "Log in"
+  },
+  "signup": {
+    "title": "Create an account",
+    "submit": "Create account"
+  }
+}

--- a/client/tests/e2e/app-smoke.spec.js
+++ b/client/tests/e2e/app-smoke.spec.js
@@ -1,4 +1,13 @@
 const { test, expect } = require('@playwright/test');
+const authCopy = require('../../src/pages/auth/authCopy.json');
+
+const rejectAuthRequest = async (page, path, message) => {
+  await page.route(`**${path}`, (route) => route.fulfill({
+    status: 400,
+    contentType: 'application/json',
+    body: JSON.stringify({ errors: [{ message }] }),
+  }));
+};
 
 test('home page responds and renders shell', async ({ page }) => {
   const pageErrors = [];
@@ -22,13 +31,15 @@ test('variant query param keeps app functional', async ({ page }) => {
 test('signup submit does not crash UI', async ({ page }) => {
   const pageErrors = [];
   page.on('pageerror', (error) => pageErrors.push(error.message));
+  await rejectAuthRequest(page, '/api/auth/new', 'Signup smoke request rejected');
 
   await page.goto('/signup', { waitUntil: 'domcontentloaded' });
-  const inputs = page.locator('input');
-  await inputs.nth(0).fill(`qa+${Date.now()}@betstan.xyz`);
-  await inputs.nth(1).fill('Password123!Password123!');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  await expect(page.getByRole('heading', { name: authCopy.signup.title })).toBeVisible();
+  await page.getByLabel('Username', { exact: true }).fill('qa-smoke');
+  await page.getByLabel('Password', { exact: true }).fill('Password123!');
+  await page.getByRole('button', { name: authCopy.signup.submit, exact: true }).click();
 
+  await expect(page.getByText('Signup smoke request rejected')).toBeVisible();
   await expect(page.locator('body')).not.toContainText("Cannot read properties of undefined (reading 'map')");
   expect(pageErrors).toEqual([]);
 });
@@ -36,13 +47,28 @@ test('signup submit does not crash UI', async ({ page }) => {
 test('login submit does not crash UI', async ({ page }) => {
   const pageErrors = [];
   page.on('pageerror', (error) => pageErrors.push(error.message));
+  await rejectAuthRequest(page, '/api/auth/login', 'Login smoke request rejected');
 
   await page.goto('/login', { waitUntil: 'domcontentloaded' });
-  const inputs = page.locator('input');
-  await inputs.nth(0).fill('qa-invalid@betstan.xyz');
-  await inputs.nth(1).fill('invalid-password');
-  await page.getByRole('button', { name: /sign (in|up)/i }).click();
+  await expect(page.getByRole('heading', { name: authCopy.login.title })).toBeVisible();
+  await page.getByLabel('Username or email').fill('qa-invalid');
+  await page.getByLabel('Password', { exact: true }).fill('invalid-password');
+  await page.getByRole('button', { name: authCopy.login.submit, exact: true }).click();
 
+  await expect(page.getByText('Login smoke request rejected')).toBeVisible();
   await expect(page.locator('body')).not.toContainText("Cannot read properties of undefined (reading 'map')");
   expect(pageErrors).toEqual([]);
+});
+
+test('auth pages fit a mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  for (const { path, title } of [
+    { path: '/login', title: authCopy.login.title },
+    { path: '/signup', title: authCopy.signup.title },
+  ]) {
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('heading', { name: title })).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+  }
 });

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -214,9 +214,9 @@ If `dns-check-stan.sh` prints `status=MATCH`, DNS is pointing to current ingress
 ## Deploy validation loop settings
 
 `deploy-validation-loop-stan.sh` supports:
-- `DOMAIN` (default `48.206.235.122.nip.io`)
-- `CERT_NAME` (default `betstan-nip-tls`)
-- `E2E_BASE_URL` (auto-derived from ingress IP when empty)
+- `DOMAIN` (default `betstan.xyz`)
+- `CERT_NAME` (default `betstan-tls`)
+- `E2E_BASE_URL` (default `https://<DOMAIN>`)
 - `MAX_ATTEMPTS`, `SLEEP_SECONDS`
 - `VALIDATION_MAX_LOOPS`, `VALIDATION_SLEEP_SECONDS`
 - `OUTPUT_DIR` (defaults to `artifacts/deploy-validation`)

--- a/infra/azure/agents/deploy-validation-loop-stan.sh
+++ b/infra/azure/agents/deploy-validation-loop-stan.sh
@@ -5,11 +5,9 @@ set -euo pipefail
 # Runs layered checks with retries and captures diagnostics on failures.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-INGRESS_NAMESPACE="${INGRESS_NAMESPACE:-ingress-nginx}"
-INGRESS_SERVICE="${INGRESS_SERVICE:-ingress-nginx-controller}"
-DOMAIN="${DOMAIN:-48.206.235.122.nip.io}"
-CERT_NAME="${CERT_NAME:-betstan-nip-tls}"
-E2E_BASE_URL="${E2E_BASE_URL:-}"
+DOMAIN="${DOMAIN:-betstan.xyz}"
+CERT_NAME="${CERT_NAME:-betstan-tls}"
+E2E_BASE_URL="${E2E_BASE_URL:-https://${DOMAIN}}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-30}"
 VALIDATION_MAX_LOOPS="${VALIDATION_MAX_LOOPS:-3}"
@@ -42,15 +40,6 @@ if ! is_positive_int "$VALIDATION_SLEEP_SECONDS"; then
   VALIDATION_SLEEP_SECONDS=20
 fi
 
-if [[ -z "$E2E_BASE_URL" ]]; then
-  INGRESS_IP="$(kubectl get svc "$INGRESS_SERVICE" -n "$INGRESS_NAMESPACE" -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
-  if [[ -n "${INGRESS_IP:-}" ]]; then
-    E2E_BASE_URL="http://${INGRESS_IP}"
-  else
-    E2E_BASE_URL="https://${DOMAIN}"
-  fi
-fi
-
 capture_diagnostics() {
   local attempt="$1"
   local reason="$2"
@@ -77,7 +66,7 @@ capture_diagnostics() {
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
   echo "=== deploy-validation attempt ${attempt}/${MAX_ATTEMPTS} ==="
 
-  if "$ROOT_DIR/infra/azure/agents/smoke-liveness-stan.sh"; then
+  if BASE_URL="$E2E_BASE_URL" "$ROOT_DIR/infra/azure/agents/smoke-liveness-stan.sh"; then
     if DOMAIN="$DOMAIN" CERT_NAME="$CERT_NAME" E2E_BASE_URL="$E2E_BASE_URL" MAX_LOOPS="$VALIDATION_MAX_LOOPS" SLEEP_SECONDS="$VALIDATION_SLEEP_SECONDS" \
       "$ROOT_DIR/infra/azure/agents/validation-loop-stan.sh"; then
       echo "deploy_validation_status=PASS"

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -90,6 +90,9 @@ require_literal "$deploy_workflow" "image_provenance_stan.py" "immutable image p
 require_literal "$deploy_workflow" '[[ "$image_id" =~ @sha256:[0-9a-f]{64}$ ]]' "serving OCI image ID verification"
 require_literal "$deploy_workflow" 'deploy-provenance-${{ github.run_id }}-${{ github.run_attempt }}' "attempt-specific provenance"
 require_literal "$deploy_workflow" 'deploy-validation-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}' "attempt-specific diagnostics"
+require_literal "$deploy_workflow" "APP_E2E_BASE_URL:" "explicit browser validation target"
+require_literal "$deploy_workflow" "https://betstan.xyz" "public HTTPS browser validation target"
+reject_literal "$deploy_workflow" "APP_E2E_BASE_URL: \${{ vars.APP_E2E_BASE_URL || '' }}" "empty browser validation fallback"
 
 require_literal "$branch_workflow" "pull_request_target:" "trusted PR metadata event"
 require_literal "$branch_workflow" 'workflows: ["production-build"]' "trusted quality completion event"


### PR DESCRIPTION
## What changed
- share login/signup copy between React and Playwright so selectors cannot drift
- make auth smoke submissions deterministic and non-mutating
- validate mobile auth pages for horizontal overflow
- target https://betstan.xyz and the production TLS certificate instead of the raw load-balancer IP
- guard against restoring an empty browser-validation fallback

## Verified
- targeted auth component tests: 9 passed
- optimized client build: passed
- Playwright on https://betstan.xyz: 5 passed
- Playwright on https://www.betstan.xyz: 5 passed
- repaired post-deploy validation loop against AKS: passed