### PR TITLE
Bootstrap OCI workflow governance

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -41,14 +41,14 @@ Inspect the current git graph and remote default branch. Do not infer that a mer
 - A green PR validates infrastructure safety but does not mean production was deployed.
 - A repository merge does not migrate databases. Migration requires a separate
   exact-SHA operator approval and live journal.
-- Inventory every production-capable workflow before reasoning about triggers. `production-build` and `production-deploy` are the only active production workflow identities.
+- Inventory every production-capable workflow before reasoning about triggers. `production-build` and `production-deploy` are the only active production workflow identities today. OCI remains inactive until all four governed OCI identities (`oci-infrastructure`, `oci-migrate`, `oci-production-build`, and `oci-production-deploy`) merge together and their environments and repository controls are locked down.
 - Before promotion, evaluate workflow branch and path filters against the exact diff and list every production-capable workflow that will run. If approval does not cover that complete trigger set, return `NO_GO`.
 - A successful `production-build` run must produce immutable images tagged with its exact commit SHA.
 - Treat a manual dispatch or rerun of the central workflows as a production action. Require a full master SHA and approval through `production-emergency`.
 - Retired central and per-service workflow identities must stay disabled so historical definitions cannot be rerun.
 - Do not change the trusted `production-build.yml` as part of a database
   topology change unless its workflow-blob bootstrap is separately approved.
-- Use only the `production-build` to `production-deploy` chain. Never invoke a retired workflow as a fallback.
+- Until OCI activation and lock-down are explicitly complete, use only the `production-build` to `production-deploy` chain. Never invoke a retired workflow as a fallback.
 - Deploy only a SHA whose required build completed successfully on `master`.
 - Do not deploy `latest` as the source of truth.
 - Verify every application Deployment uses the intended SHA after rollout.

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -12,7 +12,7 @@
 - `branch-policy-guard-stan.sh` — enforces feature/hotfix-to-dev and only-dev-to-master PR pairs.
 - `test-branch-policy-guard-stan.sh` — tests accepted and rejected branch pairs.
 - `test-workflow-run-provenance-stan.sh` — rejects wrong-SHA artifacts and untrusted build/deploy workflow runs.
-- `production-workflow-inventory-stan.sh` — derives the exact production workflow set matched by a promotion diff.
+- `production-workflow-inventory-stan.sh` — derives and validates the exact Azure-only or complete governed Azure-plus-OCI production workflow set matched by a promotion diff.
 - `pr-validation-stan.sh` — inspects trusted required checks for a PR's exact head SHA.
 - `pr-merge-safety-stan.sh` — combines branch policy, exact-SHA validation, mergeability, and production approval gates.
 - `post-merge-verification-stan.sh` — verifies merged commit workflow success plus production health across both public hosts.
@@ -220,6 +220,7 @@ If `dns-check-stan.sh` prints `status=MATCH`, DNS is pointing to current ingress
 - Promotion statuses are base-scoped and published on both the current head and unique merge snapshot; validation requires both copies to point to the same trusted runs.
 - `production-deploy` runs only after successful `production-build` on `master` and deploys that exact SHA image set.
 - Emergency manual dispatch is limited to the central workflows, requires a full master SHA, and pauses at the reviewer-protected `production-emergency` environment.
+- OCI deployment is not active yet. Governance accepts the OCI identities only as one complete four-workflow set using the exact reviewer-gated `oci-build`, `oci-infrastructure`, `oci-production`, and `oci-migration` environments with strict trigger, exact-SHA, and first-attempt contracts; activation still requires that set to merge together and repository/environment lock-down to complete.
 - Retired central and per-service workflow identities remain disabled so historical runs cannot be rerun.
 - Deploy workflow requires the validated shared-Mongo marker, one ready auth Mongo StatefulSet/PVC, no legacy Mongo StatefulSets/PVCs, and all eight exact shared URIs.
 - Deploy workflow now runs `deploy-validation-loop-stan.sh` as required post-rollout gate and uploads diagnostics artifacts on failure.

