### PR TITLE
fix(oci): run RabbitMQ probe as image user

### DIFF
--- a/infra/oci/scripts/verify-images.sh
+++ b/infra/oci/scripts/verify-images.sh
@@ -122,7 +122,7 @@ if [[ "$BOOT_IMAGES" == "1" ]]; then
         grep -qx 1; then
       mongo_ready=1
     fi
-    if docker exec "$rabbit" rabbitmq-diagnostics -q ping >/dev/null 2>&1; then
+    if docker exec --user rabbitmq "$rabbit" rabbitmq-diagnostics -q ping >/dev/null 2>&1; then
       rabbit_ready=1
     fi
     [[ "$mongo_ready" == "1" && "$rabbit_ready" == "1" ]] && break

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -219,6 +219,8 @@ grep -Fq 'docker run -d --platform linux/arm64 --name "$container"' "$verify_ima
 if grep -Eq -- '--platform linux/arm64 --name "\$(mongo|rabbit)"' "$verify_images"; then
   fail "OCI build verification dependencies must use the runner native platform"
 fi
+grep -Fq 'docker exec --user rabbitmq "$rabbit" rabbitmq-diagnostics -q ping' "$verify_images" ||
+  fail "RabbitMQ readiness verification must run as the image user"
 grep -R -n -E 'image:[[:space:]]+[^[:space:]#]+:(latest|main|master|dev)([[:space:]#]|$)' \
   "$OCI_DIR" "$ROOT_DIR/.github/workflows/oci-"*.yml >/dev/null 2>&1 &&
   fail "OCI path contains a mutable image tag"


### PR DESCRIPTION
## Summary
- run RabbitMQ readiness diagnostics as the image-owned user
- retain native dependency platforms and ARM64 application boot verification
- unblock immutable OCI image provenance publication

## Safety
- no application source changes
- no Azure deployment or migration
- no OCI infrastructure changes