### PR TITLE
fix(oci): promote native ARM64 build pipeline

### DIFF
--- a/infra/oci/build/Dockerfile.backend
+++ b/infra/oci/build/Dockerfile.backend
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1.7
 ARG NODE_IMAGE=docker.io/library/node:20.19.4-alpine3.22@sha256:df02558528d3d3d0d621f112e232611aecfee7cbc654f6b375765f72bb262799
 
-FROM ${NODE_IMAGE} AS build
+FROM --platform=$BUILDPLATFORM ${NODE_IMAGE} AS build
 ARG SERVICE
 WORKDIR /app
 COPY ${SERVICE}/package.json ${SERVICE}/package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 COPY ${SERVICE}/ ./
 COPY infra/oci/build/tsconfig.production.json ./tsconfig.production.json
 RUN ./node_modules/.bin/tsc --project tsconfig.production.json
@@ -14,7 +14,8 @@ FROM ${NODE_IMAGE} AS runtime
 ENV NODE_ENV=production
 WORKDIR /app
 COPY --from=build /app/package.json /app/package-lock.json ./
-RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev --ignore-scripts
 COPY --from=build --chown=node:node /app/dist ./dist
 USER node
 EXPOSE 3000

--- a/infra/oci/build/Dockerfile.client
+++ b/infra/oci/build/Dockerfile.client
@@ -2,11 +2,11 @@
 ARG NODE_IMAGE=docker.io/library/node:20.19.4-alpine3.22@sha256:df02558528d3d3d0d621f112e232611aecfee7cbc654f6b375765f72bb262799
 ARG NGINX_IMAGE=docker.io/library/nginx:1.30.4-alpine@sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46
 
-FROM ${NODE_IMAGE} AS build
+FROM --platform=$BUILDPLATFORM ${NODE_IMAGE} AS build
 ENV CI=true
 WORKDIR /app
 COPY client/package.json client/package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 COPY client/ ./
 RUN npm run build
 

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -194,11 +194,24 @@ grep -Fq 'shape-flex-min: "10"' "$OCI_DIR/helm/ingress-nginx-values.yaml"
 grep -Fq 'shape-flex-max: "10"' "$OCI_DIR/helm/ingress-nginx-values.yaml"
 
 for dockerfile in "$OCI_DIR/build/Dockerfile.backend" "$OCI_DIR/build/Dockerfile.client"; do
-  if grep -E '^FROM[[:space:]]+[^$@[:space:]][^@[:space:]]*([[:space:]]|$)' "$dockerfile"; then
-    fail "OCI Dockerfile contains an unpinned base image: $dockerfile"
-  fi
+  while IFS= read -r base_image; do
+    [[ "$base_image" == \$* || "$base_image" =~ @sha256:[0-9a-f]{64}$ ]] ||
+      fail "OCI Dockerfile contains an unpinned base image: $dockerfile"
+  done < <(
+    awk '
+      toupper($1) == "FROM" {
+        image = 2
+        if ($image ~ /^--platform=/) {
+          image += 1
+        }
+        print $image
+      }
+    ' "$dockerfile"
+  )
   grep -Eq '^ARG [A-Z_]+_IMAGE=[^[:space:]]+@sha256:[0-9a-f]{64}$' "$dockerfile" ||
     fail "OCI Dockerfile image ARG is not digest-pinned: $dockerfile"
+  grep -Fq 'FROM --platform=$BUILDPLATFORM ${NODE_IMAGE} AS build' "$dockerfile" ||
+    fail "OCI Dockerfile must compile architecture-independent assets on BUILDPLATFORM: $dockerfile"
 done
 grep -R -n -E 'image:[[:space:]]+[^[:space:]#]+:(latest|main|master|dev)([[:space:]#]|$)' \
   "$OCI_DIR" "$ROOT_DIR/.github/workflows/oci-"*.yml >/dev/null 2>&1 &&


### PR DESCRIPTION
## Summary
- promote native-platform compilation for architecture-independent TypeScript and client assets
- retain ARM64 runtime stages, immutable digests, and ARM64 boot verification
- reuse npm download cache across sequential image builds

The cancelled prior OCI build produced zero images. This promotion creates a fresh exact source SHA and does not deploy either cloud.