### PR TITLE
Capture shared Mongo operational lessons

### DIFF
--- a/.github/agents/betstan-aks-operator.agent.md
+++ b/.github/agents/betstan-aks-operator.agent.md
@@ -17,6 +17,7 @@ Before operating, read:
 - `.github/skills/betstan-branch-governance/SKILL.md`
 - `infra/azure/LESSONS_LEARNED.md`
 - `infra/azure/agents/README.md`
+- `.github/agents/betstan-mongo-migration.agent.md` for any shared-Mongo work
 - the specific `infra/azure/agents/*-stan.sh` scripts relevant to the task
 - `.github/workflows/production-deploy.yml` when a deployment may be involved
 
@@ -29,6 +30,8 @@ Do not assume an old conversation, branch, or plan reflects current production. 
 - Never inspect or touch unrelated tenant resources.
 - Never mutate Azure, Kubernetes, DNS, GitHub, secrets, or git history without explicit approval for that operation.
 - Treat deletion, nodepool replacement, disk restore, cluster stop/start, DNS changes, merge, deployment, and rollback as separate approval gates.
+- Route shared-Mongo preflight, migration, cleanup, rollback, and stale-lock
+  recovery through the dedicated migration agent and repository operator.
 - Never commit or push directly to `master`. Production changes may reach it only through an up-to-date pull request from `dev`.
 - For a `dev`-to-`master` promotion, workflow dispatch/rerun, deployment, or rollback, require explicit approval for the exact target SHA and every production-capable workflow the action will trigger. Generic approval to "deploy" is insufficient.
 - Before production promotion, evaluate workflow branch/path filters for the exact diff and report the complete production trigger set. Do not proceed when approval covers only part of that set.
@@ -47,13 +50,15 @@ Do not assume an old conversation, branch, or plan reflects current production. 
 
 ## Stable production baseline
 
-The established baseline is:
+The infrastructure baseline is:
 
 - one System pool named `nodepool4`;
 - `Standard_B4as_v2`;
 - Managed 64 GiB OS disk;
 - one current node, autoscaler `1..3`;
-- one retained auth Mongo StatefulSet/PVC hosting eight logical databases after validated cutover;
+- a journal-dependent database topology: eight legacy Mongo PVCs before
+  migration, a protected transition state during migration, and one retained
+  auth Mongo PVC only after validated cleanup;
 - Standard Load Balancer with required ingress and outbound public IPs;
 - both `betstan.xyz` and `www.betstan.xyz`.
 
@@ -63,6 +68,7 @@ Do not:
 - attach a ninth disk during shared-Mongo migration;
 - reduce to the known-undersized B2s profile;
 - run shared-Mongo migration or cleanup without exact-SHA approval and verified recovery artifacts;
+- treat a Kubernetes/API error as proof that a journal, lock, PVC, or PV is absent;
 - delete either required public IP or the Load Balancer;
 - delete resources directly inside the AKS-managed resource group when an AKS/Kubernetes operation owns their lifecycle.
 
@@ -70,19 +76,25 @@ Do not:
 
 1. **Baseline**
    - Confirm Azure login and exact scope without printing identifiers.
+   - Set the namespace explicitly for every Kubernetes operation.
    - Check cluster provisioning/power state, nodepool profile, nodes, pods, Deployments, StatefulSets, PVCs, events, ingress, and queue state.
    - Run the most specific existing read-only agent instead of reproducing its logic.
 
 2. **Protect**
    - Before shared-Mongo migration, require verified logical backups and application-consistent recovery copies for all eight source databases.
+   - Read the exact topology journal and operation lock; unknown state is `NO_GO`.
    - Verify rollback target, disk mapping, live image SHA, ingress address, and RabbitMQ state.
    - Use `rollback-readiness-stan.sh`; respect `NO_GO`.
 
 3. **Change**
    - Serialize deployment, migration, cleanup, and rollback with the shared-Mongo operation lock.
+   - Never substitute ad hoc `mongodump`, `mongorestore`, URI, or deletion
+     commands for the consolidation operator.
    - Replace AKS VM sizes through a new nodepool; in-place size changes are unsupported.
    - Move stateless workloads sequentially.
    - Preserve the retained auth Mongo disk identity; move or restore it only through an approved recovery procedure.
