### PR TITLE
fix(oci): use Bastion port forwarding for A1

### DIFF
--- a/.github/workflows/oci-capacity-acquire.yml
+++ b/.github/workflows/oci-capacity-acquire.yml
@@ -7,7 +7,8 @@ on:
   workflow_dispatch:
     inputs:
       approved_sha:
-        description: Optional exact current master SHA for an audited manual attempt
+        description: Exact current master SHA for an audited manual attempt
+        required: true
         type: string
 
 permissions:
@@ -22,7 +23,16 @@ jobs:
     if: >-
       github.run_attempt == 1 &&
       github.repository == 'vasilyevstan/betstan' &&
-      vars.OCI_CAPACITY_CATCHER_ENABLED == 'true'
+      (
+        (
+          github.event_name == 'schedule' &&
+          vars.OCI_CAPACITY_CATCHER_ENABLED == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.approved_sha != ''
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:

--- a/.github/workflows/oci-infrastructure.yml
+++ b/.github/workflows/oci-infrastructure.yml
@@ -263,7 +263,7 @@ jobs:
           [ "$boot_volume_gb" = "50" ]
           [ "$boot_volume_vpus_per_gb" = "10" ]
 
-      - name: Open ephemeral OCI Bastion access to k3s
+      - name: Open ephemeral OCI Bastion access and finalize k3s
         if: inputs.phase == 'finalize' && env.OCI_RUNTIME_MODE == 'k3s'
         env:
           OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
@@ -271,30 +271,35 @@ jobs:
           OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
           OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
           OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_K3S_SSH_PRIVATE_KEY: ${{ secrets.OCI_K3S_SSH_PRIVATE_KEY }}
+          OCI_K3S_RETAIN_TARGET_SSH: "true"
           INFRA_PROVENANCE_FILE: artifacts/oci-infrastructure/provenance.env
+          NETWORK_PROVENANCE_FILE: artifacts/oci-infrastructure/provenance.env
           ACQUISITION_PROVENANCE_FILE: artifacts/oci-capacity/provenance.env
           SESSION_STATE_FILE: artifacts/oci-infrastructure/k3s-access.env
+          K3S_ACCESS_STATE_FILE: artifacts/oci-infrastructure/k3s-access.env
           WORK_DIR: ${{ runner.temp }}/betstan-k3s-access
         run: |
           set -euo pipefail
+          cleanup_on_exit() {
+            status=$?
+            trap - EXIT
+            set +e
+            ./infra/oci/scripts/configure-k3s-access.sh cleanup
+            cleanup_status=$?
+            if [ "$status" -eq 0 ] && [ "$cleanup_status" -ne 0 ]; then
+              status=$cleanup_status
+            fi
+            exit "$status"
+          }
+          trap cleanup_on_exit EXIT
           RUNNER_PUBLIC_IPV4="$(
             curl --fail --silent --show-error --max-time 15 https://api.ipify.org
           )"
           export RUNNER_PUBLIC_IPV4
           ./infra/oci/scripts/configure-k3s-access.sh open
-
-      - name: Finalize k3s storage, add-ons, and OCI load balancer
-        if: inputs.phase == 'finalize' && env.OCI_RUNTIME_MODE == 'k3s'
-        env:
-          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
-          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
-          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
-          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
-          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
-          NETWORK_PROVENANCE_FILE: artifacts/oci-infrastructure/provenance.env
-          ACQUISITION_PROVENANCE_FILE: artifacts/oci-capacity/provenance.env
-          K3S_ACCESS_STATE_FILE: artifacts/oci-infrastructure/k3s-access.env
-        run: ./infra/oci/scripts/finalize-k3s.sh
+          unset OCI_K3S_SSH_PRIVATE_KEY
+          ./infra/oci/scripts/finalize-k3s.sh
 
       - name: Close ephemeral OCI Bastion access
         if: always() && inputs.phase == 'finalize' && env.OCI_RUNTIME_MODE == 'k3s'

--- a/.github/workflows/oci-migrate.yml
+++ b/.github/workflows/oci-migrate.yml
@@ -34,6 +34,8 @@ jobs:
     if: github.run_attempt == 1
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    outputs:
+      public_url: ${{ steps.provenance.outputs.public_url }}
     environment:
       name: oci-migration
     env:
@@ -313,6 +315,7 @@ jobs:
           OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
           OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
           OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_K3S_SSH_PRIVATE_KEY: ${{ secrets.OCI_K3S_SSH_PRIVATE_KEY }}
           INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env
           SESSION_STATE_FILE: artifacts/oci-migration/k3s-access.env
           WORK_DIR: ${{ runner.temp }}/betstan-k3s-access
@@ -341,13 +344,7 @@ jobs:
           JOURNAL_FILE: artifacts/oci-migration/journal.tsv
         run: ./infra/oci/scripts/migrate-from-azure.sh
 
-      - name: Install browser validation dependencies
-        run: |
-          cd client
-          npm ci
-          npx playwright install --with-deps chromium
-
-      - name: Rerun complete OCI health after migration
+      - name: Rerun protected OCI cluster health after migration
         id: health
         env:
           HOME: ${{ runner.temp }}/oci-home
@@ -362,6 +359,8 @@ jobs:
           OCI_RABBITMQ_BASELINE_FILE: artifacts/deploy/rabbitmq-baseline.txt
           OCI_EXPECTED_SOURCE_SHA: ${{ env.SOURCE_SHA }}
           OCI_PUBLIC_URL: ${{ steps.provenance.outputs.public_url }}
+          OCI_PUBLIC_CHECKS_ALREADY_PASSED: "1"
+          OCI_E2E_ALREADY_PASSED: "1"
           OUTPUT_DIR: artifacts/oci-migration/validation
         run: ./infra/oci/agents/deploy-validation-loop-stan.sh
 
@@ -422,3 +421,53 @@ jobs:
             "${{ runner.temp }}/azure-home" \
             "${{ runner.temp }}/oci-home" \
             "${{ runner.temp }}/oci-migration-ciphertext"
+
+  public-validate:
+    needs: migrate
+    if: github.run_attempt == 1 && needs.migrate.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: oci-migration
+    steps:
+      - name: Checkout exact migrated commit without credentials
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.approved_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate public-check identity
+        env:
+          SOURCE_SHA: ${{ inputs.approved_sha }}
+          OCI_PUBLIC_URL: ${{ needs.migrate.outputs.public_url }}
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [ "$GITHUB_RUN_ATTEMPT" = "1" ]
+          [ "$(git rev-parse HEAD)" = "$SOURCE_SHA" ]
+          [[ "$OCI_PUBLIC_URL" =~ ^https://[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\.nip\.io$ ]]
+
+      - name: Install browser validation dependencies
+        run: |
+          cd client
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run public OCI validation without cloud credentials
+        env:
+          OCI_PUBLIC_URL: ${{ needs.migrate.outputs.public_url }}
+          OCI_CLUSTER_CHECKS_ALREADY_PASSED: "1"
+          MAX_LOOPS: "3"
+          SLEEP_SECONDS: "20"
+          OUTPUT_DIR: artifacts/oci-public-validation
+        run: ./infra/oci/agents/validation-loop-stan.sh
+
+      - name: Upload public validation diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: oci-migration-public-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/oci-public-validation
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/oci-production-deploy.yml
+++ b/.github/workflows/oci-production-deploy.yml
@@ -34,6 +34,8 @@ jobs:
     if: github.run_attempt == 1
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    outputs:
+      public_url: ${{ steps.provenance.outputs.public_url }}
     environment:
       name: oci-production
     env:
@@ -253,6 +255,7 @@ jobs:
           OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
           OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
           OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_K3S_SSH_PRIVATE_KEY: ${{ secrets.OCI_K3S_SSH_PRIVATE_KEY }}
           INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env
           SESSION_STATE_FILE: artifacts/oci-deploy/k3s-access.env
           WORK_DIR: ${{ runner.temp }}/betstan-k3s-access
@@ -263,12 +266,6 @@ jobs:
           )"
           export RUNNER_PUBLIC_IPV4
           ./infra/oci/scripts/configure-k3s-access.sh open
-
-      - name: Install browser validation dependencies
-        run: |
-          cd client
-          npm ci
-          npx playwright install --with-deps chromium
 
       - name: Deploy immutable images sequentially
         id: apply
@@ -286,7 +283,7 @@ jobs:
           OUTPUT_DIR: artifacts/oci-deploy
         run: ./infra/oci/scripts/deploy.sh
 
-      - name: Run complete OCI deploy validation loop
+      - name: Run protected OCI cluster validation loop
         id: health
         env:
           OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
@@ -299,6 +296,8 @@ jobs:
           OCI_RABBITMQ_BASELINE_FILE: artifacts/oci-deploy/rabbitmq-baseline.txt
           OCI_EXPECTED_SOURCE_SHA: ${{ env.SOURCE_SHA }}
           OCI_PUBLIC_URL: ${{ steps.provenance.outputs.public_url }}
+          OCI_PUBLIC_CHECKS_ALREADY_PASSED: "1"
+          OCI_E2E_ALREADY_PASSED: "1"
           OUTPUT_DIR: artifacts/oci-deploy-validation
         run: ./infra/oci/agents/deploy-validation-loop-stan.sh
 
@@ -369,3 +368,53 @@ jobs:
         run: |
           rm -rf "$HOME"
           rm -f artifacts/oci-deploy/rendered.yaml
+
+  public-validate:
+    needs: deploy
+    if: github.run_attempt == 1 && needs.deploy.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: oci-production
+    steps:
+      - name: Checkout exact deployed commit without credentials
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.approved_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate public-check identity
+        env:
+          SOURCE_SHA: ${{ inputs.approved_sha }}
+          OCI_PUBLIC_URL: ${{ needs.deploy.outputs.public_url }}
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [ "$GITHUB_RUN_ATTEMPT" = "1" ]
+          [ "$(git rev-parse HEAD)" = "$SOURCE_SHA" ]
+          [[ "$OCI_PUBLIC_URL" =~ ^https://[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\.nip\.io$ ]]
+
+      - name: Install browser validation dependencies
+        run: |
+          cd client
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run public OCI validation without cloud credentials
+        env:
+          OCI_PUBLIC_URL: ${{ needs.deploy.outputs.public_url }}
+          OCI_CLUSTER_CHECKS_ALREADY_PASSED: "1"
+          MAX_LOOPS: "3"
+          SLEEP_SECONDS: "20"
+          OUTPUT_DIR: artifacts/oci-public-validation
+        run: ./infra/oci/agents/validation-loop-stan.sh
+
+      - name: Upload public validation diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: oci-public-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/oci-public-validation
+          if-no-files-found: ignore
+          retention-days: 14

--- a/infra/azure/agents/production-workflow-inventory-stan.rb
+++ b/infra/azure/agents/production-workflow-inventory-stan.rb
@@ -152,8 +152,8 @@ def validate_scheduled_oci_workflow!(name, document, content)
   dispatch = triggers["workflow_dispatch"]
   inputs = dispatch.is_a?(Hash) ? dispatch["inputs"] : nil
   approved_sha = inputs.is_a?(Hash) ? inputs["approved_sha"] : nil
-  unless approved_sha.is_a?(Hash)
-    fail_inventory("#{name} must define the optional approved_sha dispatch input")
+  unless approved_sha.is_a?(Hash) && approved_sha["required"] == true
+    fail_inventory("#{name} must require the approved_sha dispatch input")
   end
 
   require_content(
@@ -174,7 +174,12 @@ def validate_scheduled_oci_workflow!(name, document, content)
   require_content(
     content,
     /vars\.OCI_CAPACITY_CATCHER_ENABLED\s*==\s*['"]true['"]/,
-    "#{name} must retain the explicit activation kill switch"
+    "#{name} schedule must retain the explicit activation kill switch"
+  )
+  require_content(
+    content,
+    /github\.event_name\s*==\s*['"]workflow_dispatch['"]/,
+    "#{name} must permit an audited manual attempt independently of scheduling"
   )
   require_content(
     content,

--- a/infra/azure/agents/test-production-workflow-inventory-stan.sh
+++ b/infra/azure/agents/test-production-workflow-inventory-stan.sh
@@ -37,10 +37,11 @@ on:
   workflow_dispatch:
     inputs:
       approved_sha:
+        required: true
         type: string
 jobs:
   acquire:
-    if: github.run_attempt == 1 && vars.OCI_CAPACITY_CATCHER_ENABLED == 'true'
+    if: github.run_attempt == 1 && ((github.event_name == 'schedule' && vars.OCI_CAPACITY_CATCHER_ENABLED == 'true') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment:
       name: oci-capacity-acquire
@@ -305,10 +306,24 @@ assert_fail "schedule-only capacity workflow" "must have schedule and workflow_d
 
 reset_fixtures
 write_complete_oci_set
+sed -i.bak '/required: true/d' "$tmp_dir/oci-capacity-acquire.yml"
+rm "$tmp_dir/oci-capacity-acquire.yml.bak"
+assert_fail "optional manual capacity SHA" "must require the approved_sha dispatch input"
+
+reset_fixtures
+write_complete_oci_set
 sed -i.bak "s/vars.OCI_CAPACITY_CATCHER_ENABLED == 'true'/true/" \
   "$tmp_dir/oci-capacity-acquire.yml"
 rm "$tmp_dir/oci-capacity-acquire.yml.bak"
-assert_fail "capacity workflow without kill switch" "must retain the explicit activation kill switch"
+assert_fail "capacity workflow without kill switch" "schedule must retain the explicit activation kill switch"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak "s/ || github.event_name == 'workflow_dispatch'//" \
+  "$tmp_dir/oci-capacity-acquire.yml"
+rm "$tmp_dir/oci-capacity-acquire.yml.bak"
+assert_fail "capacity workflow without manual bypass" \
+  "must permit an audited manual attempt independently of scheduling"
 
 reset_fixtures
 write_complete_oci_set

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -62,6 +62,12 @@ The GitHub environments use the variables and secrets approved in the plan:
 - Registry authentication is direct `docker login` with
   `OCI_REGISTRY_USERNAME` and `OCI_REGISTRY_AUTH_TOKEN`. The build workflow
   never receives an OCI API signing key.
+- Direct k3s uses one unencrypted ED25519 host key pair. Store only
+  `OCI_K3S_SSH_PUBLIC_KEY` in `oci-capacity-acquire`; store
+  `OCI_K3S_SSH_PRIVATE_KEY` as a protected secret in `oci-infrastructure`,
+  `oci-production`, and `oci-migration`. The private key is exposed only to
+  each workflow's k3s access-opening step, is checked against acquisition
+  provenance, and is deleted as soon as target SSH is no longer required.
 
 Additional account-derived variables are intentionally required:
 
@@ -110,10 +116,15 @@ fixtures.
    The `oci-capacity-acquire` workflow checks every Frankfurt AD every five
    minutes, makes at most one real launch attempt per run, and permanently
    stops launching after one valid managed VM exists.
+   Keep the variable `false` for an isolated manual attempt; a manual dispatch
+   requires the exact current master SHA and does not enable scheduled runs.
 5. Dispatch `oci-infrastructure` with phase `finalize` after acquisition.
-   `scripts/configure-k3s-access.sh` opens ephemeral Bastion access and
-   `scripts/finalize-k3s.sh` mounts the Mongo volume, installs ingress-nginx
-   and cert-manager, and reconciles the fixed 10/10 Mbps OCI load balancer.
+   `scripts/configure-k3s-access.sh` opens separate ephemeral Bastion
+   port-forwarding sessions for target SSH and the k3s API. This avoids
+   Managed SSH, which OCI Bastion does not support for Ubuntu on Ampere A1.
+   `scripts/finalize-k3s.sh` then mounts the Mongo volume, installs
+   ingress-nginx and cert-manager, and reconciles the fixed 10/10 Mbps OCI
+   load balancer.
 6. `scripts/deploy.sh` creates secrets without logging values, renders exact
    image digests, and deploys Mongo, RabbitMQ, backends, client, and ingress
    sequentially.

--- a/infra/oci/agents/test-health-contract-stan.sh
+++ b/infra/oci/agents/test-health-contract-stan.sh
@@ -120,4 +120,48 @@ if PATH="$WORK_DIR/bin:$PATH" STUB_BAD_API=1 \
 fi
 grep -Eq 'API returned (non-JSON content|invalid JSON)' "$WORK_DIR/smoke-bad.out"
 
-echo "oci_health_fixture_contract=PASS scenarios=22"
+cat > "$WORK_DIR/bin/playwright" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'playwright-ran\n' >> "${STUB_PLAYWRIGHT_LOG:?}"
+STUB
+chmod +x "$WORK_DIR/bin/playwright"
+: > "$WORK_DIR/playwright.log"
+
+OCI_HEALTH_FIXTURE_FILE="$HEALTHY" \
+OCI_PUBLIC_URL=https://203.0.113.10.nip.io \
+OCI_PUBLIC_CHECKS_ALREADY_PASSED=1 \
+OCI_E2E_ALREADY_PASSED=1 \
+MAX_LOOPS=1 \
+SLEEP_SECONDS=1 \
+OUTPUT_DIR="$WORK_DIR/cluster-only" \
+  "$OCI_DIR/agents/validation-loop-stan.sh" |
+  grep -q 'oci_validation_loop=PASS'
+[[ ! -s "$WORK_DIR/playwright.log" ]] ||
+  { echo "cluster-only validation executed browser code" >&2; exit 1; }
+
+PATH="$WORK_DIR/bin:$PATH" \
+PLAYWRIGHT_BIN="$WORK_DIR/bin/playwright" \
+STUB_PLAYWRIGHT_LOG="$WORK_DIR/playwright.log" \
+OCI_PUBLIC_URL=https://203.0.113.10.nip.io \
+OCI_CLUSTER_CHECKS_ALREADY_PASSED=1 \
+MAX_LOOPS=1 \
+SLEEP_SECONDS=1 \
+OUTPUT_DIR="$WORK_DIR/public-only" \
+  "$OCI_DIR/agents/validation-loop-stan.sh" |
+  grep -q 'oci_validation_loop=PASS'
+grep -Fq 'playwright-ran' "$WORK_DIR/playwright.log" ||
+  { echo "public-only validation skipped browser checks" >&2; exit 1; }
+
+if OCI_PUBLIC_URL=https://203.0.113.10.nip.io \
+    OCI_PUBLIC_CHECKS_ALREADY_PASSED=1 \
+    OCI_E2E_ALREADY_PASSED=1 \
+    OCI_CLUSTER_CHECKS_ALREADY_PASSED=1 \
+    MAX_LOOPS=1 \
+    SLEEP_SECONDS=1 \
+      "$OCI_DIR/agents/validation-loop-stan.sh" >/dev/null 2>&1; then
+  echo "validation loop accepted skipping both public and cluster checks" >&2
+  exit 1
+fi
+
+echo "oci_health_fixture_contract=PASS scenarios=25"

--- a/infra/oci/agents/validation-loop-stan.sh
+++ b/infra/oci/agents/validation-loop-stan.sh
@@ -7,6 +7,10 @@ MAX_LOOPS="${MAX_LOOPS:-3}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-20}"
 OUTPUT_DIR="${OUTPUT_DIR:-$ROOT_DIR/artifacts/oci-validation-loop}"
 OCI_PUBLIC_URL="${OCI_PUBLIC_URL:-}"
+PLAYWRIGHT_BIN="${PLAYWRIGHT_BIN:-$ROOT_DIR/client/node_modules/.bin/playwright}"
+OCI_PUBLIC_CHECKS_ALREADY_PASSED="${OCI_PUBLIC_CHECKS_ALREADY_PASSED:-0}"
+OCI_E2E_ALREADY_PASSED="${OCI_E2E_ALREADY_PASSED:-0}"
+OCI_CLUSTER_CHECKS_ALREADY_PASSED="${OCI_CLUSTER_CHECKS_ALREADY_PASSED:-0}"
 
 [[ "$MAX_LOOPS" =~ ^[1-9][0-9]*$ ]] || {
   echo "NO_GO validation_reason=MAX_LOOPS must be positive" >&2
@@ -20,26 +24,50 @@ OCI_PUBLIC_URL="${OCI_PUBLIC_URL:-}"
   echo "NO_GO validation_reason=OCI_PUBLIC_URL is required" >&2
   exit 1
 }
+for value in \
+  OCI_PUBLIC_CHECKS_ALREADY_PASSED OCI_E2E_ALREADY_PASSED \
+  OCI_CLUSTER_CHECKS_ALREADY_PASSED; do
+  [[ "${!value}" == "0" || "${!value}" == "1" ]] || {
+    echo "NO_GO validation_reason=$value must be 0 or 1" >&2
+    exit 1
+  }
+done
+[[ "$OCI_PUBLIC_CHECKS_ALREADY_PASSED" == "$OCI_E2E_ALREADY_PASSED" ]] || {
+  echo "NO_GO validation_reason=public and e2e prechecks must be paired" >&2
+  exit 1
+}
+[[ "$OCI_PUBLIC_CHECKS_ALREADY_PASSED" != "1" ||
+   "$OCI_CLUSTER_CHECKS_ALREADY_PASSED" != "1" ]] || {
+  echo "NO_GO validation_reason=validation cannot skip both public and cluster checks" >&2
+  exit 1
+}
 mkdir -p "$OUTPUT_DIR"
 
 for attempt in $(seq 1 "$MAX_LOOPS"); do
   echo "oci_validation_iteration=${attempt}/${MAX_LOOPS}"
-  if OCI_PUBLIC_URL="$OCI_PUBLIC_URL" OUTPUT_DIR="$OUTPUT_DIR/smoke-${attempt}" \
+  public_ok=false
+  if [[ "$OCI_PUBLIC_CHECKS_ALREADY_PASSED" == "1" ]]; then
+    public_ok=true
+  elif OCI_PUBLIC_URL="$OCI_PUBLIC_URL" \
+      OUTPUT_DIR="$OUTPUT_DIR/smoke-${attempt}" \
       "$OCI_DIR/agents/smoke-liveness-stan.sh"; then
-    playwright="$ROOT_DIR/client/node_modules/.bin/playwright"
-    if [[ -x "$playwright" ]] && (
+    if [[ -x "$PLAYWRIGHT_BIN" ]] && (
       cd "$ROOT_DIR"
       NODE_PATH="$ROOT_DIR/client/node_modules" \
       E2E_BASE_URL="$OCI_PUBLIC_URL" \
       OCI_E2E_OUTPUT_DIR="$OUTPUT_DIR/e2e-${attempt}" \
-        "$playwright" test --config "$OCI_DIR/agents/playwright.config.js"
+        "$PLAYWRIGHT_BIN" test --config "$OCI_DIR/agents/playwright.config.js"
     ); then
-      if OCI_PUBLIC_CHECKS_ALREADY_PASSED=1 OCI_E2E_ALREADY_PASSED=1 \
+      public_ok=true
+    fi
+  fi
+  if [[ "$public_ok" == "true" ]]; then
+    if [[ "$OCI_CLUSTER_CHECKS_ALREADY_PASSED" == "1" ]] ||
+        OCI_PUBLIC_CHECKS_ALREADY_PASSED=1 OCI_E2E_ALREADY_PASSED=1 \
           OUTPUT_DIR="$OUTPUT_DIR/health-${attempt}" \
           "$OCI_DIR/agents/health-check-stan.sh"; then
-        echo "oci_validation_loop=PASS"
-        exit 0
-      fi
+      echo "oci_validation_loop=PASS"
+      exit 0
     fi
   fi
   if [[ "$attempt" -lt "$MAX_LOOPS" ]]; then

--- a/infra/oci/scripts/capacity-common.sh
+++ b/infra/oci/scripts/capacity-common.sh
@@ -11,6 +11,7 @@ oci_capacity_require_contract() {
   oci_assert_repository_root
   oci_require_command jq
   oci_require_command python3
+  oci_require_command ssh-keygen
   oci_require_vars \
     OCI_REGION OCI_TENANCY_OCID OCI_COMPARTMENT_OCID OCI_COMPARTMENT_NAME \
     OCI_CAPACITY_QUOTA_NAME OCI_VCN_NAME OCI_K3S_INSTANCE_NAME \
@@ -33,8 +34,7 @@ oci_capacity_require_contract() {
     oci_die "OCI_K3S_VERSION must be a pinned k3s release"
   [[ "$OCI_K3S_BINARY_SHA256" =~ ^[0-9a-f]{64}$ ]] ||
     oci_die "OCI_K3S_BINARY_SHA256 must be a lowercase SHA256"
-  [[ "$OCI_K3S_SSH_PUBLIC_KEY" =~ ^ssh-(ed25519|rsa)[[:space:]][A-Za-z0-9+/=]+([[:space:]].*)?$ ]] ||
-    oci_die "OCI_K3S_SSH_PUBLIC_KEY must be an SSH public key"
+  oci_ssh_ed25519_public_key_sha256 "$OCI_K3S_SSH_PUBLIC_KEY" >/dev/null
   oci_require_ocid OCI_TENANCY_OCID
   oci_require_ocid OCI_COMPARTMENT_OCID
   oci_require_ocid OCI_K3S_IMAGE_OCID

--- a/infra/oci/scripts/configure-k3s-access.sh
+++ b/infra/oci/scripts/configure-k3s-access.sh
@@ -11,9 +11,11 @@ ACQUISITION_PROVENANCE_FILE="${ACQUISITION_PROVENANCE_FILE:-}"
 SESSION_STATE_FILE="${SESSION_STATE_FILE:-}"
 WORK_DIR="${WORK_DIR:-${RUNNER_TEMP:-/tmp}/betstan-k3s-access}"
 KUBECONFIG="${KUBECONFIG:-$WORK_DIR/kubeconfig}"
+OCI_K3S_LOCAL_SSH_PORT="${OCI_K3S_LOCAL_SSH_PORT:-12222}"
 OCI_K3S_LOCAL_API_PORT="${OCI_K3S_LOCAL_API_PORT:-16443}"
 OCI_BASTION_SESSION_TTL="${OCI_BASTION_SESSION_TTL:-10800}"
 OCI_K3S_OS_USER="${OCI_K3S_OS_USER:-ubuntu}"
+OCI_K3S_RETAIN_TARGET_SSH="${OCI_K3S_RETAIN_TARGET_SSH:-false}"
 OCI_BASTION_DEFAULT_CLIENT_CIDR="${OCI_BASTION_DEFAULT_CLIENT_CIDR:-192.0.2.1/32}"
 
 [[ "$MODE" == "open" || "$MODE" == "cleanup" ]] ||
@@ -25,7 +27,7 @@ OCI_BASTION_DEFAULT_CLIENT_CIDR="${OCI_BASTION_DEFAULT_CLIENT_CIDR:-192.0.2.1/32
 
 delete_session() {
   local session_id="${1:-}"
-  [[ -n "$session_id" ]] || return
+  [[ -n "$session_id" ]] || return 0
   oci bastion session delete \
     --session-id "$session_id" \
     --force \
@@ -33,9 +35,31 @@ delete_session() {
     --max-wait-seconds 300 >/dev/null
 }
 
+release_target_ssh() {
+  local failed=0
+  if stop_tunnel "$ssh_tunnel_pid"; then
+    ssh_tunnel_pid=""
+  else
+    failed=1
+  fi
+  if delete_session "$ssh_session_id"; then
+    ssh_session_id=""
+    ssh_session_name=""
+  else
+    failed=1
+  fi
+  rm -f -- \
+    "$target_private_key" \
+    "$target_public_key" \
+    "$target_known_hosts" || failed=1
+  write_session_state
+  [[ "$failed" == "0" ]] ||
+    oci_die "target SSH access could not be fully revoked"
+}
+
 reset_bastion_allowlist() {
   local bastion_id="${1:-}"
-  [[ -n "$bastion_id" ]] || return
+  [[ -n "$bastion_id" ]] || return 0
   oci bastion bastion update \
     --bastion-id "$bastion_id" \
     --client-cidr-list "[\"$OCI_BASTION_DEFAULT_CLIENT_CIDR\"]" \
@@ -103,35 +127,104 @@ wait_active_session_id() {
   oci_die "OCI Bastion session did not become ACTIVE"
 }
 
+session_endpoint() {
+  local session_id="$1"
+  local target_port="$2"
+  local session expected_endpoint expected_command actual_command
+  expected_endpoint="host.bastion.${OCI_CLI_REGION}.oci.oraclecloud.com"
+  expected_command="ssh -i <privateKey> -N -L <localPort>:${instance_private_ip}:${target_port} -p 22 ${session_id}@${expected_endpoint}"
+  session="$(oci bastion session get --session-id "$session_id")"
+  jq -e \
+    --arg session_id "$session_id" \
+    --arg instance_id "$instance_ocid" \
+    --arg private_ip "$instance_private_ip" \
+    --argjson target_port "$target_port" '
+      .data.id == $session_id and
+      .data."lifecycle-state" == "ACTIVE" and
+      .data."target-resource-details"."session-type" == "PORT_FORWARDING" and
+      .data."target-resource-details"."target-resource-id" == $instance_id and
+      .data."target-resource-details"."target-resource-private-ip-address" == $private_ip and
+      .data."target-resource-details"."target-resource-port" == $target_port
+    ' <<<"$session" >/dev/null ||
+    oci_die "OCI Bastion session target differs from the requested port forward"
+  actual_command="$(jq -r '.data."ssh-metadata".command // empty' <<<"$session")"
+  [[ "$actual_command" == "$expected_command" ]] ||
+    oci_die "OCI Bastion SSH metadata differs from the requested port forward"
+  printf '%s' "$expected_endpoint"
+}
+
+write_session_state() {
+  local state_dir state_tmp
+  state_dir="$(dirname "$SESSION_STATE_FILE")"
+  state_tmp="${SESSION_STATE_FILE}.tmp"
+  mkdir -p "$state_dir"
+  umask 077
+  {
+    printf 'bastion_ocid=%q\n' "$bastion_ocid"
+    printf 'ssh_session_id=%q\n' "$ssh_session_id"
+    printf 'ssh_session_name=%q\n' "$ssh_session_name"
+    printf 'api_session_id=%q\n' "$api_session_id"
+    printf 'api_session_name=%q\n' "$api_session_name"
+    printf 'ssh_tunnel_pid=%q\n' "$ssh_tunnel_pid"
+    printf 'api_tunnel_pid=%q\n' "$api_tunnel_pid"
+    printf 'key_dir=%q\n' "$key_dir"
+    printf 'bastion_endpoint=%q\n' "$bastion_endpoint"
+    printf 'target_private_key=%q\n' "$target_private_key"
+    printf 'target_known_hosts=%q\n' "$target_known_hosts"
+    printf 'instance_private_ip=%q\n' "$instance_private_ip"
+    printf 'os_user=%q\n' "$OCI_K3S_OS_USER"
+    printf 'local_ssh_port=%q\n' "$OCI_K3S_LOCAL_SSH_PORT"
+  } > "$state_tmp"
+  mv -f "$state_tmp" "$SESSION_STATE_FILE"
+  chmod 600 "$SESSION_STATE_FILE"
+}
+
+stop_tunnel() {
+  local tunnel_pid="${1:-}"
+  [[ -n "$tunnel_pid" ]] || return 0
+  if kill -0 "$tunnel_pid" 2>/dev/null; then
+    kill "$tunnel_pid"
+    wait "$tunnel_pid" 2>/dev/null || true
+  fi
+}
+
 cleanup_access() {
-  local pf_session_id="" managed_session_id="" tunnel_pid="" key_dir=""
-  local pf_session_name="" managed_session_name="" bastion_ocid=""
-  local failed=0
+  local ssh_session_id="" api_session_id=""
+  local ssh_session_name="" api_session_name=""
+  local ssh_tunnel_pid="" api_tunnel_pid=""
+  local key_dir="" bastion_ocid="" bastion_endpoint=""
+  local failed=0 resolved_session_id=""
   if [[ -f "$SESSION_STATE_FILE" ]]; then
     # shellcheck disable=SC1090
     source "$SESSION_STATE_FILE"
   fi
-  if [[ -z "$pf_session_id" && -n "$bastion_ocid" && -n "$pf_session_name" ]]; then
-    pf_session_id="$(resolve_session_id "$bastion_ocid" "$pf_session_name")" ||
-      failed=1
+  if [[ -n "$bastion_ocid" && -n "$ssh_session_name" ]]; then
+    resolved_session_id="$(
+      resolve_session_id "$bastion_ocid" "$ssh_session_name"
+    )" && ssh_session_id="$resolved_session_id" || failed=1
   fi
-  if [[ -z "$managed_session_id" && -n "$bastion_ocid" &&
-        -n "$managed_session_name" ]]; then
-    managed_session_id="$(
-      resolve_session_id "$bastion_ocid" "$managed_session_name"
-    )" || failed=1
+  if [[ -n "$bastion_ocid" && -n "$api_session_name" ]]; then
+    resolved_session_id="$(
+      resolve_session_id "$bastion_ocid" "$api_session_name"
+    )" && api_session_id="$resolved_session_id" || failed=1
   fi
-  if [[ -n "$tunnel_pid" ]] && kill -0 "$tunnel_pid" 2>/dev/null; then
-    kill "$tunnel_pid" || failed=1
-    wait "$tunnel_pid" 2>/dev/null || true
-  fi
-  delete_session "$pf_session_id" || failed=1
-  delete_session "$managed_session_id" || failed=1
+  stop_tunnel "$api_tunnel_pid" || failed=1
+  stop_tunnel "$ssh_tunnel_pid" || failed=1
+  delete_session "$api_session_id" || failed=1
+  delete_session "$ssh_session_id" || failed=1
   reset_bastion_allowlist "$bastion_ocid" || failed=1
   rm -f -- "$KUBECONFIG" || failed=1
-  rm -f "$SESSION_STATE_FILE" || failed=1
+  rm -f -- \
+    "${SESSION_STATE_FILE}.tmp" \
+    "$WORK_DIR/bastion-api-tunnel.log" \
+    "$WORK_DIR/bastion-ssh-tunnel.log" || failed=1
   if [[ -n "$key_dir" && "$key_dir" == "$WORK_DIR/"* ]]; then
     rm -rf -- "$key_dir" || failed=1
+  fi
+  if [[ "$failed" == "0" ]]; then
+    rm -f -- "$SESSION_STATE_FILE" || failed=1
+  elif [[ -f "$SESSION_STATE_FILE" ]]; then
+    chmod 600 "$SESSION_STATE_FILE" || true
   fi
   [[ "$failed" == "0" ]] ||
     oci_die "k3s access cleanup could not revoke every remote and local artifact"
@@ -144,6 +237,15 @@ cleanup_open_failure() {
     cleanup_access || status=1
   fi
   exit "$status"
+}
+
+validate_local_port() {
+  local name="$1"
+  local value="$2"
+  [[ "$value" =~ ^[1-9][0-9]{3,4}$ ]] ||
+    oci_die "$name must be an unprivileged TCP port"
+  (( value >= 1024 && value <= 65535 )) ||
+    oci_die "$name must be in the unprivileged TCP port range"
 }
 
 if [[ "$MODE" == "cleanup" ]]; then
@@ -160,16 +262,23 @@ oci_require_command jq
 oci_require_command kubectl
 oci_require_command ssh
 oci_require_command ssh-keygen
-oci_require_vars OCI_COMPARTMENT_OCID RUNNER_PUBLIC_IPV4
+oci_require_vars \
+  OCI_COMPARTMENT_OCID OCI_CLI_REGION OCI_K3S_SSH_PRIVATE_KEY \
+  RUNNER_PUBLIC_IPV4
 oci_require_ocid OCI_COMPARTMENT_OCID
 oci_validate_public_ipv4 "$RUNNER_PUBLIC_IPV4" ||
   oci_die "RUNNER_PUBLIC_IPV4 must be a globally routable IPv4"
-[[ "$OCI_K3S_LOCAL_API_PORT" =~ ^[1-9][0-9]{3,4}$ ]] ||
-  oci_die "OCI_K3S_LOCAL_API_PORT must be an unprivileged TCP port"
-(( OCI_K3S_LOCAL_API_PORT <= 65535 )) ||
-  oci_die "OCI_K3S_LOCAL_API_PORT exceeds the TCP port range"
+validate_local_port OCI_K3S_LOCAL_SSH_PORT "$OCI_K3S_LOCAL_SSH_PORT"
+validate_local_port OCI_K3S_LOCAL_API_PORT "$OCI_K3S_LOCAL_API_PORT"
+[[ "$OCI_K3S_LOCAL_SSH_PORT" != "$OCI_K3S_LOCAL_API_PORT" ]] ||
+  oci_die "local SSH and k3s API ports must differ"
+[[ "$OCI_K3S_RETAIN_TARGET_SSH" == "true" ||
+   "$OCI_K3S_RETAIN_TARGET_SSH" == "false" ]] ||
+  oci_die "OCI_K3S_RETAIN_TARGET_SSH must be true or false"
 [[ "$OCI_BASTION_SESSION_TTL" =~ ^[1-9][0-9]*$ ]] ||
   oci_die "OCI_BASTION_SESSION_TTL must be a positive integer"
+(( OCI_BASTION_SESSION_TTL >= 1800 )) ||
+  oci_die "OCI_BASTION_SESSION_TTL is below the OCI Bastion minimum"
 (( OCI_BASTION_SESSION_TTL <= 10800 )) ||
   oci_die "OCI_BASTION_SESSION_TTL exceeds the OCI Bastion maximum"
 [[ -f "$INFRA_PROVENANCE_FILE" ]] ||
@@ -177,28 +286,34 @@ oci_validate_public_ipv4 "$RUNNER_PUBLIC_IPV4" ||
 
 unset runtime_mode instance_ocid cluster_ocid instance_fingerprint
 unset instance_private_ip availability_domain bastion_ocid
+unset target_ssh_public_key_sha256
 # shellcheck disable=SC1090
 source "$INFRA_PROVENANCE_FILE"
 provenance_bastion_ocid="${bastion_ocid:-}"
+expected_target_ssh_public_key_sha256="${target_ssh_public_key_sha256:-}"
 if [[ -n "$ACQUISITION_PROVENANCE_FILE" ]]; then
   [[ -f "$ACQUISITION_PROVENANCE_FILE" ]] ||
     oci_die "ACQUISITION_PROVENANCE_FILE does not exist"
   unset runtime_mode instance_ocid instance_fingerprint
   unset instance_private_ip private_ip availability_domain
+  unset target_ssh_public_key_sha256
   # shellcheck disable=SC1090
   source "$ACQUISITION_PROVENANCE_FILE"
   instance_private_ip="${instance_private_ip:-${private_ip:-}}"
   bastion_ocid="$provenance_bastion_ocid"
+  expected_target_ssh_public_key_sha256="${target_ssh_public_key_sha256:-}"
 fi
 oci_require_vars \
   runtime_mode instance_ocid instance_fingerprint instance_private_ip \
-  availability_domain bastion_ocid
+  availability_domain bastion_ocid expected_target_ssh_public_key_sha256
 [[ "$runtime_mode" == "k3s" ]] ||
   oci_die "k3s access received non-k3s infrastructure provenance"
 oci_require_ocid instance_ocid
 oci_require_ocid bastion_ocid
 [[ "$(oci_fingerprint "$instance_ocid")" == "$instance_fingerprint" ]] ||
   oci_die "k3s instance provenance fingerprint mismatch"
+[[ "$expected_target_ssh_public_key_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+  oci_die "k3s target SSH public-key fingerprint is invalid"
 
 instance="$(
   oci compute instance get --instance-id "$instance_ocid"
@@ -239,11 +354,35 @@ live_private_ip="$(jq -r '.data."private-ip" // empty' <<<"$vnic")"
 bastion="$(
   oci bastion bastion get --bastion-id "$bastion_ocid"
 )"
-bastion_endpoint="$(jq -r '.data."bastion-endpoint" // empty' <<<"$bastion")"
-[[ "$(jq -r '.data."lifecycle-state"' <<<"$bastion")" == "ACTIVE" ]] ||
-  oci_die "OCI Bastion is not ACTIVE"
-[[ "$bastion_endpoint" =~ ^[A-Za-z0-9.-]+$ ]] ||
-  oci_die "OCI Bastion endpoint is invalid"
+jq -e \
+  --arg compartment "$OCI_COMPARTMENT_OCID" \
+  --argjson ttl "$OCI_BASTION_SESSION_TTL" '
+    .data."compartment-id" == $compartment and
+    .data."bastion-type" == "STANDARD" and
+    .data."lifecycle-state" == "ACTIVE" and
+    .data."max-session-ttl-in-seconds" >= $ttl
+  ' <<<"$bastion" >/dev/null ||
+  oci_die "OCI Bastion identity or session limit differs from the access contract"
+
+oci_prepare_private_dir "$WORK_DIR"
+key_dir="$WORK_DIR/bastion-keys"
+oci_prepare_private_dir "$key_dir"
+bastion_private_key="$key_dir/bastion_id_ed25519"
+bastion_public_key="${bastion_private_key}.pub"
+target_private_key="$key_dir/target_id_ed25519"
+target_public_key="${target_private_key}.pub"
+bastion_known_hosts="$key_dir/bastion_known_hosts"
+target_known_hosts="$key_dir/target_known_hosts"
+ssh_session_id=""
+api_session_id=""
+ssh_tunnel_pid=""
+api_tunnel_pid=""
+bastion_endpoint=""
+run_identity="${GITHUB_RUN_ID:-local-$PPID}-${GITHUB_RUN_ATTEMPT:-1}"
+ssh_session_name="betstan-k3s-ssh-${run_identity}"
+api_session_name="betstan-k3s-api-${run_identity}"
+write_session_state
+trap cleanup_open_failure EXIT
 
 runner_cidr="$(jq -cn --arg cidr "${RUNNER_PUBLIC_IPV4}/32" '[$cidr]')"
 oci bastion bastion update \
@@ -253,102 +392,78 @@ oci bastion bastion update \
   --wait-for-state SUCCEEDED \
   --max-wait-seconds 300 >/dev/null
 
-oci_prepare_private_dir "$WORK_DIR"
-key_dir="$WORK_DIR/bastion-keys"
-oci_prepare_private_dir "$key_dir"
-private_key="$key_dir/id_ed25519"
-public_key="${private_key}.pub"
-known_hosts="$key_dir/known_hosts"
-managed_session_id=""
-pf_session_id=""
-tunnel_pid=""
-managed_session_name="betstan-k3s-managed-${GITHUB_RUN_ID:-local}"
-pf_session_name="betstan-k3s-api-${GITHUB_RUN_ID:-local}"
-{
-  printf 'bastion_ocid=%q\n' "$bastion_ocid"
-  printf 'managed_session_id=%q\n' "$managed_session_id"
-  printf 'managed_session_name=%q\n' "$managed_session_name"
-  printf 'pf_session_id=%q\n' "$pf_session_id"
-  printf 'pf_session_name=%q\n' "$pf_session_name"
-  printf 'tunnel_pid=%q\n' "$tunnel_pid"
-  printf 'key_dir=%q\n' "$key_dir"
-  printf 'bastion_endpoint=%q\n' "$bastion_endpoint"
-  printf 'private_key=%q\n' "$private_key"
-  printf 'known_hosts=%q\n' "$known_hosts"
-  printf 'instance_private_ip=%q\n' "$instance_private_ip"
-  printf 'os_user=%q\n' "$OCI_K3S_OS_USER"
-} > "$SESSION_STATE_FILE"
-chmod 600 "$SESSION_STATE_FILE"
-trap cleanup_open_failure EXIT
 ssh-keygen \
   -q -t ed25519 \
-  -C "betstan-bastion-${GITHUB_RUN_ID:-local}" \
+  -C "betstan-bastion-${run_identity}" \
   -N "" \
-  -f "$private_key"
-chmod 600 "$private_key"
+  -f "$bastion_private_key"
+chmod 600 "$bastion_private_key"
+printf '%s\n' "$OCI_K3S_SSH_PRIVATE_KEY" > "$target_private_key"
+unset OCI_K3S_SSH_PRIVATE_KEY
+chmod 600 "$target_private_key"
+ssh-keygen -y -P "" -f "$target_private_key" > "$target_public_key" ||
+  oci_die "OCI_K3S_SSH_PRIVATE_KEY is not an unencrypted ED25519 key"
+actual_target_ssh_public_key_sha256="$(
+  oci_ssh_ed25519_public_key_sha256 "$(cat "$target_public_key")"
+)"
+[[ "$actual_target_ssh_public_key_sha256" == \
+   "$expected_target_ssh_public_key_sha256" ]] ||
+  oci_die "target SSH private key does not match acquisition provenance"
 
-plugin_ready=0
-for _ in $(seq 1 60); do
-  plugin_status="$(
-    oci instance-agent plugin get \
-      --instanceagent-id "$instance_ocid" \
-      --compartment-id "$OCI_COMPARTMENT_OCID" \
-      --plugin-name Bastion \
-      --query 'data.status' \
-      --raw-output 2>/dev/null || true
-  )"
-  if [[ "$plugin_status" == "RUNNING" ]]; then
-    plugin_ready=1
-    break
-  fi
-  sleep 10
-done
-[[ "$plugin_ready" == "1" ]] ||
-  oci_die "OCI Bastion agent plugin did not become RUNNING"
-
-oci bastion session create-managed-ssh \
+oci bastion session create-port-forwarding \
   --bastion-id "$bastion_ocid" \
-  --display-name "$managed_session_name" \
+  --display-name "$ssh_session_name" \
   --key-type PUB \
-  --ssh-public-key-file "$public_key" \
+  --ssh-public-key-file "$bastion_public_key" \
   --session-ttl "$OCI_BASTION_SESSION_TTL" \
   --target-resource-id "$instance_ocid" \
   --target-private-ip "$instance_private_ip" \
   --target-port 22 \
-  --target-os-username "$OCI_K3S_OS_USER" \
   --wait-for-state SUCCEEDED \
   --max-wait-seconds 600 >/dev/null
-managed_session_id="$(
-  wait_active_session_id "$bastion_ocid" "$managed_session_name"
+ssh_session_id="$(
+  wait_active_session_id "$bastion_ocid" "$ssh_session_name"
 )"
-{
-  printf 'bastion_ocid=%q\n' "$bastion_ocid"
-  printf 'managed_session_id=%q\n' "$managed_session_id"
-  printf 'managed_session_name=%q\n' "$managed_session_name"
-  printf 'pf_session_id=%q\n' "$pf_session_id"
-  printf 'pf_session_name=%q\n' "$pf_session_name"
-  printf 'tunnel_pid=%q\n' "$tunnel_pid"
-  printf 'key_dir=%q\n' "$key_dir"
-  printf 'bastion_endpoint=%q\n' "$bastion_endpoint"
-  printf 'private_key=%q\n' "$private_key"
-  printf 'known_hosts=%q\n' "$known_hosts"
-  printf 'instance_private_ip=%q\n' "$instance_private_ip"
-  printf 'os_user=%q\n' "$OCI_K3S_OS_USER"
-} > "$SESSION_STATE_FILE"
+bastion_endpoint="$(session_endpoint "$ssh_session_id" 22)"
+write_session_state
 
-printf -v quoted_private_key '%q' "$private_key"
-printf -v quoted_known_hosts '%q' "$known_hosts"
-proxy_command="ssh -i $quoted_private_key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=$quoted_known_hosts -W %h:%p -p 22 ${managed_session_id}@${bastion_endpoint}"
+ssh \
+  -i "$bastion_private_key" \
+  -N \
+  -L "127.0.0.1:${OCI_K3S_LOCAL_SSH_PORT}:${instance_private_ip}:22" \
+  -o BatchMode=yes \
+  -o ExitOnForwardFailure=yes \
+  -o IdentitiesOnly=yes \
+  -o ServerAliveInterval=30 \
+  -o ServerAliveCountMax=3 \
+  -o StrictHostKeyChecking=accept-new \
+  -o UserKnownHostsFile="$bastion_known_hosts" \
+  -p 22 \
+  "${ssh_session_id}@${bastion_endpoint}" \
+  >"$WORK_DIR/bastion-ssh-tunnel.log" 2>&1 &
+ssh_tunnel_pid=$!
+write_session_state
+
+target_ssh_options=(
+  -i "$target_private_key"
+  -p "$OCI_K3S_LOCAL_SSH_PORT"
+  -o BatchMode=yes
+  -o CheckHostIP=no
+  -o ConnectTimeout=10
+  -o HostKeyAlias="$instance_ocid"
+  -o IdentitiesOnly=yes
+  -o PasswordAuthentication=no
+  -o PreferredAuthentications=publickey
+  -o StrictHostKeyChecking=accept-new
+  -o UserKnownHostsFile="$target_known_hosts"
+)
 ssh_ready=0
 for _ in $(seq 1 30); do
+  kill -0 "$ssh_tunnel_pid" 2>/dev/null ||
+    oci_die "target SSH Bastion tunnel process exited"
   if ssh \
-      -i "$private_key" \
-      -o BatchMode=yes \
-      -o ConnectTimeout=10 \
-      -o StrictHostKeyChecking=accept-new \
-      -o UserKnownHostsFile="$known_hosts" \
-      -o "ProxyCommand=$proxy_command" \
-      "${OCI_K3S_OS_USER}@${instance_private_ip}" \
+      "${target_ssh_options[@]}" \
+      "${OCI_K3S_OS_USER}@127.0.0.1" \
       'sudo test -s /etc/rancher/k3s/k3s.yaml' \
       >/dev/null 2>&1; then
     ssh_ready=1
@@ -357,16 +472,12 @@ for _ in $(seq 1 30); do
   sleep 10
 done
 [[ "$ssh_ready" == "1" ]] ||
-  oci_die "managed SSH Bastion session did not become usable"
+  oci_die "target SSH did not become usable through OCI Bastion"
+
 mkdir -p "$(dirname "$KUBECONFIG")"
 ssh \
-  -i "$private_key" \
-  -o BatchMode=yes \
-  -o ConnectTimeout=10 \
-  -o StrictHostKeyChecking=accept-new \
-  -o UserKnownHostsFile="$known_hosts" \
-  -o "ProxyCommand=$proxy_command" \
-  "${OCI_K3S_OS_USER}@${instance_private_ip}" \
+  "${target_ssh_options[@]}" \
+  "${OCI_K3S_OS_USER}@127.0.0.1" \
   'sudo cat /etc/rancher/k3s/k3s.yaml' |
   sed -E \
     "s#server: https://[^:]+:6443#server: https://127.0.0.1:${OCI_K3S_LOCAL_API_PORT}#" \
@@ -376,55 +487,47 @@ grep -Fq "server: https://127.0.0.1:${OCI_K3S_LOCAL_API_PORT}" "$KUBECONFIG" ||
   oci_die "retrieved k3s kubeconfig has an unexpected server"
 KUBECONFIG="$KUBECONFIG" kubectl config view --raw --minify >/dev/null ||
   oci_die "retrieved k3s kubeconfig is invalid"
+
 oci bastion session create-port-forwarding \
   --bastion-id "$bastion_ocid" \
-  --display-name "$pf_session_name" \
+  --display-name "$api_session_name" \
   --key-type PUB \
-  --ssh-public-key-file "$public_key" \
+  --ssh-public-key-file "$bastion_public_key" \
   --session-ttl "$OCI_BASTION_SESSION_TTL" \
   --target-resource-id "$instance_ocid" \
   --target-private-ip "$instance_private_ip" \
   --target-port 6443 \
   --wait-for-state SUCCEEDED \
   --max-wait-seconds 600 >/dev/null
-pf_session_id="$(
-  wait_active_session_id "$bastion_ocid" "$pf_session_name"
+api_session_id="$(
+  wait_active_session_id "$bastion_ocid" "$api_session_name"
 )"
+api_endpoint="$(session_endpoint "$api_session_id" 6443)"
+[[ "$api_endpoint" == "$bastion_endpoint" ]] ||
+  oci_die "OCI Bastion sessions returned different service endpoints"
+write_session_state
 
 ssh \
-  -i "$private_key" \
+  -i "$bastion_private_key" \
   -N \
   -L "127.0.0.1:${OCI_K3S_LOCAL_API_PORT}:${instance_private_ip}:6443" \
   -o BatchMode=yes \
   -o ExitOnForwardFailure=yes \
+  -o IdentitiesOnly=yes \
   -o ServerAliveInterval=30 \
   -o ServerAliveCountMax=3 \
   -o StrictHostKeyChecking=accept-new \
-  -o UserKnownHostsFile="$known_hosts" \
+  -o UserKnownHostsFile="$bastion_known_hosts" \
   -p 22 \
-  "${pf_session_id}@${bastion_endpoint}" \
-  >"$WORK_DIR/bastion-tunnel.log" 2>&1 &
-tunnel_pid=$!
-{
-  printf 'bastion_ocid=%q\n' "$bastion_ocid"
-  printf 'managed_session_id=%q\n' "$managed_session_id"
-  printf 'managed_session_name=%q\n' "$managed_session_name"
-  printf 'pf_session_id=%q\n' "$pf_session_id"
-  printf 'pf_session_name=%q\n' "$pf_session_name"
-  printf 'tunnel_pid=%q\n' "$tunnel_pid"
-  printf 'key_dir=%q\n' "$key_dir"
-  printf 'bastion_endpoint=%q\n' "$bastion_endpoint"
-  printf 'private_key=%q\n' "$private_key"
-  printf 'known_hosts=%q\n' "$known_hosts"
-  printf 'instance_private_ip=%q\n' "$instance_private_ip"
-  printf 'os_user=%q\n' "$OCI_K3S_OS_USER"
-} > "$SESSION_STATE_FILE"
-chmod 600 "$SESSION_STATE_FILE"
+  "${api_session_id}@${bastion_endpoint}" \
+  >"$WORK_DIR/bastion-api-tunnel.log" 2>&1 &
+api_tunnel_pid=$!
+write_session_state
 
 tunnel_ready=0
 for _ in $(seq 1 60); do
-  kill -0 "$tunnel_pid" 2>/dev/null ||
-    oci_die "k3s Bastion tunnel process exited"
+  kill -0 "$api_tunnel_pid" 2>/dev/null ||
+    oci_die "k3s API Bastion tunnel process exited"
   if KUBECONFIG="$KUBECONFIG" kubectl get --raw=/readyz >/dev/null 2>&1; then
     tunnel_ready=1
     break
@@ -433,5 +536,8 @@ for _ in $(seq 1 60); do
 done
 [[ "$tunnel_ready" == "1" ]] ||
   oci_die "k3s API is unavailable through OCI Bastion"
+if [[ "$OCI_K3S_RETAIN_TARGET_SSH" == "false" ]]; then
+  release_target_ssh
+fi
 trap - EXIT
-oci_log "k3s_access=PASS transport=oci-bastion"
+oci_log "k3s_access=PASS transport=oci-bastion-port-forwarding"

--- a/infra/oci/scripts/finalize-k3s.sh
+++ b/infra/oci/scripts/finalize-k3s.sh
@@ -83,7 +83,7 @@ network_prepared_value="${network_prepared:-}"
 unset source_sha runtime_mode region compartment_ocid instance_ocid
 unset instance_fingerprint availability_domain image_ocid shape ocpus memory_gb
 unset boot_volume_gb boot_volume_vpus_per_gb boot_volume_ocid
-unset vnic_ocid subnet_ocid private_ip public_ip
+unset vnic_ocid subnet_ocid private_ip public_ip target_ssh_public_key_sha256
 # shellcheck disable=SC1090
 source "$ACQUISITION_PROVENANCE_FILE"
 acquisition_source_sha="${source_sha:-}"
@@ -104,6 +104,7 @@ acquisition_vnic_ocid="${vnic_ocid:-}"
 acquisition_subnet_ocid="${subnet_ocid:-}"
 acquisition_private_ip="${private_ip:-}"
 acquisition_public_ip="${public_ip:-}"
+acquisition_target_ssh_public_key_sha256="${target_ssh_public_key_sha256:-}"
 
 for required_value in \
   "$network_source_sha" "$network_runtime_mode" "$network_region" \
@@ -119,7 +120,8 @@ for required_value in \
   "$acquisition_boot_volume_gb" "$acquisition_boot_volume_vpus" \
   "$acquisition_boot_volume_ocid" \
   "$acquisition_vnic_ocid" "$acquisition_subnet_ocid" \
-  "$acquisition_private_ip" "$acquisition_public_ip"; do
+  "$acquisition_private_ip" "$acquisition_public_ip" \
+  "$acquisition_target_ssh_public_key_sha256"; do
   [[ -n "$required_value" ]] ||
     oci_die "infrastructure or acquisition provenance is incomplete"
 done
@@ -147,6 +149,8 @@ done
   oci_die "acquisition provenance violates the approved A1 profile"
 [[ "$acquisition_image_ocid" == "$OCI_K3S_IMAGE_OCID" ]] ||
   oci_die "acquisition image differs from OCI_K3S_IMAGE_OCID"
+[[ "$acquisition_target_ssh_public_key_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+  oci_die "acquisition target SSH public-key fingerprint is invalid"
 oci_validate_public_ipv4 "$acquisition_public_ip" ||
   oci_die "acquisition provenance lacks a globally routable instance IPv4"
 
@@ -333,38 +337,45 @@ jq -e \
   ' <<<"$attachment" >/dev/null ||
   oci_die "Mongo volume attachment differs from the approved contract"
 
-unset managed_session_id bastion_endpoint private_key known_hosts
-unset instance_private_ip os_user
+unset target_private_key target_known_hosts instance_private_ip os_user
+unset local_ssh_port ssh_tunnel_pid
 # shellcheck disable=SC1090
 source "$K3S_ACCESS_STATE_FILE"
 for access_value in \
-  "${managed_session_id:-}" "${bastion_endpoint:-}" "${private_key:-}" \
-  "${known_hosts:-}" "${instance_private_ip:-}" "${os_user:-}"; do
+  "${target_private_key:-}" "${target_known_hosts:-}" \
+  "${instance_private_ip:-}" "${os_user:-}" "${local_ssh_port:-}" \
+  "${ssh_tunnel_pid:-}"; do
   [[ -n "$access_value" ]] ||
     oci_die "k3s access state is incomplete"
 done
 [[ "$instance_private_ip" == "$acquisition_private_ip" ]] ||
   oci_die "k3s access state targets an unexpected private IP"
-[[ -f "$private_key" ]] ||
-  oci_die "ephemeral Bastion SSH private key is missing"
-[[ "$bastion_endpoint" =~ ^[A-Za-z0-9.-]+$ ]] ||
-  oci_die "Bastion endpoint is invalid"
-[[ "$instance_private_ip" =~ ^[0-9.]+$ ]] ||
-  oci_die "instance private IP is invalid"
+[[ -f "$target_private_key" ]] ||
+  oci_die "target SSH private key is missing"
+[[ -f "$target_known_hosts" ]] ||
+  oci_die "target SSH known-hosts file is missing"
+[[ "$local_ssh_port" =~ ^[1-9][0-9]{3,4}$ ]] ||
+  oci_die "target SSH local port is invalid"
+(( local_ssh_port >= 1024 && local_ssh_port <= 65535 )) ||
+  oci_die "target SSH local port is invalid"
+kill -0 "$ssh_tunnel_pid" 2>/dev/null ||
+  oci_die "target SSH Bastion tunnel is not running"
 [[ "$os_user" == "ubuntu" ]] ||
   oci_die "unexpected k3s operating-system user"
 
-printf -v quoted_private_key '%q' "$private_key"
-printf -v quoted_known_hosts '%q' "$known_hosts"
-proxy_command="ssh -i $quoted_private_key -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=$quoted_known_hosts -W %h:%p -p 22 ${managed_session_id}@${bastion_endpoint}"
 ssh \
-  -i "$private_key" \
+  -i "$target_private_key" \
+  -p "$local_ssh_port" \
   -o BatchMode=yes \
+  -o CheckHostIP=no \
   -o ConnectTimeout=10 \
+  -o HostKeyAlias="$acquisition_instance_ocid" \
+  -o IdentitiesOnly=yes \
+  -o PasswordAuthentication=no \
+  -o PreferredAuthentications=publickey \
   -o StrictHostKeyChecking=accept-new \
-  -o UserKnownHostsFile="$known_hosts" \
-  -o "ProxyCommand=$proxy_command" \
-  "${os_user}@${instance_private_ip}" \
+  -o UserKnownHostsFile="$target_known_hosts" \
+  "${os_user}@127.0.0.1" \
   "bash -s -- '$OCI_MONGO_DEVICE'" <<'REMOTE'
 set -euo pipefail
 device="$1"
@@ -746,6 +757,8 @@ oci_prepare_private_dir "$PROVENANCE_DIR"
   printf 'namespace=%q\n' "$OCI_K8S_NAMESPACE"
   printf 'k3s_node_name=%q\n' "$OCI_K3S_NODE_NAME"
   printf 'k3s_version=%q\n' "$OCI_K3S_VERSION"
+  printf 'target_ssh_public_key_sha256=%q\n' \
+    "$acquisition_target_ssh_public_key_sha256"
   printf 'node_shape=%q\n' "VM.Standard.A1.Flex"
   printf 'node_ocpus=%q\n' "2"
   printf 'node_memory_gb=%q\n' "12"

--- a/infra/oci/scripts/lib.sh
+++ b/infra/oci/scripts/lib.sh
@@ -59,6 +59,18 @@ oci_fingerprint() {
   printf '%s' "$1" | oci_sha256
 }
 
+oci_ssh_ed25519_public_key_sha256() {
+  local public_key="$1" key_material
+  [[ "$public_key" != *$'\n'* &&
+     "$public_key" =~ ^ssh-ed25519[[:space:]]+([A-Za-z0-9+/=]+)([[:space:]].*)?$ ]] ||
+    oci_die "SSH public key must be a single-line ED25519 public key"
+  key_material="${BASH_REMATCH[1]}"
+  printf '%s\n' "$public_key" |
+    ssh-keygen -l -E sha256 -f - >/dev/null 2>&1 ||
+    oci_die "SSH public key is not a valid ED25519 key"
+  printf 'ssh-ed25519 %s' "$key_material" | oci_sha256
+}
+
 oci_is_positive_int() {
   [[ "$1" =~ ^[1-9][0-9]*$ ]]
 }

--- a/infra/oci/scripts/reconcile-capacity.sh
+++ b/infra/oci/scripts/reconcile-capacity.sh
@@ -67,7 +67,8 @@ record_instance() {
   local attachments attachment_count boot_volume_id boot_volume
   local vnic_attachments vnic_attachment_count vnic_id vnic public_ip private_ip
   local tags merged_tags live_tags instance_fingerprint memory_gb boot_gb
-  local boot_vpus ad
+  local boot_vpus ad target_ssh_public_key_sha256
+  local live_target_ssh_public_key_sha256
 
   managed="$(oci_capacity_managed_instances)"
   [[ "$(jq '.data | length' <<<"$managed")" == "1" ]] ||
@@ -82,9 +83,20 @@ record_instance() {
       --wait-for-state RUNNING \
       --max-wait-seconds 900 >/dev/null ||
       oci_die "managed A1 instance did not reach RUNNING"
-    instance="$(oci compute instance get --instance-id "$instance_id" --query data)"
-    oci_capacity_validate_instance "$instance"
   fi
+  instance="$(oci compute instance get --instance-id "$instance_id" --query data)"
+  oci_capacity_validate_instance "$instance"
+  target_ssh_public_key_sha256="$(
+    oci_ssh_ed25519_public_key_sha256 "$OCI_K3S_SSH_PUBLIC_KEY"
+  )"
+  live_target_ssh_public_key_sha256="$(
+    oci_ssh_ed25519_public_key_sha256 "$(
+      jq -r '.metadata.ssh_authorized_keys // empty' <<<"$instance"
+    )"
+  )"
+  [[ "$live_target_ssh_public_key_sha256" == \
+     "$target_ssh_public_key_sha256" ]] ||
+    oci_die "managed instance target SSH key differs from acquisition configuration"
 
   network="$(oci_capacity_discover_network)"
   IFS=$'\t' read -r vcn_id subnet_id nsg_id <<<"$network"
@@ -221,6 +233,7 @@ record_instance() {
     printf 'image_ocid=%q\n' "$OCI_K3S_IMAGE_OCID"
     printf 'k3s_version=%q\n' "$OCI_K3S_VERSION"
     printf 'k3s_binary_sha256=%q\n' "$OCI_K3S_BINARY_SHA256"
+    printf 'target_ssh_public_key_sha256=%q\n' "$target_ssh_public_key_sha256"
     printf 'acquisition_run_id=%q\n' "${OCI_CAPACITY_RUN_ID:-local}"
     printf 'expected_monthly_cost=%q\n' 0
   } > "$PROVENANCE_FILE"

--- a/infra/oci/tests/test-capacity-contract.sh
+++ b/infra/oci/tests/test-capacity-contract.sh
@@ -14,6 +14,10 @@ cleanup() {
 }
 trap cleanup EXIT
 mkdir -p "$FAKE_BIN"
+ssh-keygen -q -t ed25519 -N "" -C fixture-target -f "$TEST_DIR/target-key"
+ssh-keygen -q -t ed25519 -N "" -C fixture-mismatch -f "$TEST_DIR/mismatch-key"
+fixture_target_public_key="$(cat "$TEST_DIR/target-key.pub")"
+fixture_mismatch_public_key="$(cat "$TEST_DIR/mismatch-key.pub")"
 
 fail() {
   printf 'capacity contract failure: %s\n' "$*" >&2
@@ -191,6 +195,27 @@ JSON
             "acquisition-run-id": $run
           }
         '
+    elif [[ "$query" == "data" ]]; then
+      jq -cn --arg target_key "$OCI_FAKE_LAUNCH_SSH_PUBLIC_KEY" '{
+        id: "ocid1.instance.oc1..fixture",
+        "display-name": "betstan-k3s-node",
+        "availability-domain": "fixture:EU-FRANKFURT-1-AD-1",
+        "image-id": "ocid1.image.oc1..fixture",
+        shape: "VM.Standard.A1.Flex",
+        "shape-config": {ocpus: 2, "memory-in-gbs": 12.0},
+        "lifecycle-state": "RUNNING",
+        metadata: {ssh_authorized_keys: $target_key},
+        "freeform-tags": {
+          "betstan-managed": "true",
+          provider: "oci",
+          "betstan-managed-by": "oci-capacity-acquire",
+          "betstan-runtime": "k3s",
+          "betstan-contract": "1",
+          "expected-monthly-cost": "0",
+          "source-sha": "0000000000000000000000000000000000000000",
+          "acquisition-run-id": "stale"
+        }
+      }'
     elif [[ "$OCI_FAKE_SCENARIO" == "terminated" ]]; then
       echo "TERMINATED"
     else
@@ -256,7 +281,8 @@ export OCI_K3S_INSTANCE_NAME=betstan-k3s-node
 export OCI_K3S_IMAGE_OCID=ocid1.image.oc1..fixture
 export OCI_K3S_VERSION=v1.34.9+k3s1
 export OCI_K3S_BINARY_SHA256=c782d6bb71eb2eb30f034aaddabb480294f9fdae5a7bca49ac5e3e0f66b96ea5
-export OCI_K3S_SSH_PUBLIC_KEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFixtureOnlyKeyForContractTests fixture"
+export OCI_K3S_SSH_PUBLIC_KEY="$fixture_target_public_key"
+export OCI_FAKE_LAUNCH_SSH_PUBLIC_KEY="$fixture_target_public_key"
 export OCI_NODE_SHAPE=VM.Standard.A1.Flex
 export OCI_A1_OCPUS=2
 export OCI_A1_MEMORY_GB=12
@@ -269,6 +295,15 @@ export OCI_CAPACITY_RUN_NUMBER=1
 
 # shellcheck source=../scripts/capacity-common.sh
 source "$OCI_DIR/scripts/capacity-common.sh"
+target_ssh_public_key_sha256="$(
+  oci_ssh_ed25519_public_key_sha256 "$OCI_K3S_SSH_PUBLIC_KEY"
+)"
+if (
+  OCI_K3S_SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaFixtureOnlyKey fixture"
+  oci_capacity_require_contract
+) >/dev/null 2>&1; then
+  fail "capacity acquisition accepted an RSA target SSH key"
+fi
 [[ "$(OCI_A1_MEMORY_PROFILES=12 oci_capacity_profiles_json)" == "[12]" ]] ||
   fail "validated memory profile changed"
 if OCI_A1_MEMORY_PROFILES=12,10 oci_capacity_profiles_json >/dev/null 2>&1; then
@@ -375,8 +410,11 @@ bash -u -c '
   [[ "$shape" == "VM.Standard.A1.Flex" ]]
   [[ "$ocpus" == "2" && "$memory_gb" == "12" ]]
   [[ "$boot_volume_vpus_per_gb" == "10" ]]
+  [[ "$target_ssh_public_key_sha256" == "$2" ]]
   [[ -n "$private_ip" && -n "$public_ip" ]]
-' _ "$TEST_DIR/acquired-provenance/provenance.env" ||
+' _ \
+  "$TEST_DIR/acquired-provenance/provenance.env" \
+  "$target_ssh_public_key_sha256" ||
   fail "successful launch provenance lacks the canonical k3s finalization fields"
 jq -e '
   .instance_count == 1 and
@@ -402,6 +440,12 @@ grep -Fq 'instance_acquired=true' "$second_output" ||
   fail "existing managed instance allowed another launch request"
 [[ "$(grep -c 'compute instance update' "$FAKE_LOG")" == "$((tag_update_count + 1))" ]] ||
   fail "existing managed instance was not rebound to current provenance"
+if OCI_FAKE_SCENARIO=available \
+    OCI_K3S_SSH_PUBLIC_KEY="$fixture_mismatch_public_key" \
+    PROVENANCE_DIR="$TEST_DIR/mismatched-key-provenance" \
+      "$OCI_DIR/scripts/reconcile-capacity.sh" record >/dev/null 2>&1; then
+  fail "existing managed instance was rebound to a different target SSH key"
+fi
 bash -u -c '
   source "$1"
   [[ "$source_sha" == "$2" && "$acquisition_run_id" == "$3" ]]

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -324,6 +324,37 @@ for workflow in "$infra_workflow" "$deploy_workflow" "$migrate_workflow"; do
   grep -Fq 'workflow_dispatch:' "$workflow"
   grep -Fq 'github.run_attempt == 1' "$workflow"
   grep -Fq 'group: oci-control-plane' "$workflow"
+  [[ "$(grep -Fc \
+    'OCI_K3S_SSH_PRIVATE_KEY: ${{ secrets.OCI_K3S_SSH_PRIVATE_KEY }}' \
+    "$workflow")" == "1" ]] ||
+    fail "target SSH private key must be scoped to one k3s access step: $(basename "$workflow")"
+done
+! grep -Fq 'OCI_K3S_SSH_PRIVATE_KEY' "$capacity_workflow" ||
+  fail "capacity acquisition must receive only the target SSH public key"
+grep -Fq 'OCI_K3S_RETAIN_TARGET_SSH: "true"' "$infra_workflow" ||
+  fail "infrastructure finalization does not retain target SSH within its access step"
+grep -Fq 'unset OCI_K3S_SSH_PRIVATE_KEY' "$infra_workflow" ||
+  fail "infrastructure finalization does not clear the target SSH secret before use"
+! grep -Fq 'OCI_K3S_RETAIN_TARGET_SSH' "$deploy_workflow" "$migrate_workflow" ||
+  fail "deployment or migration retains target SSH after kubeconfig retrieval"
+for workflow in "$deploy_workflow" "$migrate_workflow"; do
+  public_job_line="$(grep -n -m1 '^  public-validate:' "$workflow" | cut -d: -f1)"
+  dependency_line="$(grep -n -m1 'name: Install browser validation dependencies' \
+    "$workflow" | cut -d: -f1)"
+  last_secret_line="$(grep -n 'secrets\.' "$workflow" | tail -1 | cut -d: -f1)"
+  [[ -n "$public_job_line" && -n "$dependency_line" &&
+      -n "$last_secret_line" &&
+      "$dependency_line" -gt "$public_job_line" &&
+      "$last_secret_line" -lt "$public_job_line" ]] ||
+    fail "browser dependencies share a job with cloud credentials: $(basename "$workflow")"
+  grep -Fq 'persist-credentials: false' "$workflow" ||
+    fail "public validation checkout persists a GitHub credential: $(basename "$workflow")"
+  grep -Fq 'OCI_CLUSTER_CHECKS_ALREADY_PASSED: "1"' "$workflow" ||
+    fail "public validation is not isolated from cluster checks: $(basename "$workflow")"
+  grep -Fq 'OCI_PUBLIC_CHECKS_ALREADY_PASSED: "1"' "$workflow" ||
+    fail "protected validation still executes package code: $(basename "$workflow")"
+  grep -Fq 'OCI_E2E_ALREADY_PASSED: "1"' "$workflow" ||
+    fail "protected validation still executes browser code: $(basename "$workflow")"
 done
 grep -Fq 'name: oci-infrastructure' "$infra_workflow"
 grep -Fq 'PROVISION OCI ZERO COST' "$infra_workflow"

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -59,7 +59,13 @@ case "$*" in
   "bastion bastion list "*) response=bastions.json ;;
   "artifacts container repository list "*) response=repositories.json ;;
   "os bucket list "*) response=buckets.json ;;
-  "bastion session delete "*) exit 0 ;;
+  "bastion session delete "*)
+    if [[ -n "${MOCK_OCI_FAIL_SESSION_ID:-}" &&
+          "$*" == *"$MOCK_OCI_FAIL_SESSION_ID"* ]]; then
+      exit 1
+    fi
+    exit 0
+    ;;
   "bastion bastion update "*) exit 0 ;;
   *) echo "unexpected mock OCI command: $*" >&2; exit 1 ;;
 esac
@@ -212,20 +218,37 @@ import time
 signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 time.sleep(300)
 ' &
-tunnel_pid=$!
+ssh_tunnel_pid=$!
+python3 -c '
+import signal
+import sys
+import time
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+time.sleep(300)
+' &
+api_tunnel_pid=$!
 access_work="$WORK_DIR/access"
 key_dir="$access_work/bastion-keys"
 mkdir -p "$key_dir"
-touch "$key_dir/id_ed25519"
+touch \
+  "$key_dir/bastion_id_ed25519" \
+  "$key_dir/target_id_ed25519" \
+  "$key_dir/target_known_hosts"
 state_file="$WORK_DIR/access.env"
 kubeconfig_file="$WORK_DIR/kubeconfig"
 touch "$kubeconfig_file"
 {
   printf 'bastion_ocid=%q\n' 'ocid1.bastion.oc1.fixture'
-  printf 'managed_session_id=%q\n' 'ocid1.bastionsession.oc1.managed'
-  printf 'pf_session_id=%q\n' 'ocid1.bastionsession.oc1.forward'
-  printf 'tunnel_pid=%q\n' "$tunnel_pid"
+  printf 'ssh_session_id=%q\n' 'ocid1.bastionsession.oc1.ssh'
+  printf 'api_session_id=%q\n' 'ocid1.bastionsession.oc1.api'
+  printf 'ssh_tunnel_pid=%q\n' "$ssh_tunnel_pid"
+  printf 'api_tunnel_pid=%q\n' "$api_tunnel_pid"
   printf 'key_dir=%q\n' "$key_dir"
+  printf 'target_private_key=%q\n' "$key_dir/target_id_ed25519"
+  printf 'target_known_hosts=%q\n' "$key_dir/target_known_hosts"
+  printf 'instance_private_ip=%q\n' '10.42.28.31'
+  printf 'os_user=%q\n' 'ubuntu'
+  printf 'local_ssh_port=%q\n' '12222'
 } > "$state_file"
 : > "$WORK_DIR/oci.log"
 PATH="$WORK_DIR/bin:$PATH" \
@@ -236,24 +259,108 @@ SESSION_STATE_FILE="$state_file" \
 WORK_DIR="$access_work" \
 KUBECONFIG="$kubeconfig_file" \
   "$OCI_DIR/scripts/configure-k3s-access.sh" cleanup >/dev/null
-! kill -0 "$tunnel_pid" 2>/dev/null ||
-  fail "k3s access cleanup left the exact tunnel process running"
-wait "$tunnel_pid" 2>/dev/null || true
+! kill -0 "$ssh_tunnel_pid" 2>/dev/null ||
+  fail "k3s access cleanup left the exact SSH tunnel process running"
+! kill -0 "$api_tunnel_pid" 2>/dev/null ||
+  fail "k3s access cleanup left the exact API tunnel process running"
+wait "$ssh_tunnel_pid" 2>/dev/null || true
+wait "$api_tunnel_pid" 2>/dev/null || true
 [[ ! -e "$state_file" && ! -e "$key_dir" && ! -e "$kubeconfig_file" ]] ||
   fail "k3s access cleanup left session state, kubeconfig, or ephemeral keys"
-grep -Fq 'bastion session delete --session-id ocid1.bastionsession.oc1.forward' \
+grep -Fq 'bastion session delete --session-id ocid1.bastionsession.oc1.api' \
   "$WORK_DIR/oci.log" ||
-  fail "k3s access cleanup did not delete the port-forwarding session"
-grep -Fq 'bastion session delete --session-id ocid1.bastionsession.oc1.managed' \
+  fail "k3s access cleanup did not delete the API port-forwarding session"
+grep -Fq 'bastion session delete --session-id ocid1.bastionsession.oc1.ssh' \
   "$WORK_DIR/oci.log" ||
-  fail "k3s access cleanup did not delete the managed SSH session"
+  fail "k3s access cleanup did not delete the SSH port-forwarding session"
 grep -Fq '192.0.2.1/32' "$WORK_DIR/oci.log" ||
   fail "k3s access cleanup did not restore the non-routable Bastion CIDR"
+PATH="$WORK_DIR/bin:$PATH" \
+MOCK_OCI_LOG="$WORK_DIR/oci.log" \
+MOCK_OCI_RESPONSES="$WORK_DIR/responses" \
+OCI_CLI_VERSION=3.90.0 \
+SESSION_STATE_FILE="$state_file" \
+WORK_DIR="$access_work" \
+KUBECONFIG="$kubeconfig_file" \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" cleanup >/dev/null ||
+  fail "k3s access cleanup is not idempotent after partial or prior cleanup"
+
+retry_key_dir="$access_work/retry-keys"
+mkdir -p "$retry_key_dir"
+touch "$retry_key_dir/target_id_ed25519" "$kubeconfig_file"
+{
+  printf 'bastion_ocid=%q\n' 'ocid1.bastion.oc1.fixture'
+  printf 'ssh_session_id=%q\n' ''
+  printf 'ssh_session_name=%q\n' ''
+  printf 'api_session_id=%q\n' 'ocid1.bastionsession.oc1.retry'
+  printf 'api_session_name=%q\n' ''
+  printf 'ssh_tunnel_pid=%q\n' ''
+  printf 'api_tunnel_pid=%q\n' ''
+  printf 'key_dir=%q\n' "$retry_key_dir"
+} > "$state_file"
+if PATH="$WORK_DIR/bin:$PATH" \
+    MOCK_OCI_LOG="$WORK_DIR/oci.log" \
+    MOCK_OCI_RESPONSES="$WORK_DIR/responses" \
+    MOCK_OCI_FAIL_SESSION_ID=ocid1.bastionsession.oc1.retry \
+    OCI_CLI_VERSION=3.90.0 \
+    SESSION_STATE_FILE="$state_file" \
+    WORK_DIR="$access_work" \
+    KUBECONFIG="$kubeconfig_file" \
+      "$OCI_DIR/scripts/configure-k3s-access.sh" cleanup >/dev/null 2>&1; then
+  fail "k3s access cleanup hid a remote session-deletion failure"
+fi
+[[ -f "$state_file" && ! -e "$retry_key_dir" && ! -e "$kubeconfig_file" ]] ||
+  fail "failed remote cleanup did not preserve retry state and remove key material"
+PATH="$WORK_DIR/bin:$PATH" \
+MOCK_OCI_LOG="$WORK_DIR/oci.log" \
+MOCK_OCI_RESPONSES="$WORK_DIR/responses" \
+OCI_CLI_VERSION=3.90.0 \
+SESSION_STATE_FILE="$state_file" \
+WORK_DIR="$access_work" \
+KUBECONFIG="$kubeconfig_file" \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" cleanup >/dev/null ||
+  fail "k3s access cleanup could not retry from preserved state"
+[[ ! -e "$state_file" ]] ||
+  fail "successful remote cleanup retry retained stale state"
+
 grep -Fq 'OCI_BASTION_SESSION_TTL="${OCI_BASTION_SESSION_TTL:-10800}"' \
   "$OCI_DIR/scripts/configure-k3s-access.sh" ||
   fail "k3s Bastion sessions do not match the protected workflow ceiling"
+[[ "$(grep -Fc 'bastion session create-port-forwarding' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh")" == "2" ]] ||
+  fail "k3s access does not create separate SSH and API port-forwarding sessions"
+! grep -Fq 'create-managed-ssh' "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access still uses managed SSH, which is unsupported on Ubuntu A1"
+grep -Fq '.data."ssh-metadata".command' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access does not derive the Bastion endpoint from session metadata"
+grep -Fq 'OCI_K3S_SSH_PRIVATE_KEY' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access does not require the retained target SSH private key"
+grep -Fq 'OCI_K3S_RETAIN_TARGET_SSH="${OCI_K3S_RETAIN_TARGET_SSH:-false}"' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access does not revoke target SSH by default"
+grep -Fq 'release_target_ssh' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access does not remove the retained target key after kubeconfig retrieval"
+grep -Fq '(( OCI_BASTION_SESSION_TTL >= 1800 ))' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access does not enforce the OCI Bastion minimum session TTL"
 
 finalizer="$OCI_DIR/scripts/finalize-k3s.sh"
+for access_field in \
+  target_private_key target_known_hosts instance_private_ip os_user \
+  local_ssh_port ssh_tunnel_pid; do
+  grep -Fq "printf '$access_field=%q" \
+    "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+    fail "k3s access state does not write $access_field"
+  grep -Fq "\${${access_field}:-}" "$finalizer" ||
+    fail "k3s finalizer does not require access-state field $access_field"
+done
+! grep -Eq 'managed_session_id|ProxyCommand=' "$finalizer" ||
+  fail "k3s finalizer still depends on managed SSH"
+grep -Fq '"${os_user}@127.0.0.1"' "$finalizer" ||
+  fail "k3s finalizer does not use the local target SSH forward"
 grep -Fq -- '--shape-name flexible' "$finalizer" ||
   fail "k3s finalizer does not create a flexible OCI load balancer"
 grep -Fq -- '--health-checker-protocol TCP' "$finalizer" ||


### PR DESCRIPTION
## Summary
- replace unsupported OCI Bastion Managed SSH on Ubuntu A1 with separate SSH and k3s API port-forwarding sessions
- bind the retained ED25519 target key to live launch metadata and acquisition provenance
- harden exact cleanup/retry state and isolate browser validation from cloud credentials
- allow exact-SHA manual capacity acquisition while the scheduled catcher remains disabled

## Validation
- `./infra/oci/tests/test-contract.sh`
- `./infra/azure/agents/workflow-trigger-guard-stan.sh`
- production workflow inventory tests

No deployment or image build is triggered by this PR.