### PR TITLE
Serve optimized production client runtime

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,1 +1,5 @@
 node_modules
+build
+coverage
+playwright-report
+test-results

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,16 @@
-FROM node:18-alpine
+FROM node:20-alpine AS build
 ENV CI=true
-ENV WDS_SOCKET_PORT=0
 WORKDIR /usr/app
-COPY package*.json ./
-RUN npm install
-COPY ./ ./
-CMD ["npm", "start"]
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:1.30.4-alpine
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY --from=build --chown=nginx:nginx /usr/app/build /usr/share/nginx/html
+USER nginx
+RUN nginx -t
+EXPOSE 3000
+ENTRYPOINT ["nginx"]
+CMD ["-g", "daemon off;"]

--- a/client/README.md
+++ b/client/README.md
@@ -29,6 +29,14 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
+### Container runtime
+
+The production Docker image builds the locked dependencies with `npm ci`, runs
+`npm run build`, and serves only the generated static files through Nginx on
+port 3000. Nginx provides SPA route fallback, gzip compression, no-cache HTML,
+and long-lived immutable caching for hashed assets. API requests are routed by
+the Kubernetes ingress rather than proxied by the client container.
+
 ### `npm run eject`
 
 **Note: this is a one-way operation. Once you `eject`, you can't go back!**

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,52 @@
+worker_processes auto;
+pid /tmp/nginx.pid;
+error_log /dev/stderr warn;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /dev/stdout main;
+
+    sendfile on;
+    tcp_nopush on;
+    keepalive_timeout 65;
+    server_tokens off;
+
+    gzip on;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types application/javascript application/json image/svg+xml text/css;
+
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    server {
+        listen 3000;
+        server_name _;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        location /static/ {
+            try_files $uri =404;
+            add_header Cache-Control "public, max-age=31536000, immutable" always;
+        }
+
+        location / {
+            add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/infra/k8s/client-depl.yaml
+++ b/infra/k8s/client-depl.yaml
@@ -17,25 +17,42 @@ spec:
       labels:
         app: gaming-client
     spec:
+      securityContext:
+        fsGroup: 101
+        runAsGroup: 101
+        runAsNonRoot: true
+        runAsUser: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: gaming-client
           image: stanvasilyev/gaming_client
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
             initialDelaySeconds: 5
             periodSeconds: 5
-            tcpSocket:
-              port: 3000
           livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
             initialDelaySeconds: 30
             periodSeconds: 30
-            tcpSocket:
-              port: 3000
-          env:
-            - name: JWT_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: jwt-secret
-                  key: JWT_KEY
+          volumeMounts:
+            - name: nginx-tmp
+              mountPath: /tmp
+      volumes:
+        - name: nginx-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 32Mi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## What changed
- build the React client with locked npm ci dependencies in a multi-stage image
- serve only hashed production assets through Nginx 1.30.4 instead of react-scripts dev server
- add SPA fallback, gzip, no-cache HTML, and immutable static-asset caching
- run as UID/GID 101 with read-only root filesystem, no capabilities, no privilege escalation, and RuntimeDefault seccomp
- replace TCP probes with HTTP response probes
- remove the unnecessary JWT signing secret from the static client pod

## Measured result
- current dev-server image: 169 MB compressed layers
- optimized static runtime: 26 MB uncompressed image
- production bundle: 75.92 kB JS + 4.68 kB CSS gzip

## Verified
- deterministic Docker build and embedded nginx -t
- runtime under read-only/no-capabilities restrictions
- UID 101, zero effective capabilities, NoNewPrivs enabled
- SPA fallback, gzip, no-cache HTML, one immutable asset cache header
- client auth tests: 9 passed
- client production build: passed
- Playwright against static container: 5 passed
- Kubernetes manifest YAML and client dry-run: passed