### PR TITLE
fix(ci): initialize OCI runner paths at runtime

### DIFF
--- a/.github/workflows/oci-infrastructure.yml
+++ b/.github/workflows/oci-infrastructure.yml
@@ -72,10 +72,17 @@ jobs:
       OCI_CERT_MANAGER_ACMESOLVER_DIGEST: ${{ vars.OCI_CERT_MANAGER_ACMESOLVER_DIGEST || 'sha256:dbc7cc1354f603918e7c5af7f55a0a620537394452c93a565bde75c6f48e8837' }}
       OCI_CERT_MANAGER_STARTUP_DIGEST: ${{ vars.OCI_CERT_MANAGER_STARTUP_DIGEST || 'sha256:d8ab6416e6e7303a86fa0a8daa82c94a8001f21c9d78eb2e7db20534e5d07ae8' }}
       PROVENANCE_DIR: artifacts/oci-infrastructure
-      HOME: ${{ runner.temp }}/oci-home
-      KUBECONFIG: ${{ runner.temp }}/oci-home/.kube/config
 
     steps:
+      - name: Initialize isolated OCI paths
+        run: |
+          {
+            echo "HOME=$RUNNER_TEMP/oci-home"
+            echo "KUBECONFIG=$RUNNER_TEMP/oci-home/.kube/config"
+          } >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/oci-home/.kube"
+          chmod 700 "$RUNNER_TEMP/oci-home" "$RUNNER_TEMP/oci-home/.kube"
+
       - name: Checkout approved master commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/oci-migrate.yml
+++ b/.github/workflows/oci-migrate.yml
@@ -69,11 +69,24 @@ jobs:
       AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256: ${{ vars.AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256 }}
       AZURE_EXPECTED_CLUSTER_SERVER_SHA256: ${{ vars.AZURE_EXPECTED_CLUSTER_SERVER_SHA256 }}
       AZURE_WATCHDOG_KUBECTL_IMAGE: ${{ vars.AZURE_WATCHDOG_KUBECTL_IMAGE }}
-      AZURE_CONFIG_DIR: ${{ runner.temp }}/azure-home/.azure
-      AZURE_KUBECONFIG: ${{ runner.temp }}/azure-home/kubeconfig
-      OCI_KUBECONFIG: ${{ runner.temp }}/oci-home/.kube/config
 
     steps:
+      - name: Initialize isolated cloud paths
+        run: |
+          {
+            echo "AZURE_CONFIG_DIR=$RUNNER_TEMP/azure-home/.azure"
+            echo "AZURE_KUBECONFIG=$RUNNER_TEMP/azure-home/kubeconfig"
+            echo "OCI_KUBECONFIG=$RUNNER_TEMP/oci-home/.kube/config"
+          } >> "$GITHUB_ENV"
+          mkdir -p \
+            "$RUNNER_TEMP/azure-home/.azure" \
+            "$RUNNER_TEMP/oci-home/.kube"
+          chmod 700 \
+            "$RUNNER_TEMP/azure-home" \
+            "$RUNNER_TEMP/azure-home/.azure" \
+            "$RUNNER_TEMP/oci-home" \
+            "$RUNNER_TEMP/oci-home/.kube"
+
       - name: Checkout approved master commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/oci-production-deploy.yml
+++ b/.github/workflows/oci-production-deploy.yml
@@ -66,10 +66,17 @@ jobs:
       OCI_CPU_MAX_PERCENT: "90"
       OCI_HEALTH_MAX_ATTEMPTS: ${{ vars.OCI_HEALTH_MAX_ATTEMPTS }}
       OCI_HEALTH_SLEEP_SECONDS: ${{ vars.OCI_HEALTH_SLEEP_SECONDS }}
-      HOME: ${{ runner.temp }}/oci-home
-      KUBECONFIG: ${{ runner.temp }}/oci-home/.kube/config
 
     steps:
+      - name: Initialize isolated OCI paths
+        run: |
+          {
+            echo "HOME=$RUNNER_TEMP/oci-home"
+            echo "KUBECONFIG=$RUNNER_TEMP/oci-home/.kube/config"
+          } >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/oci-home/.kube"
+          chmod 700 "$RUNNER_TEMP/oci-home" "$RUNNER_TEMP/oci-home/.kube"
+
       - name: Checkout approved master commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/oci-validate.yml
+++ b/.github/workflows/oci-validate.yml
@@ -19,5 +19,16 @@ jobs:
       - name: Checkout pull request
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Validate OCI workflow syntax
+        run: |
+          archive="$RUNNER_TEMP/actionlint.tar.gz"
+          curl --fail --silent --show-error --location \
+            --output "$archive" \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  $archive" \
+            | sha256sum --check
+          tar -xzf "$archive" -C "$RUNNER_TEMP" actionlint
+          "$RUNNER_TEMP/actionlint" -shellcheck= .github/workflows/oci-*.yml
+
       - name: Run OCI offline contract
         run: ./infra/oci/tests/test-contract.sh


### PR DESCRIPTION
## Summary
- replace invalid job-level `runner.temp` expressions with runtime `$RUNNER_TEMP` initialization
- preserve isolated OCI and Azure kubeconfig/home paths across subsequent steps
- add a checksum-pinned `actionlint` gate to `oci-validate`

## Validation
- `actionlint -shellcheck= .github/workflows/oci-*.yml`
- `./infra/oci/tests/test-contract.sh`
- production workflow inventory and trigger guard
- `bash -n infra/oci/scripts/*.sh infra/oci/agents/*.sh`