+   - Expand the bound auth PVC online; do not treat the immutable StatefulSet
+     claim template as proof of current PVC capacity.
    - Avoid concurrent application image pulls.
    - Keep the old pool until repeated health gates pass.
 

--- a/.github/agents/betstan-azure-cost-analyst.agent.md
+++ b/.github/agents/betstan-azure-cost-analyst.agent.md
@@ -14,6 +14,8 @@ Before analyzing cost, read:
 - `infra/azure/LESSONS_LEARNED.md`
 - `infra/azure/agents/README.md`
 - `infra/azure/agents/reconcile-nodepool-profile-stan.sh`
+- `infra/azure/agents/shared-mongo-topology-guard-stan.sh`
+- `infra/azure/agents/consolidate-production-mongo-stan.sh`
 - the current Azure provisioning and deployment workflows relevant to the request
 
 Treat live read-only inventory as current truth and repository documentation as the intended recoverable state. Call out any mismatch instead of silently choosing one.
@@ -44,6 +46,19 @@ Unless the user explicitly requests a separate experimental scenario, preserve:
 - one Mongo process hosting eight logical databases after validated consolidation.
 
 `Standard_B4as_v2` with a Managed 64 GiB OS disk is the established baseline. A 30 GiB Ephemeral OS disk caused image-pull `DiskPressure` and pod eviction. Cost analysis must inspect the live migration state instead of assuming either eight legacy disks or one retained disk.
+
+### Shared-Mongo accounting
+
+- Read the live topology journal and inventory actual PVC/PV attachment and
+  reclamation state.
+- In `legacy` mode, price every live per-service disk.
+- In `transition`, price every live disk plus temporary snapshots, backup
+  storage, restore workspace, and overlap.
+- Count the seven-disk steady-state saving only after `shared/complete`, exact
+  cleanup, and PV reclamation are verified.
+- Keep seven-day recovery artifacts and their operations separate from the
+  steady-state baseline.
+- Treat API errors as unknown inventory, not zero-cost resource absence.
 
 ## Required research method
 

--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -21,6 +21,7 @@ Before changing or assessing deployment behavior, read:
 - `infra/azure/agents/pre-commit-infra-check-stan.sh`
 - `infra/azure/agents/post-merge-verification-stan.sh`
 - `infra/azure/agents/rollback-readiness-stan.sh`
+- `.github/agents/betstan-mongo-migration.agent.md`
 
 Inspect the current git graph and remote default branch. Do not infer that a merged PR is missing merely because its old head differs from a newer `master`; use `git merge-base --is-ancestor` and inspect the current tree.
 
@@ -38,11 +39,15 @@ Inspect the current git graph and remote default branch. Do not infer that a mer
 ## Build and image provenance
 
 - A green PR validates infrastructure safety but does not mean production was deployed.
+- A repository merge does not migrate databases. Migration requires a separate
+  exact-SHA operator approval and live journal.
 - Inventory every production-capable workflow before reasoning about triggers. `production-build` and `production-deploy` are the only active production workflow identities.
 - Before promotion, evaluate workflow branch and path filters against the exact diff and list every production-capable workflow that will run. If approval does not cover that complete trigger set, return `NO_GO`.
 - A successful `production-build` run must produce immutable images tagged with its exact commit SHA.
 - Treat a manual dispatch or rerun of the central workflows as a production action. Require a full master SHA and approval through `production-emergency`.
 - Retired central and per-service workflow identities must stay disabled so historical definitions cannot be rerun.
+- Do not change the trusted `production-build.yml` as part of a database
+  topology change unless its workflow-blob bootstrap is separately approved.
 - Use only the `production-build` to `production-deploy` chain. Never invoke a retired workflow as a fallback.
 - Deploy only a SHA whose required build completed successfully on `master`.
 - Do not deploy `latest` as the source of truth.
@@ -60,12 +65,15 @@ Before deployment:
 - validate manifest YAML offline;
 - run `ingress-routing-guard-stan.sh`;
 - require `shared-mongo-topology-guard-stan.sh` to confirm the validated one-Mongo topology;
+- return `NO_GO` when the topology journal is in `transition`; normal deployment
+  must not race migration, cleanup, or rollback;
 - check production health and rollback readiness;
 - ensure no unresolved workflow or manifest conflict exists.
 
 During deployment:
 
 - hold the shared-Mongo operation lock across topology validation, manifest apply, rollout, and post-deploy validation;
