### PR TITLE
chore(ci): activate OCI workflow governance lock

### DIFF
--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -12,7 +12,7 @@
 - `branch-policy-guard-stan.sh` — enforces feature/hotfix-to-dev and only-dev-to-master PR pairs.
 - `test-branch-policy-guard-stan.sh` — tests accepted and rejected branch pairs.
 - `test-workflow-run-provenance-stan.sh` — rejects wrong-SHA artifacts and untrusted build/deploy workflow runs.
-- `production-workflow-inventory-stan.sh` — derives and validates the exact Azure-only or complete governed Azure-plus-OCI production workflow set matched by a promotion diff.
+- `production-workflow-inventory-stan.sh` — derives and validates the exact governed Azure-plus-OCI production workflow set matched by a promotion diff.
 - `pr-validation-stan.sh` — inspects trusted required checks for a PR's exact head SHA.
 - `pr-merge-safety-stan.sh` — combines branch policy, exact-SHA validation, mergeability, and production approval gates.
 - `post-merge-verification-stan.sh` — verifies merged commit workflow success plus production health across both public hosts.

--- a/infra/azure/agents/production-workflow-inventory-stan.rb
+++ b/infra/azure/agents/production-workflow-inventory-stan.rb
@@ -11,8 +11,7 @@ OCI_WORKFLOWS = %w[
   oci-production-build
   oci-production-deploy
 ].freeze
-CURRENT_SET = AZURE_WORKFLOWS.sort.freeze
-FUTURE_SET = (AZURE_WORKFLOWS + OCI_WORKFLOWS).sort.freeze
+REQUIRED_SET = (AZURE_WORKFLOWS + OCI_WORKFLOWS).sort.freeze
 PROTECTED_ENVIRONMENTS = {
   "oci-infrastructure" => "oci-infrastructure",
   "oci-migrate" => "oci-migration",
@@ -268,17 +267,15 @@ names = Dir.glob(File.join(directory, "*.{yml,yaml}")).each_with_object([]) do |
 end
 
 names = names.sort.uniq
-unless names == CURRENT_SET || names == FUTURE_SET
+unless names == REQUIRED_SET
   fail_inventory(
-    "expected #{CURRENT_SET.join(",")} or #{FUTURE_SET.join(",")}; found #{names.join(",")}"
+    "expected #{REQUIRED_SET.join(",")}; found #{names.join(",")}"
   )
 end
 
-if names == FUTURE_SET
-  OCI_WORKFLOWS.each do |name|
-    file, document, content = documents.fetch(name)
-    validate_oci_workflow!(name, file, document, content)
-  end
+OCI_WORKFLOWS.each do |name|
+  file, document, content = documents.fetch(name)
+  validate_oci_workflow!(name, file, document, content)
 end
 
 puts names

--- a/infra/azure/agents/test-production-workflow-inventory-stan.sh
+++ b/infra/azure/agents/test-production-workflow-inventory-stan.sh
@@ -174,7 +174,7 @@ azure_set="production-build,production-deploy"
 full_set="oci-infrastructure,oci-migrate,oci-production-build,oci-production-deploy,production-build,production-deploy"
 
 reset_fixtures
-assert_pass "$azure_set"
+assert_fail "Azure-only set" "expected $full_set; found $azure_set"
 
 reset_fixtures
 write_complete_oci_set
@@ -183,7 +183,7 @@ assert_pass "$full_set"
 reset_fixtures
 write_complete_oci_set
 rm "$tmp_dir/oci-migrate.yml"
-assert_fail "partial OCI set" "expected production-build,production-deploy or"
+assert_fail "partial OCI set" "expected $full_set; found"
 
 reset_fixtures
 write_complete_oci_set

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -119,10 +119,8 @@ workflow_set="$(
   ./infra/azure/agents/production-workflow-inventory-stan.sh |
     sed -n 's/^production_workflows=//p'
 )"
-azure_workflow_set="production-build,production-deploy"
 oci_workflow_set="oci-infrastructure,oci-migrate,oci-production-build,oci-production-deploy,production-build,production-deploy"
-[[ "$workflow_set" == "$azure_workflow_set" ||
-  "$workflow_set" == "$oci_workflow_set" ]] ||
+[[ "$workflow_set" == "$oci_workflow_set" ]] ||
   fail "unexpected production workflow set: ${workflow_set:-none}"
 
 echo "workflow_trigger_guard=PASS retired_workflows=${#retired[@]}"


### PR DESCRIPTION
## Summary
- require the complete governed Azure-plus-OCI production workflow inventory
- reject regression to the prior Azure-only workflow set
- make the resulting merge SHA the first deployable OCI source SHA

## Safety
- no Azure deployment or migration is dispatched
- no OCI resources are created by this PR
- final OCI image building remains reviewer-gated and exact-SHA bound