### PR TITLE
fix(oci): deduplicate registry layers

### DIFF
--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -20,7 +20,10 @@ load balancer.
 - OCIR repository layer storage must remain at or below
   `OCI_REGISTRY_MAX_BYTES=500000000`.
 - Frankfurt OCIR does not currently support repository-level immutability.
-  The repositories are precreated privately. The CI policy grants
+  One private `${OCI_IMAGE_PREFIX}_images` repository is precreated so the
+  eight backend images share their identical Node layers instead of charging
+  the Free Tier allowance for those layers eight times. Service-specific,
+  exact-SHA tags remain independently digest-pinned. The CI policy grants
   `manage repos` only in the dedicated compartment and only when
   `target.repo.name=/betstan_*/`; it does not cover other repositories or
   root-compartment repository creation. The protected build has no deletion

--- a/infra/oci/scripts/build-images.sh
+++ b/infra/oci/scripts/build-images.sh
@@ -28,10 +28,10 @@ fi
 
 oci_prepare_private_dir "$OUTPUT_DIR"
 services=(auth bet backoffice client event gamemaster moderation resulting slip)
+repository="${OCI_REGISTRY_HOST}/${OCI_REGISTRY_NAMESPACE}/${OCI_IMAGE_PREFIX}_images"
 
 for service in "${services[@]}"; do
-  repository="${OCI_REGISTRY_HOST}/${OCI_REGISTRY_NAMESPACE}/${OCI_IMAGE_PREFIX}_${service}"
-  tag="${repository}:oci-${SOURCE_SHA}"
+  tag="${repository}:oci-${service}-${SOURCE_SHA}"
   metadata="$OUTPUT_DIR/${service}.metadata.json"
   provenance="$OUTPUT_DIR/${service}.env"
   if [[ "$PUSH_IMAGES" == "1" ]]; then

--- a/infra/oci/scripts/inventory.sh
+++ b/infra/oci/scripts/inventory.sh
@@ -41,10 +41,7 @@ nat_gateways="$(oci_normalize_list_json "$nat_gateways")"
 repositories="$(oci_normalize_list_json "$repositories" items)"
 buckets="$(oci_normalize_list_json "$buckets")"
 expected_repositories="$(
-  jq -cn --arg prefix "$OCI_IMAGE_PREFIX" '[
-    "auth", "bet", "backoffice", "client", "event", "gamemaster",
-    "moderation", "resulting", "slip"
-  ] | map($prefix + "_" + .)'
+  jq -cn --arg prefix "$OCI_IMAGE_PREFIX" '[$prefix + "_images"]'
 )"
 
 inventory="$(
@@ -176,6 +173,7 @@ jq -e --argjson ocpus "$OCI_A1_OCPUS" --argjson memory "$OCI_A1_MEMORY_GB" \
     .registry_layers_size_bytes <= $registry_max and
     ([.registry_repositories[].name] | sort) ==
       (.expected_registry_repositories | sort) and
+    ([.registry_repositories[] | select(.image_count != 9)] | length) == 0 and
     ([.registry_repositories[] | select(
       .public != false or (.immutable != true and .immutable != null)
     )] | length) == 0 and

