### PR TITLE
docs(oci): record granular registry push policy

### DIFF
--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -20,9 +20,11 @@ load balancer.
 - OCIR repository layer storage must remain at or below
   `OCI_REGISTRY_MAX_BYTES=500000000`.
 - Frankfurt OCIR does not currently support repository-level immutability.
-  The repositories are precreated privately, the CI user has `use repos`
-  rather than create/delete access, and the build fails unless every exact-SHA
-  tag is proven absent before its single first-attempt push.
+  The repositories are precreated privately, and the CI user has only
+  `REPOSITORY_INSPECT`, `REPOSITORY_READ`, and `REPOSITORY_UPDATE` in the
+  dedicated compartment, with no repository create/delete/manage permission.
+  The build fails unless every exact-SHA tag is proven absent before its
+  single first-attempt push.
 - OCI CLI execution is fail-closed on the reviewed `3.90.0` client version.
 - There is no paid shape, enhanced-cluster, NAT gateway, extra node, extra
   Mongo, or alternate load-balancer fallback.


### PR DESCRIPTION
## Summary
- document the exact compartment-scoped OCIR permissions required for image push
- retain no repository create, delete, or management permission
- synchronize the optimized master build ancestry back into `dev`

The account policy now grants only `REPOSITORY_INSPECT`, `REPOSITORY_READ`, and `REPOSITORY_UPDATE` to the dedicated CI group. The denied build created zero image manifests.