### PR TITLE
Fix OCI A1 availability-domain quotas

### DIFF
--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -100,10 +100,11 @@ fixtures.
 3. Dispatch `oci-infrastructure` with phase `prepare`.
    `scripts/provision.sh cloud` creates/reconciles only the VCN, Internet
    Gateway, public/restricted subnets, NSGs, and OCI Bastion.
-4. Arm `oci-capacity-acquire` only after the quota, IAM, network, registry,
-   and zero-cost gates pass. It checks every Frankfurt AD every five minutes,
-   makes at most one real launch attempt per run, and permanently stops
-   launching after one valid managed VM exists.
+4. Set the repository-scoped variable `OCI_CAPACITY_CATCHER_ENABLED=true`
+   only after the quota, IAM, network, registry, and zero-cost gates pass.
+   The `oci-capacity-acquire` workflow checks every Frankfurt AD every five
+   minutes, makes at most one real launch attempt per run, and permanently
+   stops launching after one valid managed VM exists.
 5. Dispatch `oci-infrastructure` with phase `finalize` after acquisition.
    `scripts/configure-k3s-access.sh` opens ephemeral Bastion access and
    `scripts/finalize-k3s.sh` mounts the Mongo volume, installs ingress-nginx

--- a/infra/oci/scripts/capacity-common.sh
+++ b/infra/oci/scripts/capacity-common.sh
@@ -166,7 +166,7 @@ oci_capacity_require_home_region() {
 }
 
 oci_capacity_require_quota() {
-  local quotas quota_id quota statements total
+  local quotas quota_id quota statements total ads availability_domain limit
   quotas="$(
     oci limits quota list \
       --compartment-id "$OCI_TENANCY_OCID" \
@@ -188,6 +188,8 @@ oci_capacity_require_quota() {
     "zero compute-core quotas in compartment $OCI_COMPARTMENT_NAME" \
     "zero compute-memory quotas in compartment $OCI_COMPARTMENT_NAME" \
     "zero block-storage quotas in compartment $OCI_COMPARTMENT_NAME" \
+    "set compute-core quota standard-a1-core-count to 2 in compartment $OCI_COMPARTMENT_NAME where request.region = $OCI_REGION" \
+    "set compute-memory quota standard-a1-memory-count to 12 in compartment $OCI_COMPARTMENT_NAME where request.region = $OCI_REGION" \
     "set compute-core quota standard-a1-core-regional-count to 2 in compartment $OCI_COMPARTMENT_NAME where request.region = $OCI_REGION" \
     "set compute-memory quota standard-a1-memory-regional-count to 12 in compartment $OCI_COMPARTMENT_NAME where request.region = $OCI_REGION" \
     "set block-storage quota volume-count to 2 in compartment $OCI_COMPARTMENT_NAME where request.region = $OCI_REGION" \
@@ -215,6 +217,31 @@ oci_capacity_require_quota() {
         oci_die "effective regional A1 memory quota is not exactly 12 GB"
     fi
   done
+
+  ads="$(oci_capacity_availability_domains)"
+  jq -e 'length > 0' <<<"$ads" >/dev/null ||
+    oci_die "no availability domains were discovered for quota validation"
+  while IFS= read -r availability_domain; do
+    for limit in standard-a1-core-count standard-a1-memory-count; do
+      quota="$(
+        oci limits resource-availability get \
+          --service-name compute \
+          --limit-name "$limit" \
+          --compartment-id "$OCI_COMPARTMENT_OCID" \
+          --availability-domain "$availability_domain"
+      )"
+      total="$(
+        jq -r '(.data.available // 0) + (.data.used // 0)' <<<"$quota"
+      )"
+      if [[ "$limit" == "standard-a1-core-count" ]]; then
+        [[ "$total" == "2" || "$total" == "2.0" ]] ||
+          oci_die "effective A1 core quota is not exactly 2 in $availability_domain"
+      else
+        [[ "$total" == "12" || "$total" == "12.0" ]] ||
+          oci_die "effective A1 memory quota is not exactly 12 GB in $availability_domain"
+      fi
+    done
+  done < <(jq -r '.[]' <<<"$ads")
 }
 
 oci_capacity_single_id() {

--- a/infra/oci/tests/test-capacity-contract.sh
+++ b/infra/oci/tests/test-capacity-contract.sh
@@ -59,7 +59,8 @@ JSON
 JSON
     ;;
   limits/quota/get)
