### PR TITLE
fix(oci): reuse unchanged immutable images

### DIFF
--- a/.github/workflows/oci-production-build.yml
+++ b/.github/workflows/oci-production-build.yml
@@ -1,5 +1,5 @@
 name: oci-production-build
-run-name: oci-build ${{ github.event.workflow_run.head_sha }}
+run-name: oci-build ${{ github.event.workflow_run.head_sha }} upstream-${{ github.event.workflow_run.id }}
 
 on:
   workflow_run:
@@ -34,6 +34,8 @@ jobs:
       OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
       OCI_REGISTRY_NAMESPACE: ${{ vars.OCI_REGISTRY_NAMESPACE }}
       OCI_IMAGE_PREFIX: ${{ vars.OCI_IMAGE_PREFIX }}
+      REUSE_SOURCE_SHA: ${{ vars.OCI_REUSE_SOURCE_SHA }}
+      REUSE_BUILD_RUN_ID: ${{ vars.OCI_REUSE_BUILD_RUN_ID }}
 
     steps:
       - name: Checkout exact upstream source
@@ -71,6 +73,94 @@ jobs:
             exit 1
           }
 
+      - name: Select immutable image source
+        id: image_source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mode=build
+          if [ -n "$REUSE_SOURCE_SHA" ] || [ -n "$REUSE_BUILD_RUN_ID" ]; then
+            [[ "$REUSE_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+            [[ "$REUSE_BUILD_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+            [ "$REUSE_SOURCE_SHA" != "$SOURCE_SHA" ]
+            git cat-file -e "${REUSE_SOURCE_SHA}^{commit}"
+            git merge-base --is-ancestor "$REUSE_SOURCE_SHA" "$SOURCE_SHA"
+            set +e
+            ./infra/oci/scripts/compare-image-inputs.sh \
+              "$REUSE_SOURCE_SHA" "$SOURCE_SHA"
+            input_diff_status=$?
+            set -e
+            if [ "$input_diff_status" = "0" ]; then
+              trusted_workflow_id="$(
+                gh api "repos/$REPOSITORY/actions/workflows/oci-production-build.yml" \
+                  --jq '.id'
+              )"
+              reuse_run="$(
+                gh api \
+                  "repos/$REPOSITORY/actions/runs/$REUSE_BUILD_RUN_ID/attempts/1"
+              )"
+              jq -e \
+                --argjson workflow_id "$trusted_workflow_id" \
+                --arg sha "$REUSE_SOURCE_SHA" \
+                --arg repository "$REPOSITORY" \
+                '
+                  .workflow_id == $workflow_id and
+                  .path == ".github/workflows/oci-production-build.yml" and
+                  .event == "workflow_run" and
+                  .head_sha == $sha and
+                  .head_branch == "master" and
+                  .head_repository.full_name == $repository and
+                  .status == "completed" and
+                  .conclusion == "success" and
+                  .run_attempt == 1
+                ' <<<"$reuse_run" >/dev/null
+              artifact_name="oci-image-provenance-${REUSE_SOURCE_SHA}-${REUSE_BUILD_RUN_ID}-1"
+              artifact_count="$(
+                gh api \
+                  "repos/$REPOSITORY/actions/runs/$REUSE_BUILD_RUN_ID/artifacts" |
+                  jq \
+                    --arg name "$artifact_name" \
+                    '[.artifacts[] | select(
+                      .name == $name and .expired == false
+                    )] | length'
+              )"
+              [ "$artifact_count" = "1" ]
+              mkdir -p artifacts/reuse-source
+              gh run download "$REUSE_BUILD_RUN_ID" \
+                --name "$artifact_name" \
+                --dir artifacts/reuse-source
+              grep -Fxq "source_sha=$REUSE_SOURCE_SHA" \
+                artifacts/reuse-source/build-chain.txt
+              grep -Fxq "build_run_id=$REUSE_BUILD_RUN_ID" \
+                artifacts/reuse-source/build-chain.txt
+              grep -Fxq "build_run_attempt=1" \
+                artifacts/reuse-source/build-chain.txt
+              reuse_upstream_run_id="$(
+                awk -F= '$1 == "upstream_run_id" {print $2}' \
+                  artifacts/reuse-source/build-chain.txt
+              )"
+              [[ "$reuse_upstream_run_id" =~ ^[1-9][0-9]*$ ]]
+              reuse_display_title="$(jq -r '.display_title' <<<"$reuse_run")"
+              if [ "$reuse_display_title" != "oci-build $REUSE_SOURCE_SHA" ]; then
+                [ "$reuse_display_title" = \
+                  "oci-build $REUSE_SOURCE_SHA upstream-$reuse_upstream_run_id" ]
+              fi
+              mode=reuse
+            elif [ "$input_diff_status" = "1" ]; then
+              echo "Configured reusable image inputs differ from current master." >&2
+              echo "Clear OCI_REUSE_SOURCE_SHA and OCI_REUSE_BUILD_RUN_ID, then obtain a fresh full-build approval." >&2
+              exit 1
+            else
+              echo "Unable to compare reusable image inputs." >&2
+              exit "$input_diff_status"
+            fi
+          fi
+          printf 'mode=%s\n' "$mode" >> "$GITHUB_OUTPUT"
+          printf 'reuse_source_sha=%s\n' "$REUSE_SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          printf 'reuse_build_run_id=%s\n' "$REUSE_BUILD_RUN_ID" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU for ARM64 verification
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
@@ -79,15 +169,44 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Build and push exact ARM64 OCI images
+      - name: Verify reusable ARM64 image provenance
+        if: steps.image_source.outputs.mode == 'reuse'
+        env:
+          OCI_REGISTRY_USERNAME: ${{ secrets.OCI_REGISTRY_USERNAME }}
+          OCI_REGISTRY_AUTH_TOKEN: ${{ secrets.OCI_REGISTRY_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$OCI_REGISTRY_AUTH_TOKEN" |
+            docker login "$OCI_REGISTRY_HOST" \
+              --username "$OCI_REGISTRY_USERNAME" --password-stdin >/dev/null
+          PROVENANCE_DIR=artifacts/reuse-source \
+          SOURCE_SHA="$REUSE_SOURCE_SHA" \
+          EXPECTED_BUILD_RUN_ID="$REUSE_BUILD_RUN_ID" \
+          EXPECTED_BUILD_RUN_ATTEMPT=1 \
+          OUTPUT_FILE=artifacts/reuse-source/images.tsv \
+          VERIFY_REMOTE=1 BOOT_IMAGES=0 \
+            ./infra/oci/scripts/verify-images.sh
+          docker logout "$OCI_REGISTRY_HOST" >/dev/null
+
+      - name: Publish exact ARM64 OCI images
         env:
           OCI_REGISTRY_USERNAME: ${{ secrets.OCI_REGISTRY_USERNAME }}
           OCI_REGISTRY_AUTH_TOKEN: ${{ secrets.OCI_REGISTRY_AUTH_TOKEN }}
           OUTPUT_DIR: artifacts/oci-image-provenance
+          IMAGE_MODE: ${{ steps.image_source.outputs.mode }}
         run: |
           set -euo pipefail
-          SOURCE_SHA="$SOURCE_SHA" PLATFORM=linux/arm64 PUSH_IMAGES=1 \
-            ./infra/oci/scripts/build-images.sh
+          if [ "$IMAGE_MODE" = "reuse" ]; then
+            SOURCE_SHA="$SOURCE_SHA" \
+            REUSE_SOURCE_SHA="$REUSE_SOURCE_SHA" \
+            REUSE_BUILD_RUN_ID="$REUSE_BUILD_RUN_ID" \
+            REUSE_PROVENANCE_DIR=artifacts/reuse-source \
+            PLATFORM=linux/arm64 \
+              ./infra/oci/scripts/reuse-images.sh
+          else
+            SOURCE_SHA="$SOURCE_SHA" PLATFORM=linux/arm64 PUSH_IMAGES=1 \
+              ./infra/oci/scripts/build-images.sh
+          fi
 
       - name: Verify remote digests and boot emitted JavaScript
         env:
@@ -107,6 +226,8 @@ jobs:
             ./infra/oci/scripts/verify-images.sh
 
       - name: Record exact build chain
+        env:
+          IMAGE_MODE: ${{ steps.image_source.outputs.mode }}
         run: |
           printf '%s\n' \
             "source_sha=$SOURCE_SHA" \
@@ -115,8 +236,15 @@ jobs:
             "upstream_run_attempt=1" \
             "build_run_id=$GITHUB_RUN_ID" \
             "build_run_attempt=$GITHUB_RUN_ATTEMPT" \
+            "image_mode=$IMAGE_MODE" \
             "platform=linux/arm64" \
             > artifacts/oci-image-provenance/build-chain.txt
+          if [ "$IMAGE_MODE" = "reuse" ]; then
+            printf '%s\n' \
+              "reuse_source_sha=$REUSE_SOURCE_SHA" \
+              "reuse_build_run_id=$REUSE_BUILD_RUN_ID" \
+              >> artifacts/oci-image-provenance/build-chain.txt
+          fi
 
       - name: Upload immutable OCI image provenance
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/oci-production-build.yml
+++ b/.github/workflows/oci-production-build.yml
@@ -197,12 +197,23 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$IMAGE_MODE" = "reuse" ]; then
-            SOURCE_SHA="$SOURCE_SHA" \
-            REUSE_SOURCE_SHA="$REUSE_SOURCE_SHA" \
-            REUSE_BUILD_RUN_ID="$REUSE_BUILD_RUN_ID" \
-            REUSE_PROVENANCE_DIR=artifacts/reuse-source \
-            PLATFORM=linux/arm64 \
-              ./infra/oci/scripts/reuse-images.sh
+            reuse_complete=false
+            for reuse_attempt in 1 2 3; do
+              attempt_output="artifacts/oci-image-reuse-attempt-${reuse_attempt}"
+              if SOURCE_SHA="$SOURCE_SHA" \
+                  REUSE_SOURCE_SHA="$REUSE_SOURCE_SHA" \
+                  REUSE_BUILD_RUN_ID="$REUSE_BUILD_RUN_ID" \
+                  REUSE_PROVENANCE_DIR=artifacts/reuse-source \
+                  OUTPUT_DIR="$attempt_output" \
+                  PLATFORM=linux/arm64 \
+                    ./infra/oci/scripts/reuse-images.sh; then
+                mv "$attempt_output" "$OUTPUT_DIR"
+                reuse_complete=true
+                break
+              fi
+              sleep $((reuse_attempt * 10))
+            done
+            [ "$reuse_complete" = "true" ]
           else
             SOURCE_SHA="$SOURCE_SHA" PLATFORM=linux/arm64 PUSH_IMAGES=1 \
               ./infra/oci/scripts/build-images.sh

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -141,6 +141,18 @@ fixtures.
    stop both exact tunnel PIDs, and remove ephemeral keys. Cleanup failure is
    a deployment failure.
 
+The protected `oci-build` environment can define `OCI_REUSE_SOURCE_SHA` and
+`OCI_REUSE_BUILD_RUN_ID` for a prior successful first-attempt OCI build.
+`oci-production-build` reuses those verified immutable ARM64 digests only when
+the prior commit is an ancestor and `.dockerignore`, all nine service trees,
+`infra/oci/build`, and `scripts/build-images.sh` are unchanged. Any changed
+image input uses the normal build path only after the reuse variables are
+cleared and a fresh environment approval is obtained. Reuse creates new
+exact-SHA tags without uploading duplicate layers and records both build runs
+in provenance. The comparison also fingerprints the exact `lib.sh` functions
+called by `build-images.sh`; unrelated infrastructure helpers do not force a
+rebuild, while any transitive image-recipe change fails closed.
+
 For OKE fallback, set `OCI_RUNTIME_MODE=oke`; the existing Basic-cluster,
 runner-NSG, and managed-node-pool flow remains available.
 

--- a/infra/oci/scripts/compare-image-inputs.sh
+++ b/infra/oci/scripts/compare-image-inputs.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${IMAGE_INPUT_REPOSITORY_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+BASE_SHA="${BASE_SHA:-${1:-}}"
+TARGET_SHA="${TARGET_SHA:-${2:-}}"
+
+[[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "ERROR: BASE_SHA must be a full lowercase commit SHA" >&2
+  exit 2
+}
+[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "ERROR: TARGET_SHA must be a full lowercase commit SHA" >&2
+  exit 2
+}
+git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  echo "ERROR: image input repository root is not a git worktree" >&2
+  exit 2
+}
+
+paths=(
+  .dockerignore
+  auth
+  bet
+  backoffice
+  client
+  event
+  gamemaster
+  moderation
+  resulting
+  slip
+  infra/oci/build
+  infra/oci/scripts/build-images.sh
+)
+
+set +e
+git -C "$ROOT_DIR" diff --quiet "$BASE_SHA" "$TARGET_SHA" -- "${paths[@]}"
+path_status=$?
+set -e
+case "$path_status" in
+  0) ;;
+  1) exit 1 ;;
+  *)
+    echo "ERROR: unable to compare immutable image input paths" >&2
+    exit 2
+    ;;
+esac
+
+base_contract="$(mktemp)"
+target_contract="$(mktemp)"
+cleanup() {
+  rm -f "$base_contract" "$target_contract"
+}
+trap cleanup EXIT
+
+extract_lib_contract() {
+  local ref="$1"
+  git -C "$ROOT_DIR" show "${ref}:infra/oci/scripts/lib.sh" |
+    awk '
+      /^OCI_ROOT_DIR=/ {
+        print
+        next
+      }
+      /^oci_(die|log|require_command|require_vars|prepare_private_dir)\(\) \{$/ {
+        capture = 1
+      }
+      capture {
+        print
+      }
+      capture && $0 == "}" {
+        capture = 0
+      }
+    '
+}
+
+extract_lib_contract "$BASE_SHA" > "$base_contract" || {
+  echo "ERROR: unable to read reusable image library contract" >&2
+  exit 2
+}
+extract_lib_contract "$TARGET_SHA" > "$target_contract" || {
+  echo "ERROR: unable to read target image library contract" >&2
+  exit 2
+}
+[[ -s "$base_contract" && -s "$target_contract" ]] || {
+  echo "ERROR: image library contract is incomplete" >&2
+  exit 2
+}
+cmp -s "$base_contract" "$target_contract" || exit 1
+
+echo "oci_image_inputs=UNCHANGED base=$BASE_SHA target=$TARGET_SHA"

--- a/infra/oci/scripts/compare-image-inputs.sh
+++ b/infra/oci/scripts/compare-image-inputs.sh
@@ -57,20 +57,64 @@ extract_lib_contract() {
   local ref="$1"
   git -C "$ROOT_DIR" show "${ref}:infra/oci/scripts/lib.sh" |
     awk '
-      /^OCI_ROOT_DIR=/ {
+      /^[a-zA-Z_][a-zA-Z0-9_]*\(\) \{$/ {
+        in_function = 1
+        capture = ($0 ~ /^oci_(die|log|require_command|require_vars|prepare_private_dir)\(\) \{$/)
+        if (capture) {
+          print
+        }
+        next
+      }
+      in_function {
+        if (capture) {
+          print
+        }
+        if ($0 == "}") {
+          in_function = 0
+          capture = 0
+        }
+        next
+      }
+      /^[[:space:]]*$/ || /^#!/ || /^[[:space:]]*#/ {
+        next
+      }
+      /^[A-Z][A-Z0-9_]*=/ {
         print
         next
       }
-      /^oci_(die|log|require_command|require_vars|prepare_private_dir)\(\) \{$/ {
-        capture = 1
+      {
+        print "unexpected top-level image library statement: " $0 > "/dev/stderr"
+        invalid = 1
       }
-      capture {
-        print
-      }
-      capture && $0 == "}" {
-        capture = 0
+      END {
+        if (in_function || invalid) {
+          exit 2
+        }
       }
     '
+}
+
+validate_lib_contract() {
+  local contract="$1"
+  local function_name unexpected
+  for function_name in \
+    oci_die oci_log oci_require_command oci_require_vars oci_prepare_private_dir; do
+    grep -Fqx "${function_name}() {" "$contract" || {
+      echo "ERROR: image library contract is missing $function_name" >&2
+      return 2
+    }
+  done
+  unexpected="$(
+    grep -Eo 'oci_[a-z0-9_]+' "$contract" |
+      sort -u |
+      grep -Ev \
+        '^(oci_die|oci_log|oci_require_command|oci_require_vars|oci_prepare_private_dir)$' \
+      || true
+  )"
+  [[ -z "$unexpected" ]] || {
+    echo "ERROR: image library contract has an untracked helper dependency: $unexpected" >&2
+    return 2
+  }
 }
 
 extract_lib_contract "$BASE_SHA" > "$base_contract" || {
@@ -85,6 +129,8 @@ extract_lib_contract "$TARGET_SHA" > "$target_contract" || {
   echo "ERROR: image library contract is incomplete" >&2
   exit 2
 }
+validate_lib_contract "$base_contract" || exit 2
+validate_lib_contract "$target_contract" || exit 2
 cmp -s "$base_contract" "$target_contract" || exit 1
 
 echo "oci_image_inputs=UNCHANGED base=$BASE_SHA target=$TARGET_SHA"

--- a/infra/oci/scripts/reuse-images.sh
+++ b/infra/oci/scripts/reuse-images.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+env_value() {
+  local file="$1"
+  local key="$2"
+  awk -F= -v key="$key" '
+    $1 == key {
+      sub(/^[^=]*=/, "")
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' "$file"
+}
+
+require_absent_image_tag() {
+  local tag="$1"
+  local inspect_error="$2"
+  if docker buildx imagetools inspect "$tag" >"$inspect_error" 2>&1; then
+    oci_die "exact OCI tag already exists; refusing overwrite for $tag"
+  fi
+  if ! grep -Eiq '404|manifest unknown|name unknown|not found' "$inspect_error"; then
+    oci_die "unable to prove the exact OCI tag is absent for $tag"
+  fi
+  rm -f "$inspect_error"
+}
+
+SOURCE_SHA="${SOURCE_SHA:-${1:-}}"
+REUSE_SOURCE_SHA="${REUSE_SOURCE_SHA:-${2:-}}"
+REUSE_BUILD_RUN_ID="${REUSE_BUILD_RUN_ID:-${3:-}}"
+REUSE_PROVENANCE_DIR="${REUSE_PROVENANCE_DIR:-${4:-}}"
+OUTPUT_DIR="${OUTPUT_DIR:-$OCI_ROOT_DIR/artifacts/oci-build}"
+PLATFORM="${PLATFORM:-linux/arm64}"
+
+oci_require_command docker
+oci_require_vars \
+  OCI_REGISTRY_HOST OCI_REGISTRY_NAMESPACE OCI_IMAGE_PREFIX \
+  OCI_REGISTRY_USERNAME OCI_REGISTRY_AUTH_TOKEN
+[[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+  oci_die "SOURCE_SHA must be a full lowercase commit SHA"
+[[ "$REUSE_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+  oci_die "REUSE_SOURCE_SHA must be a full lowercase commit SHA"
+[[ "$SOURCE_SHA" != "$REUSE_SOURCE_SHA" ]] ||
+  oci_die "reuse source must differ from the requested source SHA"
+[[ "$REUSE_BUILD_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+  oci_die "REUSE_BUILD_RUN_ID must be a positive integer"
+[[ -d "$REUSE_PROVENANCE_DIR" ]] ||
+  oci_die "reusable provenance directory not found"
+[[ "$PLATFORM" == "linux/arm64" ]] ||
+  oci_die "OCI images must target linux/arm64"
+[[ "$OCI_REGISTRY_HOST" != *"://"* ]] ||
+  oci_die "OCI_REGISTRY_HOST must not contain a URL scheme"
+[[ "$OCI_IMAGE_PREFIX" =~ ^[a-z0-9][a-z0-9._/-]*$ ]] ||
+  oci_die "OCI_IMAGE_PREFIX contains unsupported repository characters"
+
+oci_prepare_private_dir "$OUTPUT_DIR"
+if compgen -G "$OUTPUT_DIR/*.env" >/dev/null; then
+  oci_die "output directory already contains image provenance"
+fi
+
+repository="${OCI_REGISTRY_HOST}/${OCI_REGISTRY_NAMESPACE}/${OCI_IMAGE_PREFIX}_images"
+services=(auth bet backoffice client event gamemaster moderation resulting slip)
+plan_file="$OUTPUT_DIR/reuse-plan.tsv"
+artifact_service=""
+artifact_repository=""
+artifact_source_sha=""
+artifact_tag=""
+artifact_digest=""
+artifact_platform_digest=""
+artifact_image_ref=""
+artifact_platform=""
+artifact_build_run_id=""
+artifact_build_run_attempt=""
+: > "$plan_file"
+chmod 600 "$plan_file"
+
+printf '%s' "$OCI_REGISTRY_AUTH_TOKEN" |
+  docker login "$OCI_REGISTRY_HOST" \
+    --username "$OCI_REGISTRY_USERNAME" --password-stdin >/dev/null
+trap 'docker logout "$OCI_REGISTRY_HOST" >/dev/null 2>&1 || true' EXIT
+
+for expected_service in "${services[@]}"; do
+  provenance="$REUSE_PROVENANCE_DIR/${expected_service}.env"
+  [[ -f "$provenance" ]] || oci_die "missing reusable provenance for $expected_service"
+  artifact_service="$(env_value "$provenance" service)"
+  artifact_repository="$(env_value "$provenance" repository)"
+  artifact_source_sha="$(env_value "$provenance" source_sha)"
+  artifact_tag="$(env_value "$provenance" tag)"
+  artifact_digest="$(env_value "$provenance" digest)"
+  artifact_platform_digest="$(env_value "$provenance" platform_digest)"
+  artifact_image_ref="$(env_value "$provenance" image_ref)"
+  artifact_platform="$(env_value "$provenance" platform)"
+  artifact_build_run_id="$(env_value "$provenance" build_run_id)"
+  artifact_build_run_attempt="$(env_value "$provenance" build_run_attempt)"
+  [[ "$artifact_service" == "$expected_service" ]] ||
+    oci_die "reusable service mismatch for $expected_service"
+  [[ "$artifact_source_sha" == "$REUSE_SOURCE_SHA" ]] ||
+    oci_die "reusable source SHA mismatch for $expected_service"
+  [[ "$artifact_build_run_id" == "$REUSE_BUILD_RUN_ID" &&
+     "$artifact_build_run_attempt" == "1" ]] ||
+    oci_die "reusable build provenance mismatch for $expected_service"
+  [[ "$artifact_repository" == "$repository" ]] ||
+    oci_die "reusable repository mismatch for $expected_service"
+  [[ "$artifact_tag" == "${repository}:oci-${expected_service}-${REUSE_SOURCE_SHA}" ]] ||
+    oci_die "reusable tag mismatch for $expected_service"
+  [[ "$artifact_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+    oci_die "reusable digest is invalid for $expected_service"
+  [[ "$artifact_platform_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+    oci_die "reusable platform digest is invalid for $expected_service"
+  [[ "$artifact_image_ref" == "${repository}@${artifact_digest}" ]] ||
+    oci_die "reusable image reference mismatch for $expected_service"
+  [[ "$artifact_platform" == "$PLATFORM" ]] ||
+    oci_die "reusable platform mismatch for $expected_service"
+
+  new_tag="${repository}:oci-${expected_service}-${SOURCE_SHA}"
+  inspect_error="$OUTPUT_DIR/${expected_service}.tag-inspect.log"
+  require_absent_image_tag "$new_tag" "$inspect_error"
+  printf '%s\t%s\t%s\t%s\t%s\n' \
+    "$expected_service" "$repository" "$artifact_digest" \
+    "$artifact_platform_digest" "$artifact_image_ref" \
+    >> "$plan_file"
+done
+
+while IFS=$'\t' read -r service service_repository digest platform_digest image_ref; do
+  new_tag="${service_repository}:oci-${service}-${SOURCE_SHA}"
+  docker buildx imagetools create \
+    --prefer-index=false \
+    --tag "$new_tag" \
+    "$image_ref"
+  observed_digest="$(
+    docker buildx imagetools inspect "$new_tag" \
+      --format '{{json .Manifest.Digest}}' |
+      tr -d '"'
+  )"
+  [[ "$observed_digest" == "$digest" ]] ||
+    oci_die "reused tag digest differs from approved provenance for $service"
+  {
+    printf 'service=%q\n' "$service"
+    printf 'repository=%q\n' "$service_repository"
+    printf 'source_sha=%q\n' "$SOURCE_SHA"
+    printf 'tag=%q\n' "$new_tag"
+    printf 'digest=%q\n' "$digest"
+    printf 'platform_digest=%q\n' "$platform_digest"
+    printf 'image_ref=%q\n' "$image_ref"
+    printf 'platform=%q\n' "$PLATFORM"
+    printf 'build_run_id=%q\n' "${GITHUB_RUN_ID:-local}"
+    printf 'build_run_attempt=%q\n' "${GITHUB_RUN_ATTEMPT:-1}"
+    printf 'reuse_source_sha=%q\n' "$REUSE_SOURCE_SHA"
+    printf 'reuse_build_run_id=%q\n' "$REUSE_BUILD_RUN_ID"
+  } > "$OUTPUT_DIR/${service}.env"
+done < "$plan_file"
+
+rm -f "$plan_file"
+oci_log "oci_image_reuse=PASS services=${#services[@]} platform=$PLATFORM source=$REUSE_SOURCE_SHA"

--- a/infra/oci/scripts/reuse-images.sh
+++ b/infra/oci/scripts/reuse-images.sh
@@ -23,16 +23,31 @@ env_value() {
   ' "$file"
 }
 
-require_absent_image_tag() {
+inspect_image_tag_digest() {
   local tag="$1"
   local inspect_error="$2"
-  if docker buildx imagetools inspect "$tag" >"$inspect_error" 2>&1; then
-    oci_die "exact OCI tag already exists; refusing overwrite for $tag"
+  local output status
+  set +e
+  output="$(
+    docker buildx imagetools inspect "$tag" \
+      --format '{{json .Manifest.Digest}}' \
+      2>"$inspect_error"
+  )"
+  status=$?
+  set -e
+  if [[ "$status" == "0" ]]; then
+    rm -f "$inspect_error"
+    output="${output//\"/}"
+    [[ "$output" =~ ^sha256:[0-9a-f]{64}$ ]] || return 20
+    printf '%s\n' "$output"
+    return 0
   fi
-  if ! grep -Eiq '404|manifest unknown|name unknown|not found' "$inspect_error"; then
-    oci_die "unable to prove the exact OCI tag is absent for $tag"
+  if grep -Eiq '404|manifest unknown|name unknown|not found' "$inspect_error"; then
+    rm -f "$inspect_error"
+    return 10
   fi
-  rm -f "$inspect_error"
+  cat "$inspect_error" >&2
+  return 20
 }
 
 SOURCE_SHA="${SOURCE_SHA:-${1:-}}"
@@ -124,24 +139,45 @@ for expected_service in "${services[@]}"; do
 
   new_tag="${repository}:oci-${expected_service}-${SOURCE_SHA}"
   inspect_error="$OUTPUT_DIR/${expected_service}.tag-inspect.log"
-  require_absent_image_tag "$new_tag" "$inspect_error"
-  printf '%s\t%s\t%s\t%s\t%s\n' \
-    "$expected_service" "$repository" "$artifact_digest" \
+  set +e
+  observed_digest="$(inspect_image_tag_digest "$new_tag" "$inspect_error")"
+  inspect_status=$?
+  set -e
+  case "$inspect_status" in
+    0)
+      [[ "$observed_digest" == "$artifact_digest" ]] ||
+        oci_die "existing exact OCI tag has an unexpected digest for $expected_service"
+      action=existing
+      ;;
+    10)
+      action=create
+      ;;
+    *)
+      oci_die "unable to validate the exact OCI tag for $expected_service"
+      ;;
+  esac
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$action" "$expected_service" "$repository" "$artifact_digest" \
     "$artifact_platform_digest" "$artifact_image_ref" \
     >> "$plan_file"
 done
 
-while IFS=$'\t' read -r service service_repository digest platform_digest image_ref; do
+while IFS=$'\t' read -r action service service_repository digest platform_digest image_ref; do
   new_tag="${service_repository}:oci-${service}-${SOURCE_SHA}"
-  docker buildx imagetools create \
-    --prefer-index=false \
-    --tag "$new_tag" \
-    "$image_ref"
+  if [[ "$action" == "create" ]]; then
+    docker buildx imagetools create \
+      --prefer-index=false \
+      --tag "$new_tag" \
+      "$image_ref"
+  fi
+  set +e
   observed_digest="$(
-    docker buildx imagetools inspect "$new_tag" \
-      --format '{{json .Manifest.Digest}}' |
-      tr -d '"'
+    inspect_image_tag_digest "$new_tag" "$OUTPUT_DIR/${service}.created-tag-inspect.log"
   )"
+  inspect_status=$?
+  set -e
+  [[ "$inspect_status" == "0" ]] ||
+    oci_die "unable to verify reused tag after publication for $service"
   [[ "$observed_digest" == "$digest" ]] ||
     oci_die "reused tag digest differs from approved provenance for $service"
   {

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -252,11 +252,18 @@ for dockerfile in "$OCI_DIR/build/Dockerfile.backend" "$OCI_DIR/build/Dockerfile
 done
 verify_images="$OCI_DIR/scripts/verify-images.sh"
 build_images="$OCI_DIR/scripts/build-images.sh"
+reuse_images="$OCI_DIR/scripts/reuse-images.sh"
+compare_image_inputs="$OCI_DIR/scripts/compare-image-inputs.sh"
 grep -Fq 'repository="${OCI_REGISTRY_HOST}/${OCI_REGISTRY_NAMESPACE}/${OCI_IMAGE_PREFIX}_images"' \
   "$build_images" ||
   fail "OCI builds must share one repository so common layers stay inside the Free Tier allowance"
 grep -Fq 'tag="${repository}:oci-${service}-${SOURCE_SHA}"' "$build_images" ||
   fail "shared OCI repository tags must bind the service and exact source SHA"
+grep -Fq -- '--prefer-index=false' "$reuse_images" ||
+  fail "unchanged OCI images are not reused by immutable digest"
+grep -Fq 'oci_(die|log|require_command|require_vars|prepare_private_dir)' \
+  "$compare_image_inputs" ||
+  fail "OCI image input comparison omits the transitive build library contract"
 inventory="$OCI_DIR/scripts/inventory.sh"
 grep -Fq '[$prefix + "_images"]' "$inventory" ||
   fail "OCI inventory must allow only the shared image repository"
@@ -304,6 +311,11 @@ grep -Fq 'environment:' "$build_workflow"
 grep -Fq 'name: oci-build' "$build_workflow"
 grep -Fq 'docker login "$OCI_REGISTRY_HOST"' "$build_workflow"
 grep -Fq 'exact OCI tag already exists; refusing overwrite' "$OCI_DIR/scripts/build-images.sh"
+grep -Fq 'OCI_REUSE_SOURCE_SHA' "$build_workflow"
+grep -Fq 'OCI_REUSE_BUILD_RUN_ID' "$build_workflow"
+grep -Fq 'compare-image-inputs.sh' "$build_workflow"
+grep -Fq 'reuse-images.sh' "$build_workflow"
+grep -Fq 'upstream-${{ github.event.workflow_run.id }}' "$build_workflow"
 grep -Fq 'group: oci-build-${{ github.event.workflow_run.head_sha }}' "$build_workflow"
 ! grep -Eq 'OCI_CLI_|OCI_CI_PRIVATE_KEY_PEM' "$build_workflow" ||
   fail "OCI build workflow receives an API signing key"
@@ -444,6 +456,7 @@ if grep -R -n -E 'nat-gateway create|--type ENHANCED_CLUSTER|VM\.Standard\.(E|D|
 fi
 
 "$OCI_DIR/agents/test-health-contract-stan.sh"
+"$OCI_DIR/tests/test-image-reuse-contract.sh"
 "$OCI_DIR/tests/test-capacity-contract.sh"
 "$OCI_DIR/tests/test-k3s-runtime-contract.sh"
 

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -264,6 +264,8 @@ grep -Fq -- '--prefer-index=false' "$reuse_images" ||
 grep -Fq 'oci_(die|log|require_command|require_vars|prepare_private_dir)' \
   "$compare_image_inputs" ||
   fail "OCI image input comparison omits the transitive build library contract"
+grep -Fq 'untracked helper dependency' "$compare_image_inputs" ||
+  fail "OCI image input comparison does not enforce a closed helper dependency set"
 inventory="$OCI_DIR/scripts/inventory.sh"
 grep -Fq '[$prefix + "_images"]' "$inventory" ||
   fail "OCI inventory must allow only the shared image repository"
@@ -315,6 +317,7 @@ grep -Fq 'OCI_REUSE_SOURCE_SHA' "$build_workflow"
 grep -Fq 'OCI_REUSE_BUILD_RUN_ID' "$build_workflow"
 grep -Fq 'compare-image-inputs.sh' "$build_workflow"
 grep -Fq 'reuse-images.sh' "$build_workflow"
+grep -Fq 'for reuse_attempt in 1 2 3' "$build_workflow"
 grep -Fq 'upstream-${{ github.event.workflow_run.id }}' "$build_workflow"
 grep -Fq 'group: oci-build-${{ github.event.workflow_run.head_sha }}' "$build_workflow"
 ! grep -Eq 'OCI_CLI_|OCI_CI_PRIVATE_KEY_PEM' "$build_workflow" ||

--- a/infra/oci/tests/test-image-reuse-contract.sh
+++ b/infra/oci/tests/test-image-reuse-contract.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+OCI_DIR="$ROOT_DIR/infra/oci"
+WORK_DIR="$OCI_DIR/tests/.image-reuse-work"
+OLD_SHA=1111111111111111111111111111111111111111
+NEW_SHA=2222222222222222222222222222222222222222
+OLD_RUN_ID=1234
+NEW_RUN_ID=5678
+
+fail() {
+  echo "OCI image reuse contract failure: $*" >&2
+  exit 1
+}
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR/bin" "$WORK_DIR/source" "$WORK_DIR/state"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+cat > "$WORK_DIR/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${MOCK_DOCKER_LOG:?}"
+
+tag_key() {
+  printf '%s' "$1" | cksum | awk '{print $1}'
+}
+
+case "${1:-} ${2:-}" in
+  "login fixture.invalid")
+    cat >/dev/null
+    ;;
+  "logout fixture.invalid")
+    ;;
+  "buildx imagetools")
+    case "${3:-}" in
+      inspect)
+        tag="${4:?}"
+        state="${MOCK_DOCKER_STATE:?}/$(tag_key "$tag")"
+        if [[ -f "$state" ]]; then
+          if [[ "$*" == *"--format"* ]]; then
+            printf '"%s"\n' "$(cat "$state")"
+          else
+            printf '%s\n' "$(cat "$state")"
+          fi
+          exit 0
+        fi
+        echo "manifest unknown" >&2
+        exit 1
+        ;;
+      create)
+        [[ "${4:-}" == "--prefer-index=false" ]]
+        [[ "${5:-}" == "--tag" ]]
+        tag="${6:?}"
+        source_ref="${7:?}"
+        digest="${source_ref##*@}"
+        printf '%s\n' "$digest" > "${MOCK_DOCKER_STATE:?}/$(tag_key "$tag")"
+        ;;
+      *)
+        echo "unexpected mock imagetools command: $*" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected mock docker command: $*" >&2
+    exit 1
+    ;;
+esac
+MOCK
+chmod +x "$WORK_DIR/bin/docker"
+
+services=(auth bet backoffice client event gamemaster moderation resulting slip)
+index=1
+repository=fixture.invalid/namespace/betstan_images
+for service in "${services[@]}"; do
+  digest="$(printf '%064d' "$index")"
+  cat > "$WORK_DIR/source/${service}.env" <<ENV
+service=${service}
+repository=${repository}
+source_sha=${OLD_SHA}
+tag=${repository}:oci-${service}-${OLD_SHA}
+digest=sha256:${digest}
+platform_digest=sha256:${digest}
+image_ref=${repository}@sha256:${digest}
+platform=linux/arm64
+build_run_id=${OLD_RUN_ID}
+build_run_attempt=1
+ENV
+  index=$((index + 1))
+done
+
+PATH="$WORK_DIR/bin:$PATH" \
+MOCK_DOCKER_LOG="$WORK_DIR/docker.log" \
+MOCK_DOCKER_STATE="$WORK_DIR/state" \
+SOURCE_SHA="$NEW_SHA" \
+REUSE_SOURCE_SHA="$OLD_SHA" \
+REUSE_BUILD_RUN_ID="$OLD_RUN_ID" \
+REUSE_PROVENANCE_DIR="$WORK_DIR/source" \
+OUTPUT_DIR="$WORK_DIR/output" \
+PLATFORM=linux/arm64 \
+OCI_REGISTRY_HOST=fixture.invalid \
+OCI_REGISTRY_NAMESPACE=namespace \
+OCI_IMAGE_PREFIX=betstan \
+OCI_REGISTRY_USERNAME=fixture \
+OCI_REGISTRY_AUTH_TOKEN=fixture \
+GITHUB_RUN_ID="$NEW_RUN_ID" \
+GITHUB_RUN_ATTEMPT=1 \
+  "$OCI_DIR/scripts/reuse-images.sh" >/dev/null
+
+[[ "$(grep -c '^buildx imagetools create --prefer-index=false --tag ' "$WORK_DIR/docker.log")" == "9" ]] ||
+  fail "reuse did not create exactly nine immutable tags"
+for service in "${services[@]}"; do
+  provenance="$WORK_DIR/output/${service}.env"
+  [[ -s "$provenance" ]] || fail "reuse provenance is missing for $service"
+  grep -Fxq "service=$service" "$provenance"
+  grep -Fxq "source_sha=$NEW_SHA" "$provenance"
+  grep -Fxq "tag=${repository}:oci-${service}-${NEW_SHA}" "$provenance"
+  grep -Fxq "build_run_id=$NEW_RUN_ID" "$provenance"
+  grep -Fxq "reuse_source_sha=$OLD_SHA" "$provenance"
+  grep -Fxq "reuse_build_run_id=$OLD_RUN_ID" "$provenance"
+done
+
+auth_tag="${repository}:oci-auth-${NEW_SHA}"
+auth_key="$(printf '%s' "$auth_tag" | cksum | awk '{print $1}')"
+printf '%s\n' "sha256:$(printf '%064d' 1)" > "$WORK_DIR/state/$auth_key"
+create_count_before="$(
+  grep -c '^buildx imagetools create --prefer-index=false --tag ' "$WORK_DIR/docker.log"
+)"
+if PATH="$WORK_DIR/bin:$PATH" \
+    MOCK_DOCKER_LOG="$WORK_DIR/docker.log" \
+    MOCK_DOCKER_STATE="$WORK_DIR/state" \
+    SOURCE_SHA="$NEW_SHA" \
+    REUSE_SOURCE_SHA="$OLD_SHA" \
+    REUSE_BUILD_RUN_ID="$OLD_RUN_ID" \
+    REUSE_PROVENANCE_DIR="$WORK_DIR/source" \
+    OUTPUT_DIR="$WORK_DIR/existing-output" \
+    PLATFORM=linux/arm64 \
+    OCI_REGISTRY_HOST=fixture.invalid \
+    OCI_REGISTRY_NAMESPACE=namespace \
+    OCI_IMAGE_PREFIX=betstan \
+    OCI_REGISTRY_USERNAME=fixture \
+    OCI_REGISTRY_AUTH_TOKEN=fixture \
+    "$OCI_DIR/scripts/reuse-images.sh" >/dev/null 2>&1; then
+  fail "reuse accepted an existing exact target tag"
+fi
+create_count_after="$(
+  grep -c '^buildx imagetools create --prefer-index=false --tag ' "$WORK_DIR/docker.log"
+)"
+[[ "$create_count_after" == "$create_count_before" ]] ||
+  fail "reuse mutated the registry before completing all tag-absence checks"
+
+input_repo="$WORK_DIR/input-repository"
+git -C "$WORK_DIR" init -q input-repository
+git -C "$input_repo" config user.name fixture
+git -C "$input_repo" config user.email fixture@example.invalid
+mkdir -p \
+  "$input_repo/infra/oci/build" \
+  "$input_repo/infra/oci/scripts"
+touch "$input_repo/.dockerignore"
+for service in "${services[@]}"; do
+  mkdir -p "$input_repo/$service"
+  printf '%s\n' "$service" > "$input_repo/$service/input.txt"
+done
+printf '%s\n' 'fixture image recipe' \
+  > "$input_repo/infra/oci/build/Dockerfile.backend"
+printf '%s\n' 'fixture build driver' \
+  > "$input_repo/infra/oci/scripts/build-images.sh"
+cat > "$input_repo/infra/oci/scripts/lib.sh" <<'LIB'
+OCI_ROOT_DIR="$(pwd)"
+oci_die() {
+  exit 1
+}
+oci_log() {
+  printf '%s\n' "$*"
+}
+oci_require_command() {
+  command -v "$1"
+}
+oci_require_vars() {
+  return 0
+}
+oci_prepare_private_dir() {
+  mkdir -p "$1"
+}
+oci_unrelated_helper() {
+  return 0
+}
+LIB
+git -C "$input_repo" add .
+git -C "$input_repo" commit -q -m base
+input_base="$(git -C "$input_repo" rev-parse HEAD)"
+
+cat >> "$input_repo/infra/oci/scripts/lib.sh" <<'LIB'
+oci_another_unrelated_helper() {
+  return 0
+}
+LIB
+git -C "$input_repo" add infra/oci/scripts/lib.sh
+git -C "$input_repo" commit -q -m unrelated
+input_unrelated="$(git -C "$input_repo" rev-parse HEAD)"
+IMAGE_INPUT_REPOSITORY_ROOT="$input_repo" \
+  "$OCI_DIR/scripts/compare-image-inputs.sh" \
+  "$input_base" "$input_unrelated" >/dev/null ||
+  fail "unrelated library helper prevented immutable image reuse"
+
+cat >> "$input_repo/infra/oci/scripts/lib.sh" <<'LIB'
+oci_log() {
+  printf 'changed: %s\n' "$*"
+}
+LIB
+git -C "$input_repo" add infra/oci/scripts/lib.sh
+git -C "$input_repo" commit -q -m transitive
+input_transitive="$(git -C "$input_repo" rev-parse HEAD)"
+if IMAGE_INPUT_REPOSITORY_ROOT="$input_repo" \
+    "$OCI_DIR/scripts/compare-image-inputs.sh" \
+    "$input_unrelated" "$input_transitive" >/dev/null 2>&1; then
+  fail "transitive build library change was accepted for image reuse"
+fi
+
+echo "oci_image_reuse_contract=PASS"

--- a/infra/oci/tests/test-image-reuse-contract.sh
+++ b/infra/oci/tests/test-image-reuse-contract.sh
@@ -6,6 +6,8 @@ OCI_DIR="$ROOT_DIR/infra/oci"
 WORK_DIR="$OCI_DIR/tests/.image-reuse-work"
 OLD_SHA=1111111111111111111111111111111111111111
 NEW_SHA=2222222222222222222222222222222222222222
+RETRY_SHA=3333333333333333333333333333333333333333
+MISMATCH_SHA=4444444444444444444444444444444444444444
 OLD_RUN_ID=1234
 NEW_RUN_ID=5678
 
@@ -55,6 +57,14 @@ case "${1:-} ${2:-}" in
         tag="${6:?}"
         source_ref="${7:?}"
         digest="${source_ref##*@}"
+        if [[ -n "${MOCK_DOCKER_FAIL_TAG:-}" &&
+              "$tag" == *"$MOCK_DOCKER_FAIL_TAG"* ]]; then
+          failure_marker="${MOCK_DOCKER_STATE:?}/failure-injected"
+          if [[ ! -f "$failure_marker" ]]; then
+            touch "$failure_marker"
+            exit 42
+          fi
+        fi
         printf '%s\n' "$digest" > "${MOCK_DOCKER_STATE:?}/$(tag_key "$tag")"
         ;;
       *)
@@ -122,16 +132,57 @@ for service in "${services[@]}"; do
   grep -Fxq "reuse_build_run_id=$OLD_RUN_ID" "$provenance"
 done
 
-auth_tag="${repository}:oci-auth-${NEW_SHA}"
+if PATH="$WORK_DIR/bin:$PATH" \
+    MOCK_DOCKER_LOG="$WORK_DIR/docker.log" \
+    MOCK_DOCKER_STATE="$WORK_DIR/state" \
+    MOCK_DOCKER_FAIL_TAG="oci-event-${RETRY_SHA}" \
+    SOURCE_SHA="$RETRY_SHA" \
+    REUSE_SOURCE_SHA="$OLD_SHA" \
+    REUSE_BUILD_RUN_ID="$OLD_RUN_ID" \
+    REUSE_PROVENANCE_DIR="$WORK_DIR/source" \
+    OUTPUT_DIR="$WORK_DIR/retry-first" \
+    PLATFORM=linux/arm64 \
+    OCI_REGISTRY_HOST=fixture.invalid \
+    OCI_REGISTRY_NAMESPACE=namespace \
+    OCI_IMAGE_PREFIX=betstan \
+    OCI_REGISTRY_USERNAME=fixture \
+    OCI_REGISTRY_AUTH_TOKEN=fixture \
+    "$OCI_DIR/scripts/reuse-images.sh" >/dev/null 2>&1; then
+  fail "injected mid-publication failure unexpectedly succeeded"
+fi
+PATH="$WORK_DIR/bin:$PATH" \
+MOCK_DOCKER_LOG="$WORK_DIR/docker.log" \
+MOCK_DOCKER_STATE="$WORK_DIR/state" \
+MOCK_DOCKER_FAIL_TAG="oci-event-${RETRY_SHA}" \
+SOURCE_SHA="$RETRY_SHA" \
+REUSE_SOURCE_SHA="$OLD_SHA" \
+REUSE_BUILD_RUN_ID="$OLD_RUN_ID" \
+REUSE_PROVENANCE_DIR="$WORK_DIR/source" \
+OUTPUT_DIR="$WORK_DIR/retry-second" \
+PLATFORM=linux/arm64 \
+OCI_REGISTRY_HOST=fixture.invalid \
+OCI_REGISTRY_NAMESPACE=namespace \
+OCI_IMAGE_PREFIX=betstan \
+OCI_REGISTRY_USERNAME=fixture \
+OCI_REGISTRY_AUTH_TOKEN=fixture \
+GITHUB_RUN_ID="$NEW_RUN_ID" \
+GITHUB_RUN_ATTEMPT=1 \
+  "$OCI_DIR/scripts/reuse-images.sh" >/dev/null
+for service in "${services[@]}"; do
+  [[ -s "$WORK_DIR/retry-second/${service}.env" ]] ||
+    fail "retry did not recover provenance for $service"
+done
+
+auth_tag="${repository}:oci-auth-${MISMATCH_SHA}"
 auth_key="$(printf '%s' "$auth_tag" | cksum | awk '{print $1}')"
-printf '%s\n' "sha256:$(printf '%064d' 1)" > "$WORK_DIR/state/$auth_key"
+printf '%s\n' "sha256:$(printf '%064d' 99)" > "$WORK_DIR/state/$auth_key"
 create_count_before="$(
   grep -c '^buildx imagetools create --prefer-index=false --tag ' "$WORK_DIR/docker.log"
 )"
 if PATH="$WORK_DIR/bin:$PATH" \
     MOCK_DOCKER_LOG="$WORK_DIR/docker.log" \
     MOCK_DOCKER_STATE="$WORK_DIR/state" \
-    SOURCE_SHA="$NEW_SHA" \
+    SOURCE_SHA="$MISMATCH_SHA" \
     REUSE_SOURCE_SHA="$OLD_SHA" \
     REUSE_BUILD_RUN_ID="$OLD_RUN_ID" \
     REUSE_PROVENANCE_DIR="$WORK_DIR/source" \
@@ -143,7 +194,7 @@ if PATH="$WORK_DIR/bin:$PATH" \
     OCI_REGISTRY_USERNAME=fixture \
     OCI_REGISTRY_AUTH_TOKEN=fixture \
     "$OCI_DIR/scripts/reuse-images.sh" >/dev/null 2>&1; then
-  fail "reuse accepted an existing exact target tag"
+  fail "reuse accepted an existing exact target tag with a mismatched digest"
 fi
 create_count_after="$(
   grep -c '^buildx imagetools create --prefer-index=false --tag ' "$WORK_DIR/docker.log"
@@ -207,7 +258,10 @@ IMAGE_INPUT_REPOSITORY_ROOT="$input_repo" \
 
 cat >> "$input_repo/infra/oci/scripts/lib.sh" <<'LIB'
 oci_log() {
-  printf 'changed: %s\n' "$*"
+  oci_log_delegate "$*"
+}
+oci_log_delegate() {
+  printf 'delegated: %s\n' "$*"
 }
 LIB
 git -C "$input_repo" add infra/oci/scripts/lib.sh
@@ -216,7 +270,7 @@ input_transitive="$(git -C "$input_repo" rev-parse HEAD)"
 if IMAGE_INPUT_REPOSITORY_ROOT="$input_repo" \
     "$OCI_DIR/scripts/compare-image-inputs.sh" \
     "$input_unrelated" "$input_transitive" >/dev/null 2>&1; then
-  fail "transitive build library change was accepted for image reuse"
+  fail "untracked transitive build helper was accepted for image reuse"
 fi
 
 echo "oci_image_reuse_contract=PASS"


### PR DESCRIPTION
## Summary
- reuse verified immutable ARM64 digests when all transitive image inputs are unchanged
- preserve the normal full-build path behind a fresh explicit approval when inputs change
- bind reusable runs and artifacts to exact source/upstream provenance
- prevent Buildx index wrapping and partial mutation from pre-existing tags

## Validation
- `./infra/oci/tests/test-contract.sh`
- `actionlint -shellcheck= .github/workflows/oci-*.yml`
- `shellcheck` on new scripts/tests
- deployment-safety review: GO for feature→dev only

## Deployment safety
This PR targets `dev` only and does not trigger production. Do not promote to `master` or approve OCI workflows while OCIR provider storage exceeds 500,000,000 bytes.