### PR TITLE
Fix isolated OCI CLI executable path

### DIFF
--- a/.github/workflows/oci-capacity-acquire.yml
+++ b/.github/workflows/oci-capacity-acquire.yml
@@ -59,6 +59,7 @@ jobs:
             echo "HOME=$RUNNER_TEMP/oci-capacity-home"
             echo "WORK_DIR=$RUNNER_TEMP/oci-capacity-work"
           } >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/oci-capacity-home/.local/bin" >> "$GITHUB_PATH"
           mkdir -p "$RUNNER_TEMP/oci-capacity-home" "$RUNNER_TEMP/oci-capacity-work"
           chmod 700 "$RUNNER_TEMP/oci-capacity-home" "$RUNNER_TEMP/oci-capacity-work"
 

--- a/.github/workflows/oci-infrastructure.yml
+++ b/.github/workflows/oci-infrastructure.yml
@@ -97,6 +97,7 @@ jobs:
             echo "HOME=$RUNNER_TEMP/oci-home"
             echo "KUBECONFIG=$RUNNER_TEMP/oci-home/.kube/config"
           } >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/oci-home/.local/bin" >> "$GITHUB_PATH"
           mkdir -p "$RUNNER_TEMP/oci-home/.kube"
           chmod 700 "$RUNNER_TEMP/oci-home" "$RUNNER_TEMP/oci-home/.kube"
 

--- a/.github/workflows/oci-migrate.yml
+++ b/.github/workflows/oci-migrate.yml
@@ -81,6 +81,7 @@ jobs:
             echo "AZURE_KUBECONFIG=$RUNNER_TEMP/azure-home/kubeconfig"
             echo "OCI_KUBECONFIG=$RUNNER_TEMP/oci-home/.kube/config"
           } >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/oci-home/.local/bin" >> "$GITHUB_PATH"
           mkdir -p \
             "$RUNNER_TEMP/azure-home/.azure" \
             "$RUNNER_TEMP/oci-home/.kube"

--- a/.github/workflows/oci-production-deploy.yml
+++ b/.github/workflows/oci-production-deploy.yml
@@ -78,6 +78,7 @@ jobs:
             echo "HOME=$RUNNER_TEMP/oci-home"
             echo "KUBECONFIG=$RUNNER_TEMP/oci-home/.kube/config"
           } >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/oci-home/.local/bin" >> "$GITHUB_PATH"
           mkdir -p "$RUNNER_TEMP/oci-home/.kube"
           chmod 700 "$RUNNER_TEMP/oci-home" "$RUNNER_TEMP/oci-home/.kube"
 

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -352,6 +352,13 @@ for variable in OCI_CLI_USER OCI_CLI_TENANCY OCI_CLI_FINGERPRINT OCI_CLI_KEY_CON
   grep -Fq "$variable:" "$capacity_workflow" ||
     fail "official OCI CLI mapping missing from oci-capacity-acquire.yml: $variable"
 done
+grep -Fq 'echo "$RUNNER_TEMP/oci-capacity-home/.local/bin" >> "$GITHUB_PATH"' \
+  "$capacity_workflow" ||
+  fail "capacity workflow does not expose the isolated OCI CLI installation on PATH"
+for workflow in "$infra_workflow" "$deploy_workflow" "$migrate_workflow"; do
+  grep -Fq 'echo "$RUNNER_TEMP/oci-home/.local/bin" >> "$GITHUB_PATH"' "$workflow" ||
+    fail "isolated OCI CLI installation is not on PATH in $(basename "$workflow")"
+done
 ! grep -Eq 'AZURE_|azure/' "$infra_workflow" "$deploy_workflow" ||
   fail "Azure credentials leaked into OCI infrastructure/deployment"
 


### PR DESCRIPTION
## Summary
- expose each isolated OCI home `.local/bin` through `GITHUB_PATH` before invoking the pinned Oracle CLI action
- cover infrastructure, capacity acquisition, production deployment, and migration workflows
- enforce the path contract in the OCI offline test suite

## Live failure addressed
OCI infrastructure run `30748743156` installed OCI CLI 3.90.0 successfully but could not locate the `oci` executable because `$HOME` was isolated without updating `PATH`. The failed run stopped before OCI reconciliation.