### PR TITLE
Fix OCI capacity provenance handoff

### DIFF
--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -76,6 +76,11 @@ Additional account-derived variables are intentionally required:
   `AZURE_EXPECTED_CLUSTER_SERVER_SHA256`, and
   `AZURE_WATCHDOG_KUBECTL_IMAGE` for migration only
 
+The capacity-acquirer identity needs only `VOLUME_INSPECT`, `VOLUME_UPDATE`,
+and `VOLUME_DELETE` in the deployment compartment for boot-volume
+reconciliation. OCI authorizes boot-volume operations with `VOLUME_*`
+permissions; `boot-volumes` is not an individual IAM resource type.
+
 ## Offline validation
 
 ```bash

--- a/infra/oci/scripts/reconcile-capacity.sh
+++ b/infra/oci/scripts/reconcile-capacity.sh
@@ -66,7 +66,8 @@ record_instance() {
   local managed instance instance_id state network vcn_id subnet_id nsg_id
   local attachments attachment_count boot_volume_id boot_volume
   local vnic_attachments vnic_attachment_count vnic_id vnic public_ip private_ip
-  local tags instance_fingerprint memory_gb boot_gb boot_vpus ad
+  local tags merged_tags live_tags instance_fingerprint memory_gb boot_gb
+  local boot_vpus ad
 
   managed="$(oci_capacity_managed_instances)"
   [[ "$(jq '.data | length' <<<"$managed")" == "1" ]] ||
@@ -115,6 +116,28 @@ record_instance() {
   [[ "$boot_vpus" == "$OCI_BOOT_VOLUME_VPUS_PER_GB" ]] ||
     oci_die "managed instance boot volume violates the Balanced performance contract"
   tags="$(oci_capacity_tags)"
+  merged_tags="$(
+    jq -c --argjson required "$tags" '."freeform-tags" + $required' \
+      <<<"$instance"
+  )"
+  oci compute instance update \
+    --instance-id "$instance_id" \
+    --freeform-tags "$merged_tags" \
+    --force \
+    --wait-for-state RUNNING \
+    --max-wait-seconds 300 >/dev/null
+  live_tags="$(
+    oci compute instance get \
+      --instance-id "$instance_id" \
+      --query 'data."freeform-tags"' \
+      --output json
+  )"
+  jq -e --argjson expected "$tags" '
+    . as $actual
+    | ($expected | to_entries)
+    | all(.[]; $actual[.key] == .value)
+  ' <<<"$live_tags" >/dev/null ||
+    oci_die "managed instance tags do not match the current acquisition contract"
   oci bv boot-volume update \
     --boot-volume-id "$boot_volume_id" \
     --freeform-tags "$tags" \
@@ -153,7 +176,15 @@ record_instance() {
   [[ "$private_ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
     oci_die "managed instance private IPv4 is invalid"
 
-  memory_gb="$(jq -r '."shape-config"."memory-in-gbs"' <<<"$instance")"
+  memory_gb="$(
+    jq -r '
+      ."shape-config"."memory-in-gbs"
+      | if type == "number" and . == floor
+        then floor
+        else error("instance memory is not an integer number of GiB")
+        end
+    ' <<<"$instance"
+  )"
   instance_fingerprint="$(oci_fingerprint "$instance_id")"
   oci_prepare_private_dir "$PROVENANCE_DIR"
   {

--- a/infra/oci/tests/test-capacity-contract.sh
+++ b/infra/oci/tests/test-capacity-contract.sh
@@ -6,6 +6,7 @@ OCI_DIR="$ROOT_DIR/infra/oci"
 TEST_DIR="$(mktemp -d "$ROOT_DIR/.oci-capacity-test.XXXXXX")"
 FAKE_BIN="$TEST_DIR/bin"
 FAKE_STATE="$TEST_DIR/instance-created"
+FAKE_TAG_STATE="$TEST_DIR/instance-tags-updated"
 FAKE_LOG="$TEST_DIR/oci.log"
 
 cleanup() {
@@ -103,13 +104,13 @@ JSON
     if [[ "$OCI_FAKE_SCENARIO" == "duplicate" ]]; then
       cat <<'JSON'
 {"data":[
-{"id":"ocid1.instance.oc1..fixture1","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-1","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","provider":"oci","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0"}},
-{"id":"ocid1.instance.oc1..fixture2","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-2","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","provider":"oci","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0"}}
+{"id":"ocid1.instance.oc1..fixture1","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-1","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12.0},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","provider":"oci","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0","source-sha":"0000000000000000000000000000000000000000","acquisition-run-id":"stale"}},
+{"id":"ocid1.instance.oc1..fixture2","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-2","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12.0},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","provider":"oci","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0","source-sha":"0000000000000000000000000000000000000000","acquisition-run-id":"stale"}}
 ]}
 JSON
     elif [[ -f "$OCI_FAKE_STATE" ]]; then
       cat <<'JSON'
-{"data":[{"id":"ocid1.instance.oc1..fixture","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-1","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","provider":"oci","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0"}}]}
+{"data":[{"id":"ocid1.instance.oc1..fixture","display-name":"betstan-k3s-node","availability-domain":"fixture:EU-FRANKFURT-1-AD-1","image-id":"ocid1.image.oc1..fixture","shape":"VM.Standard.A1.Flex","shape-config":{"ocpus":2,"memory-in-gbs":12.0},"lifecycle-state":"RUNNING","freeform-tags":{"betstan-managed":"true","provider":"oci","betstan-managed-by":"oci-capacity-acquire","betstan-runtime":"k3s","betstan-contract":"1","expected-monthly-cost":"0","source-sha":"0000000000000000000000000000000000000000","acquisition-run-id":"stale"}}]}
 JSON
     else
       echo '{"data":[]}'
@@ -173,11 +174,40 @@ JSON
     echo "ocid1.instance.oc1..fixture"
     ;;
   compute/instance/get)
-    if [[ "$OCI_FAKE_SCENARIO" == "terminated" ]]; then
+    query="$(arg_value --query "$@")"
+    if [[ "$query" == 'data."freeform-tags"' ]]; then
+      [[ -f "$OCI_FAKE_TAG_STATE" ]] || exit 1
+      jq -cn \
+        --arg sha "$SOURCE_SHA" \
+        --arg run "$OCI_CAPACITY_RUN_ID" '
+          {
+            "betstan-managed": "true",
+            provider: "oci",
+            "betstan-managed-by": "oci-capacity-acquire",
+            "betstan-runtime": "k3s",
+            "betstan-contract": "1",
+            "expected-monthly-cost": "0",
+            "source-sha": $sha,
+            "acquisition-run-id": $run
+          }
+        '
+    elif [[ "$OCI_FAKE_SCENARIO" == "terminated" ]]; then
       echo "TERMINATED"
     else
       echo "RUNNING"
     fi
+    ;;
+  compute/instance/update)
+    tags="$(arg_value --freeform-tags "$@")"
+    jq -e \
+      --arg sha "$SOURCE_SHA" \
+      --arg run "$OCI_CAPACITY_RUN_ID" '
+        ."source-sha" == $sha and
+        ."acquisition-run-id" == $run and
+        ."expected-monthly-cost" == "0"
+      ' <<<"$tags" >/dev/null
+    touch "$OCI_FAKE_TAG_STATE"
+    echo '{"data":{"lifecycle-state":"RUNNING"}}'
     ;;
   compute/boot-volume-attachment/list)
     arg_value --availability-domain "$@" >/dev/null
@@ -213,6 +243,7 @@ chmod +x "$FAKE_BIN/oci"
 export PATH="$FAKE_BIN:$PATH"
 export OCI_FAKE_LOG="$FAKE_LOG"
 export OCI_FAKE_STATE="$FAKE_STATE"
+export OCI_FAKE_TAG_STATE="$FAKE_TAG_STATE"
 export OCI_RUNTIME_MODE=k3s
 export OCI_REGION=eu-frankfurt-1
 export OCI_CLI_VERSION=3.90.0
@@ -289,7 +320,7 @@ jq -e '
 ' "$TEST_DIR/report.json" >/dev/null ||
   fail "capacity report did not cover every fixture AD"
 
-rm -f "$FAKE_STATE" "$FAKE_LOG"
+rm -f "$FAKE_STATE" "$FAKE_TAG_STATE" "$FAKE_LOG"
 output_file="$TEST_DIR/no-capacity-output"
 OCI_FAKE_SCENARIO=no-capacity \
 GITHUB_OUTPUT="$output_file" \
@@ -317,7 +348,7 @@ grep -Fq 'bootVolumeVpusPerGB' "$FAKE_LOG" ||
 ! grep -Fq -- '--create-vnic-details' "$FAKE_LOG" ||
   fail "capacity acquisition uses the unsupported --create-vnic-details option"
 
-rm -f "$FAKE_STATE" "$FAKE_LOG"
+rm -f "$FAKE_STATE" "$FAKE_TAG_STATE" "$FAKE_LOG"
 output_file="$TEST_DIR/acquired-output"
 OCI_FAKE_SCENARIO=available \
 GITHUB_OUTPUT="$output_file" \
@@ -326,6 +357,8 @@ PROVENANCE_DIR="$TEST_DIR/acquired-provenance" \
   "$OCI_DIR/scripts/acquire-a1.sh" >/dev/null
 grep -Fq 'acquisition_status=ACQUIRED' "$output_file" ||
   fail "successful launch did not publish ACQUIRED"
+grep -Fq 'compute instance update' "$FAKE_LOG" ||
+  fail "successful acquisition did not bind the instance to current provenance"
 grep -Fq -- '--wait-for-state RUNNING --wait-for-state TERMINATED' "$FAKE_LOG" ||
   fail "capacity acquisition does not stop waiting when OCI terminates a launch"
 [[ -s "$TEST_DIR/acquired-provenance/provenance.env" ]] ||
@@ -353,6 +386,7 @@ jq -e '
   "$TEST_DIR/acquired-provenance/inventory.json" >/dev/null ||
   fail "successful launch inventory violates zero-cost singleton contract"
 launch_count="$(grep -c 'compute instance launch' "$FAKE_LOG")"
+tag_update_count="$(grep -c 'compute instance update' "$FAKE_LOG")"
 
 second_output="$TEST_DIR/already-output"
 OCI_FAKE_SCENARIO=available \
@@ -366,8 +400,18 @@ grep -Fq 'instance_acquired=true' "$second_output" ||
   fail "existing managed instance did not republish trusted provenance"
 [[ "$(grep -c 'compute instance launch' "$FAKE_LOG")" == "$launch_count" ]] ||
   fail "existing managed instance allowed another launch request"
+[[ "$(grep -c 'compute instance update' "$FAKE_LOG")" == "$((tag_update_count + 1))" ]] ||
+  fail "existing managed instance was not rebound to current provenance"
+bash -u -c '
+  source "$1"
+  [[ "$source_sha" == "$2" && "$acquisition_run_id" == "$3" ]]
+' _ \
+  "$TEST_DIR/already-provenance/provenance.env" \
+  "$SOURCE_SHA" \
+  "$OCI_CAPACITY_RUN_ID" ||
+  fail "existing managed instance provenance is not bound to the current run"
 
-rm -f "$FAKE_STATE" "$FAKE_LOG"
+rm -f "$FAKE_STATE" "$FAKE_TAG_STATE" "$FAKE_LOG"
 if OCI_FAKE_SCENARIO=terminated \
   WORK_DIR="$TEST_DIR/terminated-work" \
   PROVENANCE_DIR="$TEST_DIR/terminated-provenance" \
@@ -375,7 +419,7 @@ if OCI_FAKE_SCENARIO=terminated \
   fail "internally terminated A1 launch was accepted"
 fi
 
-rm -f "$FAKE_STATE" "$FAKE_LOG"
+rm -f "$FAKE_STATE" "$FAKE_TAG_STATE" "$FAKE_LOG"
 if OCI_FAKE_SCENARIO=duplicate \
   WORK_DIR="$TEST_DIR/duplicate-work" \
   PROVENANCE_DIR="$TEST_DIR/duplicate-provenance" \
@@ -386,7 +430,7 @@ if [[ -f "$FAKE_LOG" ]] && grep -Fq 'compute instance launch' "$FAKE_LOG"; then
   fail "duplicate managed instances reached the launch API"
 fi
 
-rm -f "$FAKE_STATE" "$FAKE_LOG"
+rm -f "$FAKE_STATE" "$FAKE_TAG_STATE" "$FAKE_LOG"
 if OCI_FAKE_SCENARIO=fatal \
   WORK_DIR="$TEST_DIR/fatal-work" \
   PROVENANCE_DIR="$TEST_DIR/fatal-provenance" \
@@ -394,7 +438,7 @@ if OCI_FAKE_SCENARIO=fatal \
   fail "non-capacity OCI failure was treated as retryable"
 fi
 
-rm -f "$FAKE_STATE" "$FAKE_LOG"
+rm -f "$FAKE_STATE" "$FAKE_TAG_STATE" "$FAKE_LOG"
 stdout_fatal_log="$TEST_DIR/stdout-fatal.log"
 if OCI_FAKE_SCENARIO=stdout-fatal \
   WORK_DIR="$TEST_DIR/stdout-fatal-work" \


### PR DESCRIPTION
Canonicalize live OCI A1 memory, bind retained singleton instances to the current source SHA and acquisition run before provenance emission, and document exact volume IAM permissions. Full OCI contract suite passes; deployment-safety review is GO.