### PR TITLE
Use pinned OCI CLI directly in runtime workflows

### DIFF
--- a/.github/workflows/oci-capacity-acquire.yml
+++ b/.github/workflows/oci-capacity-acquire.yml
@@ -84,18 +84,24 @@ jobs:
           [ "$GITHUB_RUN_ATTEMPT" = "1" ]
           printf 'SOURCE_SHA=%s\n' "$SOURCE_SHA" >> "$GITHUB_ENV"
 
-      - name: Install OCI CLI with capacity identity
-        uses: oracle-actions/run-oci-cli-command@368cc7991534d1b8074846d10e1d84ac4c0d1a28 # v1.3.2
+      - name: Install pinned OCI CLI and verify capacity identity
         env:
           OCI_CLI_USER: ${{ vars.OCI_CAPACITY_USER_OCID }}
           OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
           OCI_CLI_FINGERPRINT: ${{ vars.OCI_CAPACITY_KEY_FINGERPRINT }}
           OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CAPACITY_PRIVATE_KEY_PEM }}
           OCI_CLI_REGION: ${{ vars.OCI_REGION }}
-        with:
-          command: iam region-subscription list
-          query: 'data[?"is-home-region" == `true`]."region-name"'
-          silent: true
+          OCI_HOME_REGION_QUERY: 'data[?"is-home-region" == `true`]."region-name" | [0]'
+        run: |
+          set -euo pipefail
+          ./infra/oci/scripts/install-cli.sh
+          home_region="$(
+            oci iam region-subscription list \
+              --tenancy-id "$OCI_CLI_TENANCY" \
+              --query "$OCI_HOME_REGION_QUERY" \
+              --raw-output
+          )"
+          [ "$home_region" = "$OCI_CLI_REGION" ]
 
       - name: Attempt one reconciled Free Tier placement
         id: acquire

--- a/.github/workflows/oci-infrastructure.yml
+++ b/.github/workflows/oci-infrastructure.yml
@@ -120,18 +120,24 @@ jobs:
           mkdir -p "$HOME/.kube"
           chmod 700 "$HOME" "$HOME/.kube"
 
-      - name: Install OCI CLI with read-only identity call
-        uses: oracle-actions/run-oci-cli-command@368cc7991534d1b8074846d10e1d84ac4c0d1a28 # v1.3.2
+      - name: Install pinned OCI CLI and verify identity
         env:
           OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
           OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
           OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
           OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
           OCI_CLI_REGION: ${{ vars.OCI_REGION }}
-        with:
-          command: iam region-subscription list
-          query: 'data[?"is-home-region" == `true`]."region-name"'
-          silent: true
+          OCI_HOME_REGION_QUERY: 'data[?"is-home-region" == `true`]."region-name" | [0]'
+        run: |
+          set -euo pipefail
+          ./infra/oci/scripts/install-cli.sh
+          home_region="$(
+            oci iam region-subscription list \
+              --tenancy-id "$OCI_CLI_TENANCY" \
+              --query "$OCI_HOME_REGION_QUERY" \
+              --raw-output
+          )"
+          [ "$home_region" = "$OCI_CLI_REGION" ]
 
       - name: Zero-cost preflight and cloud reconciliation
         id: cloud

--- a/.github/workflows/oci-migrate.yml
+++ b/.github/workflows/oci-migrate.yml
@@ -232,24 +232,13 @@ jobs:
           [ "$actual_hash" = "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256" ]
           printf 'resource_id_hash=%s\n' "$actual_hash" >> "$GITHUB_OUTPUT"
 
-      - name: Install OCI CLI with read-only cluster call
-        if: env.OCI_RUNTIME_MODE == 'oke'
-        uses: oracle-actions/run-oci-cli-command@368cc7991534d1b8074846d10e1d84ac4c0d1a28 # v1.3.2
+      - name: Install pinned OCI CLI
         env:
           HOME: ${{ runner.temp }}/oci-home
