### PR TITLE
Fix OCI A1 launch VNIC arguments

### DIFF
--- a/infra/oci/scripts/acquire-a1.sh
+++ b/infra/oci/scripts/acquire-a1.sh
@@ -11,6 +11,7 @@ REPORT_FILE="$WORK_DIR/capacity-report.json"
 USER_DATA_FILE="$WORK_DIR/cloud-init.yaml"
 SSH_PUBLIC_KEY_FILE="$WORK_DIR/k3s-ssh.pub"
 ERROR_FILE="$WORK_DIR/launch-error.log"
+OUTPUT_FILE="$WORK_DIR/launch-output.log"
 OCI_CAPACITY_RUN_NUMBER="${OCI_CAPACITY_RUN_NUMBER:-1}"
 
 cleanup() {
@@ -91,21 +92,7 @@ shape_config="$(
     --argjson memory "$memory_gb" \
     '{ocpus:$ocpus,memoryInGBs:$memory}'
 )"
-vnic_details="$(
-  jq -cn \
-    --arg subnet "$subnet_id" \
-    --arg nsg "$nsg_id" \
-    --argjson tags "$tags" '
-      {
-        subnetId: $subnet,
-        assignPublicIp: true,
-        assignPrivateDnsRecord: true,
-        nsgIds: [$nsg],
-        displayName: "betstan-k3s-primary",
-        freeformTags: $tags
-      }
-    '
-)"
+nsg_ids="$(jq -cn --arg nsg "$nsg_id" '[$nsg]')"
 agent_config='{
   "isManagementDisabled": false,
   "areAllPluginsDisabled": false,
@@ -116,34 +103,42 @@ agent_config='{
 }'
 
 set +e
-instance_id="$(
-  oci compute instance launch \
-    --compartment-id "$OCI_COMPARTMENT_OCID" \
-    --availability-domain "$availability_domain" \
-    --shape "$OCI_NODE_SHAPE" \
-    --shape-config "$shape_config" \
-    --source-details "$source_details" \
-    --create-vnic-details "$vnic_details" \
-    --display-name "$OCI_K3S_INSTANCE_NAME" \
-    --hostname-label betstank3s \
-    --freeform-tags "$tags" \
-    --ssh-authorized-keys-file "$SSH_PUBLIC_KEY_FILE" \
-    --user-data-file "$USER_DATA_FILE" \
-    --is-pv-encryption-in-transit-enabled true \
-    --agent-config "$agent_config" \
-    --wait-for-state RUNNING \
-    --wait-interval-seconds 15 \
-    --max-wait-seconds 900 \
-    --query 'data.id' \
-    --raw-output 2>"$ERROR_FILE"
-)"
+oci compute instance launch \
+  --compartment-id "$OCI_COMPARTMENT_OCID" \
+  --availability-domain "$availability_domain" \
+  --shape "$OCI_NODE_SHAPE" \
+  --shape-config "$shape_config" \
+  --source-details "$source_details" \
+  --subnet-id "$subnet_id" \
+  --assign-public-ip true \
+  --assign-private-dns-record true \
+  --nsg-ids "$nsg_ids" \
+  --vnic-display-name betstan-k3s-primary \
+  --display-name "$OCI_K3S_INSTANCE_NAME" \
+  --hostname-label betstank3s \
+  --freeform-tags "$tags" \
+  --ssh-authorized-keys-file "$SSH_PUBLIC_KEY_FILE" \
+  --user-data-file "$USER_DATA_FILE" \
+  --is-pv-encryption-in-transit-enabled true \
+  --agent-config "$agent_config" \
+  --wait-for-state RUNNING \
+  --wait-interval-seconds 15 \
+  --max-wait-seconds 900 \
+  --query 'data.id' \
+  --raw-output >"$OUTPUT_FILE" 2>"$ERROR_FILE"
 launch_status=$?
 set -e
 
 if [[ "$launch_status" != "0" ]]; then
+  launch_error="$(
+    {
+      cat "$OUTPUT_FILE"
+      cat "$ERROR_FILE"
+    } | oci_redact
+  )"
   if grep -Eiq \
       'OutOfHostCapacity|OUT_OF_HOST_CAPACITY|out of host capacity' \
-      "$ERROR_FILE"; then
+      <<<"$launch_error"; then
     PROVENANCE_DIR="$PROVENANCE_DIR" "$SCRIPT_DIR/reconcile-capacity.sh" cleanup >/dev/null
     oci_capacity_output instance_acquired false
     oci_capacity_output acquisition_status CAPACITY_UNAVAILABLE
