### PR TITLE
Promote OCI capacity handoff correction

### DIFF
--- a/infra/oci/scripts/capacity-common.sh
+++ b/infra/oci/scripts/capacity-common.sh
@@ -46,7 +46,7 @@ oci_capacity_profiles_json() {
 import json
 import sys
 
-allowed = {6, 8, 10, 12}
+allowed = {12}
 result = []
 for raw in sys.argv[1].split(","):
     value = raw.strip()
@@ -71,6 +71,7 @@ oci_capacity_tags() {
     --arg contract "$OCI_CAPACITY_CONTRACT_VERSION" \
     '{
       "betstan-managed": "true",
+      "provider": "oci",
       "betstan-managed-by": $managed_by,
       "betstan-runtime": "k3s",
       "betstan-contract": $contract,
@@ -130,6 +131,7 @@ oci_capacity_validate_instance() {
        $instance."lifecycle-state" == "STARTING" or
        $instance."lifecycle-state" == "RUNNING") and
       $instance."freeform-tags"."betstan-managed" == "true" and
+      $instance."freeform-tags".provider == "oci" and
       $instance."freeform-tags"."betstan-managed-by" == $managed_by and
       $instance."freeform-tags"."betstan-runtime" == "k3s" and
       $instance."freeform-tags"."betstan-contract" == $contract and

--- a/infra/oci/tests/test-capacity-contract.sh
+++ b/infra/oci/tests/test-capacity-contract.sh
@@ -103,13 +103,13 @@ JSON
     if [[ "$OCI_FAKE_SCENARIO" == "duplicate" ]]; then
       cat <<'JSON'
 {"data":[
-{"id":"ocid1.instance.oc1..fixture1","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-1","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0"}},
-{"id":"ocid1.instance.oc1..fixture2","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-2","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0"}}
+{"id":"ocid1.instance.oc1..fixture1","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-1","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","provider":"oci","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0"}},
+{"id":"ocid1.instance.oc1..fixture2","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-2","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","provider":"oci","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0"}}
 ]}
 JSON
     elif [[ -f "$OCI_FAKE_STATE" ]]; then
       cat <<'JSON'
-{"data":[{"id":"ocid1.instance.oc1..fixture","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-1","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0"}}]}
+{"data":[{"id":"ocid1.instance.oc1..fixture","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-1","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","provider":"oci","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0"}}]}
 JSON
     else
       echo '{"data":[]}'
@@ -225,11 +225,19 @@ export OCI_CAPACITY_RUN_NUMBER=1
 
 # shellcheck source=../scripts/capacity-common.sh
 source "$OCI_DIR/scripts/capacity-common.sh"
-[[ "$(OCI_A1_MEMORY_PROFILES=12,10,8 oci_capacity_profiles_json)" == "[12,10,8]" ]] ||
-  fail "validated memory profile order changed"
-if OCI_A1_MEMORY_PROFILES=12,7 oci_capacity_profiles_json >/dev/null 2>&1; then
+[[ "$(OCI_A1_MEMORY_PROFILES=12 oci_capacity_profiles_json)" == "[12]" ]] ||
+  fail "validated memory profile changed"
+if OCI_A1_MEMORY_PROFILES=12,10 oci_capacity_profiles_json >/dev/null 2>&1; then
   fail "unvalidated memory profile was accepted"
 fi
+jq -e '
+  ."betstan-managed" == "true" and
+  .provider == "oci" and
+  ."betstan-managed-by" == "oci-capacity-acquire" and
+  ."betstan-runtime" == "k3s" and
+  ."expected-monthly-cost" == "0"
+' <<<"$(oci_capacity_tags)" >/dev/null ||
+  fail "capacity resources do not carry the finalization ownership tags"
 if (OCI_FAKE_SCENARIO=quota-missing-ad oci_capacity_require_quota) >/dev/null 2>&1; then
   fail "quota policy without A1 availability-domain grants was accepted"
 fi


### PR DESCRIPTION
## Summary
Promote the reviewed direct-k3s acquisition handoff correction from `dev` to `master`.

This ensures acquired compute and boot volumes carry the ownership tags required by infrastructure finalization and constrains acquisition to the only fully supported 2 OCPU / 12 GB profile.

Source PR: #127

The capacity watcher remains disabled until this promotion is merged and the exact new master SHA is verified.