-          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
-          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
-          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
-          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
-          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
-        with:
-          command: ce cluster get --cluster-id ${{ steps.provenance.outputs.runtime_ocid }}
-          query: 'data.{type:type,state:"lifecycle-state"}'
-          silent: true
+        run: ./infra/oci/scripts/install-cli.sh
 
-      - name: Install OCI CLI with read-only k3s instance call
-        if: env.OCI_RUNTIME_MODE == 'k3s'
-        uses: oracle-actions/run-oci-cli-command@368cc7991534d1b8074846d10e1d84ac4c0d1a28 # v1.3.2
+      - name: Verify OKE identity
+        if: env.OCI_RUNTIME_MODE == 'oke'
         env:
           HOME: ${{ runner.temp }}/oci-home
           OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
@@ -257,10 +246,30 @@ jobs:
           OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
           OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
           OCI_CLI_REGION: ${{ vars.OCI_REGION }}
-        with:
-          command: compute instance get --instance-id ${{ steps.provenance.outputs.runtime_ocid }}
-          query: 'data.{shape:shape,state:"lifecycle-state"}'
-          silent: true
+          OCI_CLUSTER_OCID: ${{ steps.provenance.outputs.runtime_ocid }}
+        run: |
+          set -euo pipefail
+          oci ce cluster get \
+            --cluster-id "$OCI_CLUSTER_OCID" \
+            --query 'data.{type:type,state:"lifecycle-state"}' \
+            >/dev/null
+
+      - name: Verify k3s identity
+        if: env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          HOME: ${{ runner.temp }}/oci-home
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_INSTANCE_OCID: ${{ steps.provenance.outputs.runtime_ocid }}
+        run: |
+          set -euo pipefail
+          oci compute instance get \
+            --instance-id "$OCI_INSTANCE_OCID" \
+            --query 'data.{shape:shape,state:"lifecycle-state"}' \
+            >/dev/null
 
       - name: Reconcile expired and authorize current runner IPv4
         if: env.OCI_RUNTIME_MODE == 'oke'

--- a/.github/workflows/oci-production-deploy.yml
+++ b/.github/workflows/oci-production-deploy.yml
@@ -181,33 +181,40 @@ jobs:
           fi
           printf 'public_url=https://%s\n' "$public_host" >> "$GITHUB_OUTPUT"
 
-      - name: Install OCI CLI with read-only identity call
-        if: env.OCI_RUNTIME_MODE == 'oke'
-        uses: oracle-actions/run-oci-cli-command@368cc7991534d1b8074846d10e1d84ac4c0d1a28 # v1.3.2
-        env:
-          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
-          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
-          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
-          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
-          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
-        with:
-          command: ce cluster get --cluster-id ${{ steps.provenance.outputs.cluster_ocid }}
-          query: 'data.{type:type,state:"lifecycle-state"}'
-          silent: true
+      - name: Install pinned OCI CLI
+        run: ./infra/oci/scripts/install-cli.sh
 
-      - name: Install OCI CLI with k3s identity call
-        if: env.OCI_RUNTIME_MODE == 'k3s'
-        uses: oracle-actions/run-oci-cli-command@368cc7991534d1b8074846d10e1d84ac4c0d1a28 # v1.3.2
+      - name: Verify OKE identity
+        if: env.OCI_RUNTIME_MODE == 'oke'
         env:
           OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
           OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
           OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
           OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
           OCI_CLI_REGION: ${{ vars.OCI_REGION }}