@@ -151,10 +146,12 @@ if [[ "$launch_status" != "0" ]]; then
       "capacity_acquisition=CAPACITY_UNAVAILABLE report=$reported_status memory_gb=$memory_gb"
     exit 0
   fi
-  redacted="$(oci_redact < "$ERROR_FILE")"
-  oci_die "A1 launch failed with a non-capacity error: $redacted"
+  [[ -n "$launch_error" ]] ||
+    launch_error="OCI CLI exited with status $launch_status without diagnostics"
+  oci_die "A1 launch failed with a non-capacity error: $launch_error"
 fi
 
+instance_id="$(<"$OUTPUT_FILE")"
 oci_require_ocid_value="$instance_id"
 [[ "$oci_require_ocid_value" =~ ^ocid1\.instance\.oc[0-9]*\..+ ]] ||
   oci_die "OCI launch did not return an instance OCID"

--- a/infra/oci/tests/test-capacity-contract.sh
+++ b/infra/oci/tests/test-capacity-contract.sh
@@ -133,6 +133,10 @@ JSON
     }'
     ;;
   compute/instance/launch)
+    if [[ "$OCI_FAKE_SCENARIO" == "stdout-fatal" ]]; then
+      echo "No such option: --fixture"
+      exit 2
+    fi
     if [[ "$OCI_FAKE_SCENARIO" == "fatal" ]]; then
       echo "NotAuthorizedOrNotFound" >&2
       exit 1
@@ -252,6 +256,18 @@ grep -Fq 'acquisition_status=CAPACITY_UNAVAILABLE' "$output_file" ||
   fail "a no-capacity cycle must make exactly one real launch attempt"
 grep -qv -- '--fault-domain' "$FAKE_LOG" ||
   fail "capacity acquisition pinned a fault domain"
+grep -Fq -- '--subnet-id ocid1.subnet.oc1..fixture' "$FAKE_LOG" ||
+  fail "capacity acquisition omitted the prepared worker subnet"
+grep -Fq -- '--assign-public-ip true' "$FAKE_LOG" ||
+  fail "capacity acquisition omitted the reviewed ephemeral public IP"
+grep -Fq -- '--assign-private-dns-record true' "$FAKE_LOG" ||
+  fail "capacity acquisition omitted the primary VNIC DNS record"
+grep -Fq -- '--nsg-ids' "$FAKE_LOG" ||
+  fail "capacity acquisition omitted the prepared worker NSG"
+grep -Fq -- '--vnic-display-name betstan-k3s-primary' "$FAKE_LOG" ||
+  fail "capacity acquisition omitted the reviewed primary VNIC name"
+! grep -Fq -- '--create-vnic-details' "$FAKE_LOG" ||
+  fail "capacity acquisition uses the unsupported --create-vnic-details option"
 
 rm -f "$FAKE_STATE" "$FAKE_LOG"
 output_file="$TEST_DIR/acquired-output"
@@ -314,5 +330,16 @@ if OCI_FAKE_SCENARIO=fatal \
   "$OCI_DIR/scripts/acquire-a1.sh" >/dev/null 2>&1; then
   fail "non-capacity OCI failure was treated as retryable"
 fi
+
+rm -f "$FAKE_STATE" "$FAKE_LOG"
+stdout_fatal_log="$TEST_DIR/stdout-fatal.log"
+if OCI_FAKE_SCENARIO=stdout-fatal \
+  WORK_DIR="$TEST_DIR/stdout-fatal-work" \
+  PROVENANCE_DIR="$TEST_DIR/stdout-fatal-provenance" \
+  "$OCI_DIR/scripts/acquire-a1.sh" >"$stdout_fatal_log" 2>&1; then
+  fail "OCI CLI parser failure was treated as retryable"
+fi
+grep -Fq 'No such option: --fixture' "$stdout_fatal_log" ||
+  fail "OCI CLI stdout failure diagnostics were discarded"
 
 echo "oci_capacity_contract=PASS"


### PR DESCRIPTION
## Summary
- replace the removed --create-vnic-details option with OCI CLI 3.90.0 flattened primary-VNIC arguments
- retain the exact prepared subnet, worker NSG, ephemeral public IP, private DNS, and VNIC name contract
- capture and redact both stdout and stderr for fatal launch diagnostics
- add launch-argument and stdout-failure fixtures

## Live failure addressed
Capacity run 30750146593 authenticated and passed every pre-launch gate, but OCI CLI rejected the removed option before sending a LaunchInstance API request. OCI Audit confirms no launch request and the compartment still has no instance or boot volume. The watcher is paused during promotion.