### PR TITLE
fix(oci): normalize paravirtualized attachment type

### DIFF
--- a/infra/oci/scripts/finalize-k3s.sh
+++ b/infra/oci/scripts/finalize-k3s.sh
@@ -331,7 +331,7 @@ jq -e \
     .data."instance-id" == $instance and
     .data."volume-id" == $volume and
     .data.device == $device and
-    .data."attachment-type" == "PARAVIRTUALIZED" and
+    (.data."attachment-type" | ascii_downcase) == "paravirtualized" and
     .data."is-read-only" == false and
     .data."is-shareable" == false and
     .data."lifecycle-state" == "ATTACHED"

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -373,6 +373,18 @@ grep -Fq 'kubectl --request-timeout=15s get node' "$finalizer" ||
   fail "k3s finalizer node lookup does not have a bounded request timeout"
 grep -Fq -- '--shape-name flexible' "$finalizer" ||
   fail "k3s finalizer does not create a flexible OCI load balancer"
+grep -Fq '(.data."attachment-type" | ascii_downcase) == "paravirtualized"' \
+  "$finalizer" ||
+  fail "k3s finalizer does not normalize OCI attachment type casing"
+jq -e '
+  (.data."attachment-type" | ascii_downcase) == "paravirtualized"
+' <<< '{"data":{"attachment-type":"paravirtualized"}}' >/dev/null ||
+  fail "provider-reported lowercase paravirtualized attachment was rejected"
+if jq -e '
+    (.data."attachment-type" | ascii_downcase) == "paravirtualized"
+  ' <<< '{"data":{"attachment-type":"iscsi"}}' >/dev/null; then
+  fail "non-paravirtualized attachment type was accepted"
+fi
 grep -Fq -- '--health-checker-protocol TCP' "$finalizer" ||
   fail "k3s finalizer does not use TCP load balancer health checks"
 grep -Fq 'ensure_listener betstan-http 80 betstan-http' "$finalizer" ||


### PR DESCRIPTION
## Root cause

Infrastructure finalize run `30960644309` failed closed after OCI attached the zero-cost 50-GB Mongo volume. The live OCI API serializes `attachment-type` as lowercase `paravirtualized`, while `finalize-k3s.sh` compared it case-sensitively with uppercase `PARAVIRTUALIZED`. All other approved attachment properties matched.

## Deployment-only fix

Normalize only the provider enum casing with jq `ascii_downcase`, while continuing to require paravirtualized, the exact instance/volume/device, read-write, non-shareable, and ATTACHED state. No application code, topology, architecture, Azure behavior, or safety threshold changes.

## Validation

- full OCI offline contract suite: PASS
- targeted k3s runtime contract: PASS
- live attached-volume regression assertion: PASS
- pre-commit secret/ingress checks: PASS
- offline YAML parse: PASS
- failed-run Bastion cleanup: one Bastion, zero active sessions, non-routable default CIDR

The failed first attempt produced no infrastructure provenance and deployed no application.