-        with:
-          command: compute instance get --instance-id ${{ steps.provenance.outputs.instance_ocid }}
-          query: 'data.{shape:shape,state:"lifecycle-state"}'
-          silent: true
+          OCI_CLUSTER_OCID: ${{ steps.provenance.outputs.cluster_ocid }}
+        run: |
+          set -euo pipefail
+          oci ce cluster get \
+            --cluster-id "$OCI_CLUSTER_OCID" \
+            --query 'data.{type:type,state:"lifecycle-state"}' \
+            >/dev/null
+
+      - name: Verify k3s identity
+        if: env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_INSTANCE_OCID: ${{ steps.provenance.outputs.instance_ocid }}
+        run: |
+          set -euo pipefail
+          oci compute instance get \
+            --instance-id "$OCI_INSTANCE_OCID" \
+            --query 'data.{shape:shape,state:"lifecycle-state"}' \
+            >/dev/null
 
       - name: Reconcile expired and authorize current runner IPv4
         if: env.OCI_RUNTIME_MODE == 'oke'

--- a/infra/oci/scripts/install-cli.sh
+++ b/infra/oci/scripts/install-cli.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${OCI_CLI_VERSION:?OCI_CLI_VERSION is required}"
+[[ "$OCI_CLI_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  printf 'OCI_CLI_VERSION must be an exact semantic version\n' >&2
+  exit 1
+}
+
+python3 -m pip install \
+  --disable-pip-version-check \
+  --no-input \
+  --user \
+  "oci-cli==${OCI_CLI_VERSION}"
+
+actual_version="$(oci --version)"
+if [[ "$actual_version" != "$OCI_CLI_VERSION" ]]; then
+  printf 'OCI CLI version mismatch: expected %s, got %s\n' \
+    "$OCI_CLI_VERSION" \
+    "$actual_version" >&2
+  exit 1
+fi

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -295,6 +295,7 @@ infra_workflow="$ROOT_DIR/.github/workflows/oci-infrastructure.yml"
 deploy_workflow="$ROOT_DIR/.github/workflows/oci-production-deploy.yml"
 migrate_workflow="$ROOT_DIR/.github/workflows/oci-migrate.yml"
 validate_workflow="$ROOT_DIR/.github/workflows/oci-validate.yml"
+cli_installer="$OCI_DIR/scripts/install-cli.sh"
 
 grep -Fq 'workflow_run:' "$build_workflow"
 grep -Fq 'workflows: ["production-build"]' "$build_workflow"
@@ -359,6 +360,16 @@ for workflow in "$infra_workflow" "$deploy_workflow" "$migrate_workflow"; do
   grep -Fq 'echo "$RUNNER_TEMP/oci-home/.local/bin" >> "$GITHUB_PATH"' "$workflow" ||
     fail "isolated OCI CLI installation is not on PATH in $(basename "$workflow")"
 done
+for workflow in "$capacity_workflow" "$infra_workflow" "$deploy_workflow" "$migrate_workflow"; do
+  grep -Fq './infra/oci/scripts/install-cli.sh' "$workflow" ||
+    fail "pinned OCI CLI installer missing from $(basename "$workflow")"
+  ! grep -Fq 'oracle-actions/run-oci-cli-command' "$workflow" ||
+    fail "opaque OCI CLI action remains in $(basename "$workflow")"
+done
+grep -Fq '"oci-cli==${OCI_CLI_VERSION}"' "$cli_installer" ||
+  fail "OCI CLI package installation is not pinned to OCI_CLI_VERSION"
+grep -Fq 'python3 -m pip install' "$cli_installer" ||
+  fail "OCI CLI installer does not use the runner's explicit Python 3"
 ! grep -Eq 'AZURE_|azure/' "$infra_workflow" "$deploy_workflow" ||
   fail "Azure credentials leaked into OCI infrastructure/deployment"
 


### PR DESCRIPTION
## Summary
- replace the opaque Oracle CLI wrapper with a shared exact-version OCI CLI installer
- run direct, quoted, fail-closed identity checks for infrastructure, capacity acquisition, OKE, and k3s
- keep OCI credentials step-scoped and suppress successful resource payloads
- add offline contracts that prohibit reintroducing the wrapper or an unpinned CLI package

## Live failure addressed
Runs `30749016141` and `30749131825` reached the wrapper executable but it discarded the underlying OCI CLI error. The replacement was validated in an isolated home with the exact active CI identity and OCI CLI 3.90.0.