--- a/infra/azure/agents/production-workflow-inventory-stan.rb
+++ b/infra/azure/agents/production-workflow-inventory-stan.rb
@@ -1,0 +1,284 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+directory = ARGV.fetch(0)
+
+AZURE_WORKFLOWS = %w[production-build production-deploy].freeze
+OCI_WORKFLOWS = %w[
+  oci-infrastructure
+  oci-migrate
+  oci-production-build
+  oci-production-deploy
+].freeze
+CURRENT_SET = AZURE_WORKFLOWS.sort.freeze
+FUTURE_SET = (AZURE_WORKFLOWS + OCI_WORKFLOWS).sort.freeze
+PROTECTED_ENVIRONMENTS = {
+  "oci-infrastructure" => "oci-infrastructure",
+  "oci-migrate" => "oci-migration",
+  "oci-production-build" => "oci-build",
+  "oci-production-deploy" => "oci-production"
+}.freeze
+AZURE_SECRET_NAME = /\A(?:AZURE[A-Z0-9_]*|ARM[A-Z0-9_]*|ACR[A-Z0-9_]*|
+  RESOURCE_GROUP|CLUSTER_NAME)\z/ix
+AZURE_DOT_SECRET_REFERENCE = %r{
+  \bsecrets\s*\.\s*(?:AZURE[A-Z0-9_]*|ARM[A-Z0-9_]*|ACR[A-Z0-9_]*|
+    RESOURCE_GROUP|CLUSTER_NAME)\b
+}ix
+
+def fail_inventory(message)
+  warn "production workflow inventory rejected: #{message}"
+  exit 1
+end
+
+def workflow_triggers(document)
+  triggers = document["on"] || document[true] || {}
+  triggers.is_a?(Hash) ? triggers : {}
+end
+
+def require_content(content, pattern, message)
+  fail_inventory(message) unless content.match?(pattern)
+end
+
+def reject_content(content, pattern, message)
+  fail_inventory(message) if content.match?(pattern)
+end
+
+def validate_environment!(name, document)
+  jobs = document["jobs"]
+  fail_inventory("#{name} must define jobs") unless jobs.is_a?(Hash) && !jobs.empty?
+  expected_environment = PROTECTED_ENVIRONMENTS.fetch(name)
+
+  jobs.each do |job_name, job|
+    if job.is_a?(Hash) && job.key?("uses")
+      fail_inventory(
+        "#{name} job #{job_name} must not call a reusable workflow"
+      )
+    end
+    environment = job.is_a?(Hash) ? job["environment"] : nil
+    environment_name =
+      environment.is_a?(Hash) ? environment["name"] : environment
+    next if environment_name == expected_environment
+
+    fail_inventory(
+      "#{name} job #{job_name} must use reviewer-gated #{expected_environment}"
+    )
+  end
+end
+
+def validate_non_migration_secrets!(name, content)
+  reject_content(
+    content,
+    AZURE_DOT_SECRET_REFERENCE,
+    "#{name} must not receive Azure credentials"
+  )
+
+  content.scan(/\bsecrets\s*\[([^\]]+)\]/i).each do |match|
+    expression = match.fetch(0).strip
+    literal = /\A(['"])([A-Z0-9_]+)\1\z/i.match(expression)
+    unless literal
+      fail_inventory("#{name} must not use dynamic secret contexts")
+    end
+    if AZURE_SECRET_NAME.match?(literal[2])
+      fail_inventory("#{name} must not receive Azure credentials")
+    end
+  end
+end
+
+def validate_manual_oci_workflow!(name, document, content)
+  triggers = workflow_triggers(document)
+  fail_inventory("#{name} must be workflow_dispatch-only") unless triggers.keys == ["workflow_dispatch"]
+
+  dispatch = triggers["workflow_dispatch"]
+  inputs = dispatch.is_a?(Hash) ? dispatch["inputs"] : nil
+  approved_sha = inputs.is_a?(Hash) ? inputs["approved_sha"] : nil
+  unless approved_sha.is_a?(Hash) && approved_sha["required"] == true
+    fail_inventory("#{name} must require the approved_sha dispatch input")
+  end
+
+  require_content(
+    content,
+    %r{run-name:\s*.*\$\{\{\s*inputs\.approved_sha\s*\}\}},
+    "#{name} run name must identify the approved SHA"
+  )
+  require_content(
+    content,
+    %r{ref:\s*\$\{\{\s*inputs\.approved_sha\s*\}\}},
+    "#{name} must check out inputs.approved_sha"
+  )
+  require_content(
+    content,
+    /github\.run_attempt\s*==\s*1/,
+    "#{name} must reject rerun attempts"
+  )
+  require_content(
+    content,
+    /(?:GITHUB_REF_NAME["'}\s=]+master|github\.ref_name\s*==\s*['"]master['"])/,
+    "#{name} must reject non-master dispatches"
+  )
+  require_content(
+    content,
+    /\^\[0-9a-f\]\{40\}\$/,
+    "#{name} must validate a complete lowercase SHA"
+  )
+  require_content(
+    content,
+    %r{origin/master},
+    "#{name} must bind the approved SHA to current master"
+  )
+  reject_content(
+    content,
+    /\$\{\{\s*github\.sha\s*\}\}/,
+    "#{name} must not use the dispatch workflow github.sha"
+  )
+end
+
+def validate_oci_workflow!(name, file, document, content)
+  expected_file = "#{name}.yml"
+  unless File.basename(file) == expected_file
+    fail_inventory("#{name} must use .github/workflows/#{expected_file}")
+  end
+
+  validate_environment!(name, document)
+  reject_content(
+    content,
+    /(?:^|:)latest(?:\s|$)/i,
+    "#{name} must not use a mutable latest image tag"
+  )
+
+  if name == "oci-production-build"
+    triggers = workflow_triggers(document)
+    fail_inventory("#{name} must be workflow_run-only") unless triggers.keys == ["workflow_run"]
+
+    workflow_run = triggers["workflow_run"]
+    workflows = workflow_run.is_a?(Hash) ? Array(workflow_run["workflows"]) : []
+    types = workflow_run.is_a?(Hash) ? Array(workflow_run["types"]) : []
+    unless workflows == ["production-build"] && types == ["completed"]
+      fail_inventory(
+        "#{name} must run only after completed production-build workflows"
+      )
+    end
+
+    require_content(
+      content,
+      /\$\{\{\s*github\.event\.workflow_run\.head_sha\s*\}\}/,
+      "#{name} must use the upstream workflow_run head SHA"
+    )
+    require_content(
+      content,
+      %r{ref:\s*\$\{\{\s*github\.event\.workflow_run\.head_sha\s*\}\}},
+      "#{name} must check out the upstream workflow_run head SHA"
+    )
+    reject_content(
+      content,
+      /\$\{\{\s*github\.sha\s*\}\}/,
+      "#{name} must not use the downstream workflow github.sha"
+    )
+    {
+      "conclusion" => "success",
+      "event" => "push",
+      "head_branch" => "master",
+      "head_repository.full_name" => "github.repository",
+      "run_attempt" => "1"
+    }.each do |field, value|
+      require_content(
+        content,
+        /github\.event\.workflow_run\.#{Regexp.escape(field)}\s*==\s*['"]?#{Regexp.escape(value)}['"]?/,
+        "#{name} must validate upstream #{field}=#{value}"
+      )
+    end
+    require_content(
+      content,
+      /github\.run_attempt\s*==\s*1/,
+      "#{name} must reject downstream rerun attempts"
+    )
+  else
+    validate_manual_oci_workflow!(name, document, content)
+  end
+
+  return if name == "oci-migrate"
+
+  validate_non_migration_secrets!(name, content)
+  reject_content(
+    content,
+    %r{
+      azure/(?:login|CLI|aks-set-context)@|
+      \baz\s+(?:login|account|aks\s+get-credentials)\b
+    }ix,
+    "#{name} must not receive Azure credentials"
+  )
+end
+
+documents = {}
+names = Dir.glob(File.join(directory, "*.{yml,yaml}")).each_with_object([]) do |file, result|
+  content = File.read(file)
+  document = YAML.safe_load(content, aliases: true) || {}
+  next unless document.is_a?(Hash)
+
+  name = document["name"] || File.basename(file, File.extname(file))
+  fail_inventory("duplicate workflow identity: #{name}") if documents.key?(name)
+
+  documents[name] = [file, document, content]
+  triggers = workflow_triggers(document)
+
+  push_master = false
+  if triggers.key?("push")
+    push = triggers["push"]
+    push_master =
+      if push.nil?
+        true
+      elsif push.is_a?(Hash)
+        branches = push["branches"]
+        branches.nil? || Array(branches).include?("master")
+      else
+        true
+      end
+  end
+
+  workflow_run = triggers["workflow_run"]
+  chained_production =
+    workflow_run.is_a?(Hash) &&
+    Array(workflow_run["workflows"]).any? do |workflow|
+      ["production-build", "oci-production-build"].include?(workflow)
+    end
+
+  production_capable = content.match?(
+    %r{
+      production-(?:automatic|emergency)|
+      infra/k8s-prod|
+      docker/build-push-action|
+      kubectl\s+(?:apply|set\ image)|
+      deploy-stan\.sh|
+      terraform\s+apply|
+      uses:\s*\./\.github/workflows/|
+      infra/oci|
+      [a-z0-9.-]+\.ocir\.io|
+      \boci\s+(?:setup|ce|compute|iam|os|bv|lb|network|container|artifacts)\b|
+      secrets\s*(?:\.\s*(?:AZURE[A-Z0-9_]*|ARM[A-Z0-9_]*|ACR[A-Z0-9_]*|
+        RESOURCE_GROUP|CLUSTER_NAME|
+        OCI[A-Z0-9_]*|OCIR[A-Z0-9_]*)\b|\[)
+    }ix
+  ) || OCI_WORKFLOWS.include?(name)
+  manual_production = triggers.key?("workflow_dispatch")
+
+  next unless production_capable &&
+              (push_master || chained_production || manual_production)
+
+  result << name
+end
+
+names = names.sort.uniq
+unless names == CURRENT_SET || names == FUTURE_SET
+  fail_inventory(
+    "expected #{CURRENT_SET.join(",")} or #{FUTURE_SET.join(",")}; found #{names.join(",")}"
+  )
+end
+
+if names == FUTURE_SET
+  OCI_WORKFLOWS.each do |name|
+    file, document, content = documents.fetch(name)
+    validate_oci_workflow!(name, file, document, content)
+  end
+end
+
+puts names

--- a/infra/azure/agents/production-workflow-inventory-stan.sh
+++ b/infra/azure/agents/production-workflow-inventory-stan.sh
@@ -62,54 +62,8 @@ fi
 }
 
 workflow_set="$(
-  ruby -ryaml - "$WORKFLOW_DIR" <<'RUBY'
-directory = ARGV.fetch(0)
-
-names = Dir.glob(File.join(directory, "*.{yml,yaml}")).each_with_object([]) do |file, result|
-  content = File.read(file)
-  document = YAML.safe_load(content, aliases: true) || {}
-  triggers = document["on"] || document[true] || {}
-  next unless triggers.is_a?(Hash)
-
-  push_master = false
-  if triggers.key?("push")
-    push = triggers["push"]
-    push_master =
-      if push.nil?
-        true
-      elsif push.is_a?(Hash)
-        branches = push["branches"]
-        branches.nil? || Array(branches).include?("master")
-      else
-        true
-      end
-  end
-
-  workflow_run = triggers["workflow_run"]
-  chained_production =
-    workflow_run.is_a?(Hash) &&
-    Array(workflow_run["workflows"]).include?("production-build")
-
-  production_capable = content.match?(
-    %r{
-      production-(?:automatic|emergency)|
-      infra/k8s-prod|
-      docker/build-push-action|
-      kubectl\s+(?:apply|set\ image)|
-      deploy-stan\.sh|
-      secrets\.(?:AZURE_CREDENTIALS|RESOURCE_GROUP|CLUSTER_NAME)\b
-    }x
-  )
-  manual_production = triggers.key?("workflow_dispatch")
-
-  next unless production_capable &&
-    (push_master || chained_production || manual_production)
-
-  result << (document["name"] || File.basename(file, File.extname(file)))
-end
-
-puts names.sort.uniq
-RUBY
+  ruby "$ROOT_DIR/infra/azure/agents/production-workflow-inventory-stan.rb" \
+    "$WORKFLOW_DIR"
 )"
 
 grep -qx "production-build" <<<"$workflow_set" || {

--- a/infra/azure/agents/test-production-workflow-inventory-stan.sh
+++ b/infra/azure/agents/test-production-workflow-inventory-stan.sh
@@ -3,16 +3,147 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 INVENTORY="$ROOT_DIR/infra/azure/agents/production-workflow-inventory-stan.sh"
-tmp_dir="$(mktemp -d)"
+tmp_dir="$(mktemp -d "$ROOT_DIR/.workflow-inventory-test.XXXXXX")"
 cleanup() {
   rm -rf -- "$tmp_dir"
 }
 trap cleanup EXIT
 
-cp "$ROOT_DIR/.github/workflows/production-build.yml" "$tmp_dir/"
-cp "$ROOT_DIR/.github/workflows/production-deploy.yml" "$tmp_dir/"
+reset_fixtures() {
+  rm -f -- "$tmp_dir"/*.yml "$tmp_dir"/*.yaml
+  cp "$ROOT_DIR/.github/workflows/production-build.yml" "$tmp_dir/"
+  cp "$ROOT_DIR/.github/workflows/production-deploy.yml" "$tmp_dir/"
 
-assert_set() {
+  cat > "$tmp_dir/oci-validate.yml" <<'YAML'
+name: oci-validate
+on:
+  pull_request:
+    branches: [dev, master]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: terraform validate
+YAML
+}
+
+write_complete_oci_set() {
+  cat > "$tmp_dir/oci-production-build.yml" <<'YAML'
+name: oci-production-build
+on:
+  workflow_run:
+    workflows: ["production-build"]
+    types: [completed]
+env:
+  IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+jobs:
+  build:
+    if: >-
+      github.run_attempt == 1 &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    environment:
+      name: oci-build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: iad.ocir.io/example/betstan:${{ env.IMAGE_TAG }}
+YAML
+
+  cat > "$tmp_dir/oci-infrastructure.yml" <<'YAML'
+name: oci-infrastructure
+run-name: provision ${{ inputs.approved_sha }}
+on:
+  workflow_dispatch:
+    inputs:
+      approved_sha:
+        required: true
+        type: string
+jobs:
+  apply:
+    if: github.run_attempt == 1
+    runs-on: ubuntu-latest
+    environment:
+      name: oci-infrastructure
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.approved_sha }}
+      - run: |
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [[ "${{ inputs.approved_sha }}" =~ ^[0-9a-f]{40}$ ]]
+          git fetch origin master:refs/remotes/origin/master
+          [ "${{ inputs.approved_sha }}" = "$(git rev-parse origin/master)" ]
+          terraform apply
+YAML
+
+  cat > "$tmp_dir/oci-production-deploy.yml" <<'YAML'
+name: oci-production-deploy
+run-name: deploy ${{ inputs.approved_sha }}
+on:
+  workflow_dispatch:
+    inputs:
+      approved_sha:
+        required: true
+        type: string
+jobs:
+  deploy:
+    if: github.run_attempt == 1
+    runs-on: ubuntu-latest
+    environment:
+      name: oci-production
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.approved_sha }}
+      - run: |
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [[ "${{ inputs.approved_sha }}" =~ ^[0-9a-f]{40}$ ]]
+          git fetch origin master:refs/remotes/origin/master
+          [ "${{ inputs.approved_sha }}" = "$(git rev-parse origin/master)" ]
+          kubectl set image deployment/client client=iad.ocir.io/example/client:${{ inputs.approved_sha }}
+YAML
+
+  cat > "$tmp_dir/oci-migrate.yml" <<'YAML'
+name: oci-migrate
+run-name: migrate ${{ inputs.approved_sha }}
+on:
+  workflow_dispatch:
+    inputs:
+      approved_sha:
+        required: true
+        type: string
+jobs:
+  migrate:
+    if: github.run_attempt == 1
+    runs-on: ubuntu-latest
+    environment:
+      name: oci-migration
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.approved_sha }}
+      - env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+          OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+        run: |
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [[ "${{ inputs.approved_sha }}" =~ ^[0-9a-f]{40}$ ]]
+          git fetch origin master:refs/remotes/origin/master
+          [ "${{ inputs.approved_sha }}" = "$(git rev-parse origin/master)" ]
+          echo migrate
+YAML
+}
+
+assert_pass() {
   local expected="$1"
   local actual
   actual="$(
@@ -25,14 +156,47 @@ assert_set() {
   }
 }
 
-assert_set "production-build,production-deploy"
+assert_fail() {
+  local label="$1"
+  local expected_message="$2"
+  local output
+  if output="$(WORKFLOW_DIR="$tmp_dir" "$INVENTORY" 2>&1)"; then
+    echo "$label unexpectedly passed: $output" >&2
+    exit 1
+  fi
+  grep -Fq "$expected_message" <<<"$output" || {
+    echo "$label failed without expected message: $output" >&2
+    exit 1
+  }
+}
 
+azure_set="production-build,production-deploy"
+full_set="oci-infrastructure,oci-migrate,oci-production-build,oci-production-deploy,production-build,production-deploy"
+
+reset_fixtures
+assert_pass "$azure_set"
+
+reset_fixtures
+write_complete_oci_set
+assert_pass "$full_set"
+
+reset_fixtures
+write_complete_oci_set
+rm "$tmp_dir/oci-migrate.yml"
+assert_fail "partial OCI set" "expected production-build,production-deploy or"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak 's/name: oci-infrastructure/name: oci-platform/' "$tmp_dir/oci-infrastructure.yml"
+rm "$tmp_dir/oci-infrastructure.yml.bak"
+assert_fail "renamed OCI identity" "found oci-migrate,oci-platform"
+
+reset_fixtures
 cat > "$tmp_dir/rogue-production.yml" <<'YAML'
 name: rogue-production
 on:
   push:
-    branches:
-      - master
+    branches: [master]
 jobs:
   mutate:
     runs-on: ubuntu-latest
@@ -40,8 +204,105 @@ jobs:
     steps:
       - run: echo unsafe
 YAML
+assert_fail "unexpected production workflow" "rogue-production"
 
-assert_set "production-build,production-deploy,rogue-production"
+reset_fixtures
+write_complete_oci_set
+python3 - "$tmp_dir/oci-production-deploy.yml" <<'PY'
+from pathlib import Path
+path = Path(__import__("sys").argv[1])
+text = path.read_text()
+path.write_text(text.replace("on:\n  workflow_dispatch:", "on:\n  push:\n    branches: [master]\n  workflow_dispatch:"))
+PY
+assert_fail "automatic OCI deployment" "oci-production-deploy must be workflow_dispatch-only"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak 's/:${{ inputs.approved_sha }}/:latest/' "$tmp_dir/oci-production-deploy.yml"
+rm "$tmp_dir/oci-production-deploy.yml.bak"
+assert_fail "mutable OCI image" "must not use a mutable latest image tag"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/GITHUB_REF_NAME/d' "$tmp_dir/oci-infrastructure.yml"
+rm "$tmp_dir/oci-infrastructure.yml.bak"
+assert_fail "non-master OCI dispatch" "must reject non-master dispatches"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/environment:/,+1d' "$tmp_dir/oci-migrate.yml"
+rm "$tmp_dir/oci-migrate.yml.bak"
+assert_fail "missing protected environment" "must use reviewer-gated oci-migration"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak 's/github.event.workflow_run.head_sha/github.sha/g' "$tmp_dir/oci-production-build.yml"
+rm "$tmp_dir/oci-production-build.yml.bak"
+assert_fail "downstream workflow SHA" "must use the upstream workflow_run head SHA"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/github.run_attempt == 1/d' "$tmp_dir/oci-infrastructure.yml"
+rm "$tmp_dir/oci-infrastructure.yml.bak"
+assert_fail "missing run-attempt guard" "must reject rerun attempts"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/ref:.*inputs.approved_sha/d' "$tmp_dir/oci-infrastructure.yml"
+rm "$tmp_dir/oci-infrastructure.yml.bak"
+assert_fail "missing exact-SHA checkout" "must check out inputs.approved_sha"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/terraform apply/i\
+          echo "${{ secrets.AZURE_CREDENTIALS }}"' "$tmp_dir/oci-infrastructure.yml"
+rm "$tmp_dir/oci-infrastructure.yml.bak"
+assert_fail "Azure credentials outside migration" "must not receive Azure credentials"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/terraform apply/i\
+          echo "${{ secrets[\"AZURE_CREDENTIALS\"] }}"' "$tmp_dir/oci-infrastructure.yml"
+rm "$tmp_dir/oci-infrastructure.yml.bak"
+assert_fail "bracketed Azure credentials outside migration" "must not receive Azure credentials"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/terraform apply/i\
+          echo "${{ secrets[env.RUNTIME_SECRET_NAME] }}"' "$tmp_dir/oci-infrastructure.yml"
+rm "$tmp_dir/oci-infrastructure.yml.bak"
+assert_fail "dynamic secret lookup outside migration" "must not use dynamic secret contexts"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/terraform apply/i\
+          echo "${{ secrets[\"OCI_CLI_USER\"] }}"' "$tmp_dir/oci-infrastructure.yml"
+rm "$tmp_dir/oci-infrastructure.yml.bak"
+assert_pass "$full_set"
+
+reset_fixtures
+write_complete_oci_set
+cat >"$tmp_dir/_azure-bridge.yml" <<'YAML'
+name: azure-bridge
+on:
+  workflow_call:
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ secrets.AZURE_CREDENTIALS }}"
+YAML
+python3 - "$tmp_dir/oci-production-build.yml" <<'PY'
+from pathlib import Path
+path = Path(__import__("sys").argv[1])
+text = path.read_text()
+path.write_text(text.replace(
+    "jobs:\n",
+    "jobs:\n  bridge:\n    uses: ./.github/workflows/_azure-bridge.yml\n    secrets: inherit\n",
+    1,
+))
+PY
+assert_fail "reusable workflow from governed OCI job" "must not call a reusable workflow"
 
 "$ROOT_DIR/infra/azure/agents/test-shared-mongo-consolidation-stan.sh"
 

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -119,7 +119,10 @@ workflow_set="$(
   ./infra/azure/agents/production-workflow-inventory-stan.sh |
     sed -n 's/^production_workflows=//p'
 )"
-[[ "$workflow_set" == "production-build,production-deploy" ]] ||
+azure_workflow_set="production-build,production-deploy"
+oci_workflow_set="oci-infrastructure,oci-migrate,oci-production-build,oci-production-deploy,production-build,production-deploy"
+[[ "$workflow_set" == "$azure_workflow_set" ||
+  "$workflow_set" == "$oci_workflow_set" ]] ||
   fail "unexpected production workflow set: ${workflow_set:-none}"
 
 echo "workflow_trigger_guard=PASS retired_workflows=${#retired[@]}"


### PR DESCRIPTION
## Summary
- accept only the current Azure workflow set or the exact complete OCI extension
- enforce dedicated reviewer-gated OCI environments and exact-SHA/first-attempt contracts
- reject Azure credential leakage, dynamic secret indirection, and reusable-workflow bypasses
- add adversarial workflow inventory fixtures without changing `production-build.yml`

## Validation
- `./infra/azure/agents/test-production-workflow-inventory-stan.sh`
- `./infra/azure/agents/workflow-trigger-guard-stan.sh`
- `./infra/azure/agents/pre-commit-infra-check-stan.sh`
- actual OCI implementation workflow set validated through the new inventory
