### PR TITLE
Promote OCI k3s SSH-loopback access fix

### DIFF
--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -37,8 +37,8 @@ remains an explicit fallback selected with `OCI_RUNTIME_MODE=oke`.
   Mongo, or alternate load-balancer fallback.
 - Only the OCI load balancer exposes ports 80/443. In k3s mode, ingress-nginx
   uses fixed NodePorts 30080/30443 and the Kubernetes API is reachable only
-  through short-lived OCI Bastion sessions. Mongo and RabbitMQ remain
-  `ClusterIP`.
+  through a short-lived OCI Bastion SSH session and a target-loopback tunnel.
+  Mongo and RabbitMQ remain `ClusterIP`.
 - The Kustomize overlay explicitly lists nine application manifests,
   RabbitMQ, and `auth-mongo-depl.yaml`. It never traverses
   `infra/k8s/legacy-mongo`.
@@ -67,7 +67,8 @@ The GitHub environments use the variables and secrets approved in the plan:
   `OCI_K3S_SSH_PRIVATE_KEY` as a protected secret in `oci-infrastructure`,
   `oci-production`, and `oci-migration`. The private key is exposed only to
   each workflow's k3s access-opening step, is checked against acquisition
-  provenance, and is deleted as soon as target SSH is no longer required.
+  provenance, and is deleted after the API tunnel is established unless
+  infrastructure finalization still requires target SSH.
 
 Additional account-derived variables are intentionally required:
 
@@ -119,9 +120,11 @@ fixtures.
    Keep the variable `false` for an isolated manual attempt; a manual dispatch
    requires the exact current master SHA and does not enable scheduled runs.
 5. Dispatch `oci-infrastructure` with phase `finalize` after acquisition.
-   `scripts/configure-k3s-access.sh` opens separate ephemeral Bastion
-   port-forwarding sessions for target SSH and the k3s API. This avoids
-   Managed SSH, which OCI Bastion does not support for Ubuntu on Ampere A1.
+   `scripts/configure-k3s-access.sh` opens one ephemeral Bastion
+   port-forwarding session to target SSH, then tunnels the k3s API through
+   the target loopback interface. This avoids both Managed SSH, which OCI
+   Bastion does not support for Ubuntu on Ampere A1, and the OCI Ubuntu host
+   firewall that rejects direct non-SSH input.
    `scripts/finalize-k3s.sh` then mounts the Mongo volume, installs
    ingress-nginx and cert-manager, and reconciles the fixed 10/10 Mbps OCI
    load balancer.
@@ -134,9 +137,9 @@ fixtures.
    isolated kubeconfigs, an Azure expiry watchdog, a bounded write freeze,
    age-encrypted streams, exact database signatures, and unconditional Azure
    replica restoration.
-9. Delete the exact Bastion sessions, restore the non-routable client CIDR,
-   stop the exact tunnel PID, and remove ephemeral keys. Cleanup failure is a
-   deployment failure.
+9. Delete the exact Bastion session, restore the non-routable client CIDR,
+   stop both exact tunnel PIDs, and remove ephemeral keys. Cleanup failure is
+   a deployment failure.
 
 For OKE fallback, set `OCI_RUNTIME_MODE=oke`; the existing Basic-cluster,
 runner-NSG, and managed-node-pool flow remains available.

--- a/infra/oci/scripts/configure-k3s-access.sh
+++ b/infra/oci/scripts/configure-k3s-access.sh
@@ -35,26 +35,18 @@ delete_session() {
     --max-wait-seconds 300 >/dev/null
 }
 