--- a/infra/oci/scripts/verify-images.sh
+++ b/infra/oci/scripts/verify-images.sh
@@ -34,7 +34,8 @@ for file in "$PROVENANCE_DIR"/*.env; do
   seen_services+="$service "
   [[ "$source_sha" == "$SOURCE_SHA" ]] || oci_die "source SHA mismatch for $service"
   [[ "$platform" == "linux/arm64" ]] || oci_die "platform mismatch for $service"
-  [[ "$tag" == "${repository}:oci-${SOURCE_SHA}" ]] || oci_die "non-exact OCI tag for $service"
+  [[ "$tag" == "${repository}:oci-${service}-${SOURCE_SHA}" ]] ||
+    oci_die "non-exact OCI tag for $service"
   [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || oci_die "invalid digest for $service"
   [[ "$platform_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
     oci_die "invalid linux/arm64 platform digest for $service"
@@ -42,7 +43,7 @@ for file in "$PROVENANCE_DIR"/*.env; do
   [[ "$repository" != *docker.io/stanvasilyev* ]] || oci_die "OCI provenance points at Docker Hub"
   if [[ -n "${OCI_REGISTRY_HOST:-}" || -n "${OCI_REGISTRY_NAMESPACE:-}" || -n "${OCI_IMAGE_PREFIX:-}" ]]; then
     oci_require_vars OCI_REGISTRY_HOST OCI_REGISTRY_NAMESPACE OCI_IMAGE_PREFIX
-    expected_repository="${OCI_REGISTRY_HOST}/${OCI_REGISTRY_NAMESPACE}/${OCI_IMAGE_PREFIX}_${service}"
+    expected_repository="${OCI_REGISTRY_HOST}/${OCI_REGISTRY_NAMESPACE}/${OCI_IMAGE_PREFIX}_images"
     [[ "$repository" == "$expected_repository" ]] ||
       oci_die "image repository differs from the approved OCIR path for $service"
   fi

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -91,12 +91,12 @@ index=1
 for service in "${services[@]}"; do
   digit="$index"
   digest="$(printf '%064d' "$digit")"
-  repository="fixture.invalid/namespace/betstan_${service}"
+  repository="fixture.invalid/namespace/betstan_images"
   cat > "$WORK_DIR/provenance/${service}.env" <<ENV
 service=${service}
 repository=${repository}
 source_sha=1111111111111111111111111111111111111111
-tag=${repository}:oci-1111111111111111111111111111111111111111
+tag=${repository}:oci-${service}-1111111111111111111111111111111111111111
 digest=sha256:${digest}
 platform_digest=sha256:${digest}
 image_ref=${repository}@sha256:${digest}
@@ -214,6 +214,17 @@ for dockerfile in "$OCI_DIR/build/Dockerfile.backend" "$OCI_DIR/build/Dockerfile
     fail "OCI Dockerfile must compile architecture-independent assets on BUILDPLATFORM: $dockerfile"
 done
 verify_images="$OCI_DIR/scripts/verify-images.sh"
+build_images="$OCI_DIR/scripts/build-images.sh"
+grep -Fq 'repository="${OCI_REGISTRY_HOST}/${OCI_REGISTRY_NAMESPACE}/${OCI_IMAGE_PREFIX}_images"' \
+  "$build_images" ||
+  fail "OCI builds must share one repository so common layers stay inside the Free Tier allowance"
+grep -Fq 'tag="${repository}:oci-${service}-${SOURCE_SHA}"' "$build_images" ||
+  fail "shared OCI repository tags must bind the service and exact source SHA"
+inventory="$OCI_DIR/scripts/inventory.sh"
+grep -Fq '[$prefix + "_images"]' "$inventory" ||
+  fail "OCI inventory must allow only the shared image repository"
+grep -Fq 'select(.image_count != 9)' "$inventory" ||
+  fail "OCI inventory must require all nine exact application images"
 grep -Fq 'docker run -d --platform linux/arm64 --name "$container"' "$verify_images" ||
   fail "OCI application boot verification must run the ARM64 images"
 if grep -Eq -- '--platform linux/arm64 --name "\$(mongo|rabbit)"' "$verify_images"; then


### PR DESCRIPTION
## Summary
- publish all nine service-specific exact-SHA tags to one private `betstan_images` repository
- preserve independent image digests and ARM64 boot verification
- require exactly nine images in the zero-cost inventory
- document the Free Tier storage rationale

## Measured gate
- separate repositories: 702,694,321 bytes (fails 500 MB limit)
- shared-repository local OCI layout: 171,307,793 compressed layer bytes
- projected headroom: 328,692,207 bytes

All nine locally built ARM64 images booted successfully with native MongoDB and RabbitMQ verification dependencies. No application source, topology, Azure path, or live infrastructure changed.