+- treat lock acquisition or release failure as deployment failure;
 - apply shared infrastructure without causing intermediate untagged application rollouts;
 - apply SHA-pinned application Deployments sequentially;
 - wait for each rollout before pulling the next image;
@@ -118,7 +126,11 @@ A Running broker with missing consumers is not healthy production.
 
 ## Rollback
 
-- Run `rollback-readiness-stan.sh` before taking rollback action.
+- Distinguish ordinary application rollback from shared-Mongo migration
+  rollback. Use the dedicated migration agent and consolidation operator when
+  the topology journal is `transition` or when legacy databases must be
+  recreated.
+- Run `rollback-readiness-stan.sh` before either rollback path.
 - Require a known target SHA with successful build/deployment provenance.
 - Prefer application rollback over disk restore when data integrity is healthy.
 - Restore Mongo snapshots only when integrity checks justify it.
@@ -131,6 +143,8 @@ The retained auth Mongo is the only supported final database topology.
 - Never use the retired stage shared-Mongo workflow or scripts as a production fallback.
 - Never run normal deployment before the exact migration journal is validated.
 - Never force-release the database operation lock without matching its operation ID and exact SHA.
+- Never interpret a Kubernetes/API read failure as NotFound or an unlocked
+  state.
 - Migration cleanup may delete only the exact seven allowlisted legacy StatefulSets, Services, and PVCs.
 - Keep stage credentials and resources separate.
 - Do not run stage workflows on `master`.

