### PR TITLE
Promote OCI NSG reconciliation fix

### DIFF
--- a/infra/oci/scripts/authorize-github-runner.sh
+++ b/infra/oci/scripts/authorize-github-runner.sh
@@ -22,7 +22,7 @@ oci_is_positive_int "$OCI_RUNNER_RULE_TTL_MINUTES" ||
 cleanup_stale() {
   local now rules stale_ids
   now="$(date -u +%s)"
-  rules="$(oci network nsg rules list --network-security-group-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all)"
+  rules="$(oci network nsg rules list --nsg-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all)"
   rules="$(oci_normalize_list_json "$rules")"
   stale_ids="$(
     jq -r --argjson now "$now" '
@@ -38,13 +38,13 @@ cleanup_stale() {
       [[ -n "$rule_id" ]] || continue
       ids="$(jq -cn --arg id "$rule_id" '[$id]')"
       oci network nsg rules remove \
-        --network-security-group-id "$OCI_ENDPOINT_NSG_OCID" \
+        --nsg-id "$OCI_ENDPOINT_NSG_OCID" \
         --security-rule-ids "$ids" --force >/dev/null
     done <<<"$stale_ids"
   fi
   remaining="$(
     oci network nsg rules list \
-      --network-security-group-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all
+      --nsg-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all
   )"
   remaining="$(oci_normalize_list_json "$remaining")"
   jq -e --argjson now "$now" '
@@ -82,7 +82,7 @@ description="betstan-github-runner run=${GITHUB_RUN_ID} attempt=1 expires=${expi
 cidr="${RUNNER_PUBLIC_IPV4}/32"
 existing="$(
   oci network nsg rules list \
-    --network-security-group-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all
+    --nsg-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all
 )"
 existing="$(oci_normalize_list_json "$existing")"
 rule_id="$(
@@ -113,7 +113,7 @@ if [[ -z "$rule_id" ]]; then
   )"
   result="$(
     oci network nsg rules add \
-      --network-security-group-id "$OCI_ENDPOINT_NSG_OCID" \
+      --nsg-id "$OCI_ENDPOINT_NSG_OCID" \
       --security-rules "$rules"
   )"
   rule_id="$(jq -r '.data."security-rules"[0].id // empty' <<<"$result")"
@@ -126,7 +126,7 @@ rollback_unrecorded_rule() {
   if [[ "$status" -ne 0 && -n "${rule_id:-}" ]]; then
     ids="$(jq -cn --arg id "$rule_id" '[$id]')"
     oci network nsg rules remove \
-      --network-security-group-id "$OCI_ENDPOINT_NSG_OCID" \
+      --nsg-id "$OCI_ENDPOINT_NSG_OCID" \
       --security-rule-ids "$ids" --force >/dev/null 2>&1 || true
   fi
   exit "$status"

--- a/infra/oci/scripts/provision.sh
+++ b/infra/oci/scripts/provision.sh
@@ -93,7 +93,7 @@ ensure_nsg_rule() {
   local existing
   existing="$(
     oci network nsg rules list \
-      --network-security-group-id "$nsg_id" --all
+      --nsg-id "$nsg_id" --all
   )"
   existing="$(oci_normalize_list_json "$existing")"
   if jq -e --arg description "$description" --argjson expected "$rule_json" '
@@ -117,7 +117,7 @@ ensure_nsg_rule() {
     <<<"$existing" >/dev/null ||
     oci_die "managed NSG rule differs from the approved contract: $description"
   oci network nsg rules add \
-    --network-security-group-id "$nsg_id" \
+    --nsg-id "$nsg_id" \
     --security-rules "[$rule_json]" >/dev/null
 }
 
@@ -127,7 +127,7 @@ assert_nsg_rule_set() {
   local rules
   rules="$(
     oci network nsg rules list \
-      --network-security-group-id "$nsg_id" \
+      --nsg-id "$nsg_id" \
       --all
   )"
   rules="$(oci_normalize_list_json "$rules")"

--- a/infra/oci/scripts/revoke-github-runner.sh
+++ b/infra/oci/scripts/revoke-github-runner.sh
@@ -18,7 +18,7 @@ oci_require_ocid OCI_ENDPOINT_NSG_OCID
 
 rules="$(
   oci network nsg rules list \
-    --network-security-group-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all
+    --nsg-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all
 )"
 rules="$(oci_normalize_list_json "$rules")"
 match_count="$(
@@ -30,7 +30,7 @@ match_count="$(
 if [[ "$match_count" == "1" ]]; then
   ids="$(jq -cn --arg id "$OCI_RUNNER_RULE_ID" '[$id]')"
   oci network nsg rules remove \
-    --network-security-group-id "$OCI_ENDPOINT_NSG_OCID" \
+    --nsg-id "$OCI_ENDPOINT_NSG_OCID" \
     --security-rule-ids "$ids" --force >/dev/null
 elif [[ "$match_count" != "0" ]]; then
   oci_die "runner rule identity is ambiguous; refusing broad NSG cleanup"
@@ -38,7 +38,7 @@ fi
 
 remaining="$(
   oci network nsg rules list \
-    --network-security-group-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all
+    --nsg-id "$OCI_ENDPOINT_NSG_OCID" --direction INGRESS --all
 )"
 remaining="$(oci_normalize_list_json "$remaining")"
 jq -e --arg id "$OCI_RUNNER_RULE_ID" '[.data[]? | select(.id == $id)] | length == 0' \

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -370,6 +370,10 @@ grep -Fq '"oci-cli==${OCI_CLI_VERSION}"' "$cli_installer" ||
   fail "OCI CLI package installation is not pinned to OCI_CLI_VERSION"
 grep -Fq 'python3 -m pip install' "$cli_installer" ||
   fail "OCI CLI installer does not use the runner's explicit Python 3"
+! grep -R --include='*.sh' -F -- '--network-security-group-id' "$OCI_DIR/scripts" >/dev/null ||
+  fail "OCI scripts use the unsupported NSG rule argument --network-security-group-id"
+grep -Fq -- '--nsg-id "$nsg_id"' "$OCI_DIR/scripts/provision.sh" ||
+  fail "OCI network reconciliation does not use the supported NSG rule argument"
 ! grep -Eq 'AZURE_|azure/' "$infra_workflow" "$deploy_workflow" ||
   fail "Azure credentials leaked into OCI infrastructure/deployment"
 


### PR DESCRIPTION
## Summary
- use the supported OCI CLI --nsg-id contract across provisioning and temporary runner-rule cleanup
- unblock idempotent continuation from the already-created zero-cost network resources
- preserve all zero-cost, runtime, and Azure safeguards

The partial live inventory currently contains only the expected VCN, Internet Gateway, route table, restricted security list, and three NSGs.