-release_target_ssh() {
+release_target_ssh_key() {
   local failed=0
-  if stop_tunnel "$ssh_tunnel_pid"; then
-    ssh_tunnel_pid=""
-  else
-    failed=1
-  fi
-  if delete_session "$ssh_session_id"; then
-    ssh_session_id=""
-    ssh_session_name=""
-  else
-    failed=1
-  fi
   rm -f -- \
     "$target_private_key" \
     "$target_public_key" \
     "$target_known_hosts" || failed=1
+  target_private_key=""
+  target_public_key=""
+  target_known_hosts=""
   write_session_state
   [[ "$failed" == "0" ]] ||
-    oci_die "target SSH access could not be fully revoked"
+    oci_die "target SSH key material could not be fully removed"
 }
 
 reset_bastion_allowlist() {
@@ -163,8 +155,6 @@ write_session_state() {
     printf 'bastion_ocid=%q\n' "$bastion_ocid"
     printf 'ssh_session_id=%q\n' "$ssh_session_id"
     printf 'ssh_session_name=%q\n' "$ssh_session_name"
-    printf 'api_session_id=%q\n' "$api_session_id"
-    printf 'api_session_name=%q\n' "$api_session_name"
     printf 'ssh_tunnel_pid=%q\n' "$ssh_tunnel_pid"
     printf 'api_tunnel_pid=%q\n' "$api_tunnel_pid"
     printf 'key_dir=%q\n' "$key_dir"
@@ -189,6 +179,7 @@ stop_tunnel() {
 }
 
 cleanup_access() {
+  # Keep legacy API-session fields readable so interrupted pre-upgrade runs can be revoked.
   local ssh_session_id="" api_session_id=""
   local ssh_session_name="" api_session_name=""
   local ssh_tunnel_pid="" api_tunnel_pid=""
@@ -216,6 +207,7 @@ cleanup_access() {
   rm -f -- "$KUBECONFIG" || failed=1
   rm -f -- \
     "${SESSION_STATE_FILE}.tmp" \
+    "$WORK_DIR/target-api-tunnel.log" \
     "$WORK_DIR/bastion-api-tunnel.log" \
     "$WORK_DIR/bastion-ssh-tunnel.log" || failed=1
   if [[ -n "$key_dir" && "$key_dir" == "$WORK_DIR/"* ]]; then
@@ -374,13 +366,11 @@ target_public_key="${target_private_key}.pub"
 bastion_known_hosts="$key_dir/bastion_known_hosts"
 target_known_hosts="$key_dir/target_known_hosts"
 ssh_session_id=""
-api_session_id=""
 ssh_tunnel_pid=""
 api_tunnel_pid=""
 bastion_endpoint=""
 run_identity="${GITHUB_RUN_ID:-local-$PPID}-${GITHUB_RUN_ATTEMPT:-1}"
 ssh_session_name="betstan-k3s-ssh-${run_identity}"
-api_session_name="betstan-k3s-api-${run_identity}"
 write_session_state
 trap cleanup_open_failure EXIT
 
@@ -488,39 +478,15 @@ grep -Fq "server: https://127.0.0.1:${OCI_K3S_LOCAL_API_PORT}" "$KUBECONFIG" ||
 KUBECONFIG="$KUBECONFIG" kubectl config view --raw --minify >/dev/null ||
   oci_die "retrieved k3s kubeconfig is invalid"
 
-oci bastion session create-port-forwarding \
-  --bastion-id "$bastion_ocid" \
-  --display-name "$api_session_name" \
-  --key-type PUB \
-  --ssh-public-key-file "$bastion_public_key" \
-  --session-ttl "$OCI_BASTION_SESSION_TTL" \
-  --target-resource-id "$instance_ocid" \
-  --target-private-ip "$instance_private_ip" \
-  --target-port 6443 \
-  --wait-for-state SUCCEEDED \
-  --max-wait-seconds 600 >/dev/null
-api_session_id="$(
-  wait_active_session_id "$bastion_ocid" "$api_session_name"
-)"
-api_endpoint="$(session_endpoint "$api_session_id" 6443)"
-[[ "$api_endpoint" == "$bastion_endpoint" ]] ||
-  oci_die "OCI Bastion sessions returned different service endpoints"
-write_session_state
-
 ssh \
-  -i "$bastion_private_key" \
+  "${target_ssh_options[@]}" \
   -N \
-  -L "127.0.0.1:${OCI_K3S_LOCAL_API_PORT}:${instance_private_ip}:6443" \
-  -o BatchMode=yes \
+  -L "127.0.0.1:${OCI_K3S_LOCAL_API_PORT}:127.0.0.1:6443" \
   -o ExitOnForwardFailure=yes \
-  -o IdentitiesOnly=yes \
   -o ServerAliveInterval=30 \
   -o ServerAliveCountMax=3 \
-  -o StrictHostKeyChecking=accept-new \
-  -o UserKnownHostsFile="$bastion_known_hosts" \
-  -p 22 \
-  "${api_session_id}@${bastion_endpoint}" \
-  >"$WORK_DIR/bastion-api-tunnel.log" 2>&1 &
+  "${OCI_K3S_OS_USER}@127.0.0.1" \
+  >"$WORK_DIR/target-api-tunnel.log" 2>&1 &
 api_tunnel_pid=$!
 write_session_state
 
@@ -528,7 +494,8 @@ tunnel_ready=0
 for _ in $(seq 1 60); do
   kill -0 "$api_tunnel_pid" 2>/dev/null ||
     oci_die "k3s API Bastion tunnel process exited"
-  if KUBECONFIG="$KUBECONFIG" kubectl get --raw=/readyz >/dev/null 2>&1; then
+  if KUBECONFIG="$KUBECONFIG" \
+      kubectl --request-timeout=10s get --raw=/readyz >/dev/null 2>&1; then
     tunnel_ready=1
     break
   fi
@@ -537,7 +504,7 @@ done
 [[ "$tunnel_ready" == "1" ]] ||
   oci_die "k3s API is unavailable through OCI Bastion"
 if [[ "$OCI_K3S_RETAIN_TARGET_SSH" == "false" ]]; then
-  release_target_ssh
+  release_target_ssh_key
 fi
 trap - EXIT
-oci_log "k3s_access=PASS transport=oci-bastion-port-forwarding"
+oci_log "k3s_access=PASS transport=oci-bastion-target-ssh-loopback"

--- a/infra/oci/scripts/finalize-k3s.sh
+++ b/infra/oci/scripts/finalize-k3s.sh
@@ -214,7 +214,7 @@ jq -e \
   ' <<<"$boot_volume" >/dev/null ||
   oci_die "live boot volume differs from the approved 50 GB Balanced contract"
 
-node_json="$(kubectl get node "$OCI_K3S_NODE_NAME" -o json)"
+node_json="$(kubectl --request-timeout=15s get node "$OCI_K3S_NODE_NAME" -o json)"
 jq -e \
   --arg version "$OCI_K3S_VERSION" \
   --arg instance "$acquisition_instance_ocid" '
@@ -227,7 +227,8 @@ jq -e \
   ' <<<"$node_json" >/dev/null ||
   oci_die "k3s node identity, architecture, version, or readiness is invalid"
 for forbidden_addon in traefik servicelb local-path-provisioner; do
-  if kubectl get deployment "$forbidden_addon" -n kube-system >/dev/null 2>&1; then
+  if kubectl --request-timeout=15s \
+      get deployment "$forbidden_addon" -n kube-system >/dev/null 2>&1; then
     oci_die "bundled k3s addon must remain disabled: $forbidden_addon"
   fi
 done
@@ -681,7 +682,10 @@ helm upgrade --install cert-manager "$cert_chart" \
   --wait \
   --timeout 15m
 
-ingress_service="$(kubectl get service ingress-nginx-controller -n ingress-nginx -o json)"
+ingress_service="$(
+  kubectl --request-timeout=15s \
+    get service ingress-nginx-controller -n ingress-nginx -o json
+)"
 jq -e '
   .spec.type == "NodePort" and
   ([.spec.ports[] | select(

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -336,7 +336,7 @@ grep -Fq 'OCI_K3S_RETAIN_TARGET_SSH: "true"' "$infra_workflow" ||
 grep -Fq 'unset OCI_K3S_SSH_PRIVATE_KEY' "$infra_workflow" ||
   fail "infrastructure finalization does not clear the target SSH secret before use"
 ! grep -Fq 'OCI_K3S_RETAIN_TARGET_SSH' "$deploy_workflow" "$migrate_workflow" ||
-  fail "deployment or migration retains target SSH after kubeconfig retrieval"
+  fail "deployment or migration retains target SSH key material after API forwarding"
 for workflow in "$deploy_workflow" "$migrate_workflow"; do
   public_job_line="$(grep -n -m1 '^  public-validate:' "$workflow" | cut -d: -f1)"
   dependency_line="$(grep -n -m1 'name: Install browser validation dependencies' \

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -240,7 +240,6 @@ touch "$kubeconfig_file"
 {
   printf 'bastion_ocid=%q\n' 'ocid1.bastion.oc1.fixture'
   printf 'ssh_session_id=%q\n' 'ocid1.bastionsession.oc1.ssh'
-  printf 'api_session_id=%q\n' 'ocid1.bastionsession.oc1.api'
   printf 'ssh_tunnel_pid=%q\n' "$ssh_tunnel_pid"
   printf 'api_tunnel_pid=%q\n' "$api_tunnel_pid"
   printf 'key_dir=%q\n' "$key_dir"
@@ -267,12 +266,11 @@ wait "$ssh_tunnel_pid" 2>/dev/null || true
 wait "$api_tunnel_pid" 2>/dev/null || true
 [[ ! -e "$state_file" && ! -e "$key_dir" && ! -e "$kubeconfig_file" ]] ||
   fail "k3s access cleanup left session state, kubeconfig, or ephemeral keys"
-grep -Fq 'bastion session delete --session-id ocid1.bastionsession.oc1.api' \
-  "$WORK_DIR/oci.log" ||
-  fail "k3s access cleanup did not delete the API port-forwarding session"
 grep -Fq 'bastion session delete --session-id ocid1.bastionsession.oc1.ssh' \
   "$WORK_DIR/oci.log" ||
   fail "k3s access cleanup did not delete the SSH port-forwarding session"
+[[ "$(grep -Fc 'bastion session delete' "$WORK_DIR/oci.log")" == "1" ]] ||
+  fail "k3s access cleanup deleted an unexpected Bastion session"
 grep -Fq '192.0.2.1/32' "$WORK_DIR/oci.log" ||
   fail "k3s access cleanup did not restore the non-routable Bastion CIDR"
 PATH="$WORK_DIR/bin:$PATH" \
@@ -290,10 +288,8 @@ mkdir -p "$retry_key_dir"
 touch "$retry_key_dir/target_id_ed25519" "$kubeconfig_file"
 {
   printf 'bastion_ocid=%q\n' 'ocid1.bastion.oc1.fixture'
-  printf 'ssh_session_id=%q\n' ''
+  printf 'ssh_session_id=%q\n' 'ocid1.bastionsession.oc1.retry'
   printf 'ssh_session_name=%q\n' ''
-  printf 'api_session_id=%q\n' 'ocid1.bastionsession.oc1.retry'
-  printf 'api_session_name=%q\n' ''
   printf 'ssh_tunnel_pid=%q\n' ''
   printf 'api_tunnel_pid=%q\n' ''
   printf 'key_dir=%q\n' "$retry_key_dir"
@@ -327,8 +323,8 @@ grep -Fq 'OCI_BASTION_SESSION_TTL="${OCI_BASTION_SESSION_TTL:-10800}"' \
   "$OCI_DIR/scripts/configure-k3s-access.sh" ||
   fail "k3s Bastion sessions do not match the protected workflow ceiling"
 [[ "$(grep -Fc 'bastion session create-port-forwarding' \
-  "$OCI_DIR/scripts/configure-k3s-access.sh")" == "2" ]] ||
-  fail "k3s access does not create separate SSH and API port-forwarding sessions"
+  "$OCI_DIR/scripts/configure-k3s-access.sh")" == "1" ]] ||
+  fail "k3s access must create exactly one SSH port-forwarding session"
 ! grep -Fq 'create-managed-ssh' "$OCI_DIR/scripts/configure-k3s-access.sh" ||
   fail "k3s access still uses managed SSH, which is unsupported on Ubuntu A1"
 grep -Fq '.data."ssh-metadata".command' \
@@ -339,10 +335,22 @@ grep -Fq 'OCI_K3S_SSH_PRIVATE_KEY' \
   fail "k3s access does not require the retained target SSH private key"
 grep -Fq 'OCI_K3S_RETAIN_TARGET_SSH="${OCI_K3S_RETAIN_TARGET_SSH:-false}"' \
   "$OCI_DIR/scripts/configure-k3s-access.sh" ||
-  fail "k3s access does not revoke target SSH by default"
-grep -Fq 'release_target_ssh' \
+  fail "k3s access does not remove the target key by default"
+grep -Fq 'release_target_ssh_key' \
   "$OCI_DIR/scripts/configure-k3s-access.sh" ||
-  fail "k3s access does not remove the retained target key after kubeconfig retrieval"
+  fail "k3s access does not remove the target key after API forwarding"
+grep -Fq -- \
+  '-L "127.0.0.1:${OCI_K3S_LOCAL_API_PORT}:127.0.0.1:6443"' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s API does not use the target SSH loopback forward"
+grep -Fq 'kubectl --request-timeout=10s get --raw=/readyz' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s API readiness does not have a bounded request timeout"
+! grep -Eq 'iptables|netfilter|ufw' "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access mutates the target host firewall"
+! grep -Eq 'ControlMaster|ControlPersist' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s API tunnel leaves a reusable SSH control channel"
 grep -Fq '(( OCI_BASTION_SESSION_TTL >= 1800 ))' \
   "$OCI_DIR/scripts/configure-k3s-access.sh" ||
   fail "k3s access does not enforce the OCI Bastion minimum session TTL"
@@ -361,6 +369,8 @@ done
   fail "k3s finalizer still depends on managed SSH"
 grep -Fq '"${os_user}@127.0.0.1"' "$finalizer" ||
   fail "k3s finalizer does not use the local target SSH forward"
+grep -Fq 'kubectl --request-timeout=15s get node' "$finalizer" ||
+  fail "k3s finalizer node lookup does not have a bounded request timeout"
 grep -Fq -- '--shape-name flexible' "$finalizer" ||
   fail "k3s finalizer does not create a flexible OCI load balancer"
 grep -Fq -- '--health-checker-protocol TCP' "$finalizer" ||


### PR DESCRIPTION
## Summary
- promote the live-validated OCI k3s API transport fix from protected `dev`
- use one Bastion SSH session plus a target-loopback API tunnel
- preserve deterministic key, tunnel, session, and CIDR cleanup
- bound k3s API requests so failed access cannot hang until job timeout

## Provenance
- source PR: #137
- dev merge: `3e3b8aafd667dd053db3f3ef01387f9c9e97110b`
- feature commit: `d711f714bd518fb1b5115a3cec4de2f881ba0978`

## Safety
- exact transport passed live against the retained A1 host
- no application/service architecture change and no host-firewall mutation
- capacity workflow remains disabled and catcher remains false
- withhold all production and OCI image build approvals while OCIR exceeds 500 MB