-    cat <<'JSON'
+    if [[ "$OCI_FAKE_SCENARIO" == "quota-missing-ad" ]]; then
+      cat <<'JSON'
 {"data":{"name":"betstan-free-tier-hard-limit","lifecycle-state":"ACTIVE","statements":[
 "zero compute quotas in compartment betstan-oci",
 "zero compute-core quotas in compartment betstan-oci",
@@ -71,10 +72,28 @@ JSON
 "set block-storage quota total-storage-gb to 100 in compartment betstan-oci where request.region = eu-frankfurt-1"
 ]}}
 JSON
+    else
+      cat <<'JSON'
+{"data":{"name":"betstan-free-tier-hard-limit","lifecycle-state":"ACTIVE","statements":[
+"zero compute quotas in compartment betstan-oci",
+"zero compute-core quotas in compartment betstan-oci",
+"zero compute-memory quotas in compartment betstan-oci",
+"zero block-storage quotas in compartment betstan-oci",
+"set compute-core quota standard-a1-core-count to 2 in compartment betstan-oci where request.region = eu-frankfurt-1",
+"set compute-memory quota standard-a1-memory-count to 12 in compartment betstan-oci where request.region = eu-frankfurt-1",
+"set compute-core quota standard-a1-core-regional-count to 2 in compartment betstan-oci where request.region = eu-frankfurt-1",
+"set compute-memory quota standard-a1-memory-regional-count to 12 in compartment betstan-oci where request.region = eu-frankfurt-1",
+"set block-storage quota volume-count to 2 in compartment betstan-oci where request.region = eu-frankfurt-1",
+"set block-storage quota total-storage-gb to 100 in compartment betstan-oci where request.region = eu-frankfurt-1"
+]}}
+JSON
+    fi
     ;;
   limits/resource-availability/get)
     limit="$(arg_value --limit-name "$@")"
-    if [[ "$limit" == "standard-a1-core-regional-count" ]]; then
+    if [[ "$OCI_FAKE_SCENARIO" == "quota-zero-ad" && "$limit" != *-regional-* ]]; then
+      echo '{"data":{"available":0,"used":0}}'
+    elif [[ "$limit" == *-core-* ]]; then
       echo '{"data":{"available":2,"used":0}}'
     else
       echo '{"data":{"available":12,"used":0}}'
@@ -210,6 +229,12 @@ source "$OCI_DIR/scripts/capacity-common.sh"
   fail "validated memory profile order changed"
 if OCI_A1_MEMORY_PROFILES=12,7 oci_capacity_profiles_json >/dev/null 2>&1; then
   fail "unvalidated memory profile was accepted"
+fi
+if (OCI_FAKE_SCENARIO=quota-missing-ad oci_capacity_require_quota) >/dev/null 2>&1; then
+  fail "quota policy without A1 availability-domain grants was accepted"
+fi
+if (OCI_FAKE_SCENARIO=quota-zero-ad oci_capacity_require_quota) >/dev/null 2>&1; then
+  fail "zero effective A1 availability-domain quota was accepted"
 fi
 
 cloud_init="$TEST_DIR/cloud-init.yaml"


### PR DESCRIPTION
## Summary
- restore the AD-scoped A1 CPU and memory quota counters required by direct VM launch
- fail closed unless regional and every Frankfurt AD counter are exactly 2 OCPUs / 12 GB
- add regressions for missing and ineffective AD grants
- document the repository-scoped capacity watcher flag

## Live evidence
Acquisition run `30750587357` reached `LaunchInstance` and OCI rejected `standard-a1-core-count` and `standard-a1-memory-count`; live regional counters are 2/12 while all three AD counters are 0.

## Validation
- `./infra/oci/tests/test-contract.sh`
- deployment-safety specialist: safe to review

The capacity watcher remains disabled until this change is promoted and the live policy is corrected.