--- a/.github/agents/betstan-mongo-migration.agent.md
+++ b/.github/agents/betstan-mongo-migration.agent.md
@@ -1,0 +1,155 @@
+---
+name: betstan-mongo-migration
+description: Manually invoked specialist for BetStan shared-Mongo preflight, migration, cleanup, rollback, and interrupted-operation recovery.
+target: github-copilot
+tools: [read, search, execute, web]
+disable-model-invocation: true
+user-invocable: true
+---
+
+You are BetStan's shared-Mongo migration specialist. Preserve data, follow the
+persisted topology journal, and use the repository operator instead of
+reimplementing database operations.
+
+## Read first
+
+Before assessing or operating, read:
+
+- `CONTRIBUTING.md`
+- `.github/skills/betstan-branch-governance/SKILL.md`
+- `infra/azure/LESSONS_LEARNED.md`
+- `infra/azure/agents/README.md`
+- `infra/azure/agents/consolidate-production-mongo-stan.sh`
+- `infra/azure/agents/shared-mongo-operation-lock-stan.sh`
+- `infra/azure/agents/shared-mongo-topology-guard-stan.sh`
+- `infra/azure/agents/rollback-readiness-stan.sh`
+- `infra/azure/agents/mongo-database-signature-stan.js`
+- `infra/k8s/legacy-mongo/README.md`
+
+Re-read the exact checked-out versions. Conversation history and an old plan
+are not evidence of the live topology or current journal phase.
+
+## Authority and isolation
+
+- Begin read-only and identify the exact cluster, namespace, approved full SHA,
+  migration ID, topology journal, operation lock, and private backup directory.
+- Use a private temporary `KUBECONFIG`; do not alter the global Kubernetes
+  context.
+- Never inspect or touch unrelated tenant, cluster, namespace, or database
+  resources.
+- Treat `migrate`, `cleanup`, `rollback`, and `unlock` as separate approval
+  gates. Approval to migrate never authorizes volume deletion.
+- Repository merge, production promotion, deployment, and database migration
+  are distinct actions. Never infer one approval from another.
+- Never operate from an unclean checkout, abbreviated SHA, unapproved commit,
+  or backup directory inside the repository.
+- Never print credentials, documents, raw storage identifiers, kubeconfig
+  contents, private inventory, or backup contents.
+
+## Executable source of truth
+
+Use `consolidate-production-mongo-stan.sh` for `plan`, `preflight`, `migrate`,
+`cleanup`, `rollback`, and `unlock`. Do not hand-run dump, restore, URI switch,
+legacy manifest application, or resource deletion commands as a substitute.
+
+Use:
+
+- `shared-mongo-operation-lock-stan.sh` for the persistent compare-and-swap
+  operation lock;
+- `shared-mongo-topology-guard-stan.sh` for the final shared topology;
+- `rollback-readiness-stan.sh` before rollback;
+- the canonical signature helper for data and collection metadata parity.
+
+Any Kubernetes or API read error means state is unknown and therefore
+`NO_GO`; it is never proof that a journal, lock, PVC, or PV is absent.
+
+Until issue #85 is resolved, independently require a successful topology
+journal read or explicit NotFound immediately before migration, and explicit
+NotFound for every journaled legacy PV after cleanup. Do not accept the
+operator's exit status alone for those two checks.
+
+## Journal and rollback model
+
+Interpret the exact journal identity `(mode, phase, migration-id, source-sha)`:
+
+| Journal state | Authoritative data and safe action |
+|---|---|
+| no journal or legacy baseline | Run preflight before a new migration. |
+| `transition/backing-up` | Legacy databases remain authoritative; rollback must not copy partial shared data over them. |
+| `transition/preparing-target` | Legacy databases remain authoritative; rollback without reverse copy. |
+| `transition/restoring` | Legacy databases remain authoritative; rollback without reverse copy. |
+| `transition/switching` | Writers remain stopped and legacy data is authoritative; rollback without reverse copy. |
+| `transition/validating-applications` | Shared applications may have written; rollback must preserve those writes by reverse-copying. |
+| `transition/awaiting-cleanup` | Shared data is authoritative; validate artifacts before cleanup or reverse-copy on rollback. |
+| `transition/rollback-copying` | Resume the verified reverse copy; do not start applications against partial legacy restores. |
+| `transition/rollback-data-restored` | Legacy data is already restored; do not repeat a destructive reverse copy. |
+| `shared/complete` | Legacy volumes are gone; rollback recreates them and reverse-copies current shared data. |
+| `legacy/rollback-complete` | Require a fresh migration ID and new backups for any later migration. |
+
+Never reuse artifacts from a different migration ID or SHA. A retry must use
+the same journal identity and verified private artifacts.
+
+## Required gates
+
+### Preflight
+
+- Require exact server-version and FCV compatibility for all eight sources.
+- Verify exact live legacy `MONGO_URI` values and the eight logical database
+  names.
+- Verify target capacity, expandable StorageClass, retained auth PVC identity,
+  and the auth normalized-identifier unique partial index.
+- Verify the backup directory is absolute, private, outside the repository, and
+  contains no stale artifacts for a different migration.
+
+### Migrate
+
+- Require explicit maintenance and eight-recovery-copy confirmations.
+- Drain RabbitMQ to zero ready and unacknowledged messages.
+- Scale every writer to zero and wait for zero desired, available, and ready
+  replicas plus zero matching pods.
+- Back up all eight databases, checksum archives, and record canonical data and
+  metadata signatures.
+- Restore only the seven non-auth databases. Never restore over `gaming_auth`.
+- Drop each named destination database before restore; `mongorestore --drop`
+  alone does not remove destination-only collections.
+- Start applications only after exact URI, database-presence, parity, and
+  readiness checks pass.
+
+### Cleanup
+
+- Require separate application-validation and seven-volume-deletion
+  confirmations.
+- Accept only `transition/awaiting-cleanup` with the exact migration identity.
+- Reject missing, empty, duplicate, unknown, or structurally mismatched
+  databases.
+- Delete only the seven operator allowlisted StatefulSets, Services, and PVCs.
+- Require the journaled PVs to be reclaimed and the final topology guard to
+  pass.
+- No soak is required, but no validation gate may be skipped.
+
+### Rollback and stale lock recovery
+
+- Run migration-transition-aware rollback readiness with the exact SHA,
+  migration ID, and private backup directory.
+- Let the operator choose phase-appropriate reverse-copy behavior.
+- Never restore snapshots merely because an application rollback failed.
+- Force-release a stale lock only after proving the holder is dead and the
+  operation ID and source SHA match. A lock release error is an operation
+  failure, not cleanup noise.
+
+## Completion decisions
+
+Return exactly one:
+
+- `NO_GO`: name the failed or unknown invariant and safest next action.
+- `READY_FOR_PREFLIGHT`: read-only prerequisites are complete.
+- `READY_FOR_MIGRATE`: preflight passed and explicit migrate approval is still
+  required.
+- `READY_FOR_CLEANUP`: migration validation passed and explicit deletion
+  approval is still required.
+- `READY_FOR_ROLLBACK`: rollback readiness passed for the exact journal phase.
+- `MIGRATION_COMPLETE`: only after live evidence confirms `shared/complete`,
+  one retained auth Mongo PVC, eight logical databases, no seven legacy
+  resources, healthy applications on both public hosts, and healthy queues.
+
+Never use a successful command exit alone as completion evidence.

--- a/.github/skills/betstan-branch-governance/SKILL.md
+++ b/.github/skills/betstan-branch-governance/SKILL.md
@@ -10,7 +10,8 @@ Use this skill whenever a task involves branches, commits, pushes, pull requests
 ## Required flow
 
 - Never commit or push directly to `master`.
-- Normal changes enter `dev`, either directly or through a focused pull request.
+- Normal changes enter `dev` through a focused pull request; never push directly
+  to protected `dev`.
 - Only an up-to-date `dev` branch may open a pull request into `master`.
 - A production promotion requires green trusted `branch-policy/master` and `pr-quality-gates/master` statuses on both its current head and unique merge snapshot.
 - Before promotion, identify the exact head SHA and every production-capable workflow triggered by the diff. Require explicit approval covering that exact set.

--- a/infra/azure/LESSONS_LEARNED.md
+++ b/infra/azure/LESSONS_LEARNED.md
@@ -68,22 +68,79 @@ Use domain-based checks: `curl https://www.betstan.xyz/api/event` **and** `curl 
 
 ## Database Topology
 
-### One retained auth Mongo hosts all logical databases
-The target topology is one `gaming-auth-mongo-depl` StatefulSet and PVC, exposed
-to applications through `gaming-shared-mongo-srv`. The eight logical database
-names remain unchanged.
+### Topology is journal-dependent
+The supported final topology is one `gaming-auth-mongo-depl` StatefulSet and
+PVC, exposed through `gaming-shared-mongo-srv`, with all eight logical database
+names unchanged. Do not assume that final topology before live evidence:
 
-Normal deployment is blocked until
-`shared-mongo-topology-guard-stan.sh` confirms that the exact migration is
-validated, the seven legacy StatefulSets/PVCs are gone, all eight Deployments
-use the shared endpoint, and only the auth Mongo PVC remains.
+- no journal or `legacy/rollback-complete`: the legacy databases are the source
+  of truth;
+- `transition/*`: migration or rollback is incomplete and normal deployment is
+  blocked;
+- `shared/complete`: cleanup and the final topology guard have passed.
 
-Use `consolidate-production-mongo-stan.sh` for preflight, migration, cleanup, or
-rollback. Cutover requires stopped writers, drained queues, verified logical and
-storage recovery copies, full database parity, and exact deletion allowlists.
-The migration and cleanup operations are separate commands so application
-validation can complete before immediate legacy-volume deletion; there is no
-soak period.
+`shared-mongo-topology-guard-stan.sh` requires the validated marker, one ready
+auth Mongo PVC of the required capacity, no seven legacy StatefulSets/PVCs, and
+all eight exact shared URIs.
+
+### Use one operator and one operation lock
+Use `consolidate-production-mongo-stan.sh` for preflight, migration, cleanup,
+rollback, and stale-lock recovery. Do not replace it with ad hoc dump, restore,
+URI, manifest, or deletion commands.
+
+Migration, cleanup, rollback, and deployment share the persistent
+`gaming-mongo-migration-lock`. Acquisition and release use resource-versioned
+compare-and-swap. A lock release error fails an otherwise successful operation,
+and a stale lock may be released only when its operation ID and source SHA
+match. Kubernetes/API read errors mean unknown state, never NotFound.
+
+### A complete write freeze includes pod termination
+RabbitMQ must have zero ready and unacknowledged messages before applications
+stop. Scale-to-zero is complete only when every backend Deployment has zero
+desired, available, and ready replicas and no matching pods remain. Starting a
+backup while terminating pods can still write is not a consistent snapshot.
+
+### Restore semantics must remove destination-only collections
+`mongorestore --drop` drops collections present in the archive; it does not
+remove destination-only collections. Before forward or reverse restore, drop
+only the exact named destination database, then restore its exact namespace and
+compare canonical data and metadata signatures.
+
+Counts alone are insufficient. Signatures cover collection hashes, indexes,
+validators, options, collations, views, capped/time-series metadata, and
+collection presence. Cleanup rejects missing, empty, duplicate, unknown, or
+structurally mismatched databases.
+
+### Rollback behavior depends on the journal phase
+- In `backing-up`, `preparing-target`, `restoring`, and `switching`, legacy data
+  remains authoritative. Do not overwrite it from a partial shared target.
+- In `validating-applications`, `awaiting-cleanup`, `rollback-copying`, or
+  `shared/complete`, shared applications may have written. Preserve those
+  writes by reverse-copying before switching to legacy.
+- In `rollback-data-restored`, do not repeat the destructive reverse copy.
+- After `legacy/rollback-complete`, use a fresh migration ID and fresh backups;
+  never reuse stale artifacts.
+
+Backup and cleanup journals must be exact, private, written atomically, and
+bound to the migration ID and full source SHA.
+
+### Bound PVC capacity and claim templates are different
+The retained auth PVC is expanded online after StorageClass expansion is
+verified. The StatefulSet claim template remains at its immutable original
+request and is not evidence of the bound PVC's current capacity. Do not
+recreate the StatefulSet merely to change that template, especially while its
+Mongo image is unpinned.
+
+### No soak still requires complete validation
+Migration and cleanup are separate commands. There is no soak period, but
+cleanup starts only after data/metadata parity, all application mappings,
+representative application behavior, APIs, and queues pass. Cleanup deletes
+only the seven exact allowlisted StatefulSets, Services, and PVCs and waits for
+their journaled PVs to be reclaimed.
+
+The live legacy volumes are deleted immediately after validation. Verified
+logical and storage recovery artifacts remain private and retained for seven
+days.
 
 ---
 
@@ -98,9 +155,12 @@ RabbitMQ runs as an ephemeral Deployment. Replacing its broker can leave queue d
 
 ### Dev integration is safe; only a dev promotion reaches production
 - Never commit or push directly to `master`.
-- Normal changes enter `dev`; direct pushes to `dev` are allowed, though focused PRs are preferred.
+- Normal changes enter `dev` through focused pull requests; do not push directly
+  to protected `dev`.
 - Only an up-to-date pull request from `dev` may target `master`.
-- A merge to `master` triggers `production-build` → `production-deploy` automatically.
+- A merge to `master` starts the protected `production-build` path. Production
+  deployment is a separate exact-SHA `production-deploy` dispatch after a
+  successful approved build; production never deploys automatically.
 - Review all infra changes with `pre-commit-infra-check-stan.sh` before pushing.
 - After a squash promotion, immediately merge the new `master` commit back into `dev`.
 - Manual emergency deployment uses only the central workflows, a full approved master SHA, and the reviewer-protected `production-emergency` environment.

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -253,19 +253,22 @@ Repository merge does not migrate production. The final manifests intentionally
 cannot be applied by the normal deployment workflow until the migration marker
 is validated.
 
-1. Run `consolidate-production-mongo-stan.sh preflight` from the exact approved
-   SHA.
-2. Pause writers, drain RabbitMQ, create eight verified recovery copies, and run
-   `migrate`.
-3. Validate data, metadata, all eight application mappings, APIs, and queues.
-4. Run `cleanup` with the explicit seven-volume deletion confirmation.
-5. Retain the external recovery artifacts for seven days.
-
 The rollback-only manifests are under `infra/k8s/legacy-mongo/` and are never
 part of normal `kubectl apply -f infra/k8s`.
 
 The operator requires a clean exact-SHA checkout and a private backup directory
-outside the repository:
+outside the repository. Set `NAMESPACE` explicitly when it is not `default`.
+
+| Operation | Required starting evidence | Exact confirmations | Successful result |
+|---|---|---|---|
+| `plan` | Repository mapping only | None | Sanitized eight-database/seven-resource map |
+| `preflight` | Full approved SHA, clean checkout, live legacy topology, private backup directory | None | Read-only compatibility and capacity pass |
+| `migrate` | No conflicting journal, or same safely resumable early transition | `CONFIRM_MAINTENANCE=writers-paused`, `CONFIRM_RECOVERY_COPIES=verified-eight-recovery-copies` | `transition/awaiting-cleanup` |
+| `cleanup` | Exact `transition/awaiting-cleanup`, verified backups and applications | `CONFIRM_APPLICATION_VALIDATED=shared-mongo-application-validation-passed`, `CONFIRM_DELETE_LEGACY_MONGO=delete-seven-legacy-mongo-volumes` | `shared/complete` and final topology guard pass |
+| `rollback` | Supported exact transition phase or `shared/complete`, plus rollback readiness | `CONFIRM_ROLLBACK=restore-seven-legacy-databases` | `legacy/rollback-complete` |
+| `unlock` | Proven stale lock with matching migration ID and SHA | `CONFIRM_UNLOCK=remove-stale-migration-lock` | Matching lock released; topology unchanged |
+
+Run preflight first:
 
 ```bash
 APPROVED_SHA=<full-master-sha> \
@@ -288,11 +291,62 @@ CONFIRM_DELETE_LEGACY_MONGO=delete-seven-legacy-mongo-volumes \
 ./infra/azure/agents/consolidate-production-mongo-stan.sh cleanup
 ```
 
-Never put `BACKUP_DIR` inside the repository. `cleanup` is immediate after
-application validation; it is not a soak gate. Destructive operations acquire the persistent `gaming-mongo-migration-lock`
-ConfigMap through a resource-versioned compare-and-swap. If an operator process
-is killed and leaves it active, inspect the journal and workloads first, then
-release only the matching stale lock with:
+For migration rollback, first run the transition-aware readiness gate, then the
+operator:
+
+```bash
+TARGET_SHA=<full-master-sha> \
+MIGRATION_ID=<approved-id> \
+MIGRATION_BACKUP_DIR=<private-absolute-path> \
+./infra/azure/agents/rollback-readiness-stan.sh
+
+APPROVED_SHA=<full-master-sha> \
+MIGRATION_ID=<approved-id> \
+BACKUP_DIR=<private-absolute-path> \
+CONFIRM_ROLLBACK=restore-seven-legacy-databases \
+./infra/azure/agents/consolidate-production-mongo-stan.sh rollback
+```
+
+### Journal phases and interrupted operations
+
+| Phase | Rollback source of truth |
+|---|---|
+| `backing-up`, `preparing-target`, `restoring`, `switching` | Legacy data; do not reverse-copy partial shared data |
+| `validating-applications`, `awaiting-cleanup` | Shared data may contain new writes; reverse-copy before switching |
+| `rollback-copying` | Resume verified reverse copy with applications stopped |
+| `rollback-data-restored` | Legacy restore is complete; do not reverse-copy again |
+| `shared/complete` | Recreate legacy stores and reverse-copy current shared data |
+| `legacy/rollback-complete` | Use a new migration ID and fresh backups before retrying migration |
+
+Resume only with the same full SHA, migration ID, private backup directory, and
+verified checksums. Never reuse backups from a completed rollback or another
+migration.
+
+Never put `BACKUP_DIR` inside the repository. Backup archives, signatures,
+checksums, and cleanup PVC/PV journals are private recovery artifacts, not
+source files.
+
+`cleanup` is immediate after application validation; it is not a soak gate. It
+still requires complete data, metadata, application, API, queue, and exact
+resource validation. Retain verified external recovery artifacts for seven
+days.
+
+Issue #85 tracks two remaining fail-closed runtime reads. Until it is resolved,
+independently require a successful topology journal read or explicit NotFound
+immediately before `migrate`, and explicit NotFound for every journaled legacy
+PV after `cleanup`. An authorization, timeout, transport, or other API error is
+`NO_GO`, even when the operator process exits successfully.
+
+### Lock recovery
+
+Destructive operations and normal deployment acquire the persistent
+`gaming-mongo-migration-lock` ConfigMap through resource-versioned
+compare-and-swap. API errors are unknown state, not absence. A release failure
+fails an otherwise successful operation.
+
+If an operator process is killed and leaves the lock active, inspect the
+journal, holder, workloads, and process first. Release only the matching stale
+lock:
 
 ```bash
 APPROVED_SHA=<full-master-sha> \
@@ -300,6 +354,15 @@ MIGRATION_ID=<approved-id> \
 CONFIRM_UNLOCK=remove-stale-migration-lock \
 ./infra/azure/agents/consolidate-production-mongo-stan.sh unlock
 ```
+
+### Script portability and offline validation
+
+- Keep operational shell scripts compatible with macOS Bash 3.2; avoid
+  `mapfile`, associative arrays, and other Bash 4-only features.
+- Test GNU and BSD command variants. Probe a platform's successful form first;
+  a failed command that emits partial stdout can corrupt fallback output.
+- Use Ruby YAML parsing for offline manifest syntax. `kubectl apply
+  --dry-run=client` may still contact the configured API server for discovery.
 
 ## Stage lifecycle and cost controls
 

--- a/infra/azure/agents/test-shared-mongo-consolidation-stan.sh
+++ b/infra/azure/agents/test-shared-mongo-consolidation-stan.sh
@@ -6,6 +6,7 @@ OPERATOR="$ROOT_DIR/infra/azure/agents/consolidate-production-mongo-stan.sh"
 LOCK_SCRIPT="$ROOT_DIR/infra/azure/agents/shared-mongo-operation-lock-stan.sh"
 ROLLBACK_READINESS="$ROOT_DIR/infra/azure/agents/rollback-readiness-stan.sh"
 SIGNATURE_SCRIPT="$ROOT_DIR/infra/azure/agents/mongo-database-signature-stan.js"
+MIGRATION_AGENT="$ROOT_DIR/.github/agents/betstan-mongo-migration.agent.md"
 MONGO_TEST_IMAGE="${MONGO_TEST_IMAGE:-mongo:7}"
 SKIP_DOCKER="${SKIP_DOCKER:-0}"
 
@@ -51,6 +52,19 @@ grep -Fq '"$lock_script" acquire' "$ROOT_DIR/infra/azure/agents/deploy-stan.sh" 
   fail "direct deploy does not acquire the database operation lock"
 [[ -x "$LOCK_SCRIPT" ]] ||
   fail "shared database operation lock helper is missing"
+[[ -f "$MIGRATION_AGENT" ]] ||
+  fail "shared database migration agent is missing"
+for required_reference in \
+  'disable-model-invocation: true' \
+  'consolidate-production-mongo-stan.sh' \
+  'shared-mongo-operation-lock-stan.sh' \
+  'shared-mongo-topology-guard-stan.sh' \
+  'rollback-readiness-stan.sh' \
+  'READY_FOR_CLEANUP' \
+  'MIGRATION_COMPLETE'; do
+  grep -Fq "$required_reference" "$MIGRATION_AGENT" ||
+    fail "migration agent is missing required reference: $required_reference"
+done
 
 retired_paths=(
   "$ROOT_DIR/.github/workflows/deploy-stage-shared-db.yml"

--- a/infra/k8s/legacy-mongo/README.md
+++ b/infra/k8s/legacy-mongo/README.md
@@ -4,5 +4,14 @@ These seven manifests are rollback-only templates for
 `consolidate-production-mongo-stan.sh`. Normal deployment must never apply this
 directory.
 
+Apply them only through the operator's `rollback` operation after exact journal
+and rollback-readiness validation. Do not rename resources, change selectors,
+or edit these templates independently of the operator's database/resource
+allowlist and synthetic contract test.
+
+Never use wildcard or directory-wide deletion against these resources. Normal
+root application remains `kubectl apply -f infra/k8s`, which intentionally does
+not recurse into this directory.
+
 The active topology under `infra/k8s/` contains only the retained auth Mongo,
 which hosts all eight logical databases after migration.


### PR DESCRIPTION
## Summary
- add a manually invoked shared-Mongo migration specialist with exact approvals, journal-phase rollback rules, operation locking, and live completion gates
- align the AKS, deployment-safety, cost, and branch-governance guidance with the consolidated topology and protected `dev` workflow
- expand the runbooks with restore semantics, complete writer freeze, retry-safe journals, PVC immutability, immediate-cleanup gates, and GNU/BSD portability
- add focused contract assertions so the migration agent cannot lose its operator, lock, topology, rollback, or decision-state references

## Scope and safety
- follows merged prerequisite PR #84
- changes no migration/runtime operator, workflow, application manifest, or connection string
- performs no merge to `master`, workflow dispatch, deployment, database migration, cleanup, or cloud/Kubernetes action
- records runtime fail-closed follow-up in #85 and documents compensating checks until it is fixed

## Validation
- agent and skill frontmatter parsing
- Kubernetes/workflow YAML parsing
- Docker-backed Mongo 7 synthetic migration for all eight databases
- production workflow inventory and trigger guard
- infra pre-commit check (0 errors, 0 warnings)
- shell syntax and diff checks
- adversarial operational-guidance review