### PR TITLE
fix(oci): promote attachment type normalization

### DIFF
--- a/infra/oci/scripts/finalize-k3s.sh
+++ b/infra/oci/scripts/finalize-k3s.sh
@@ -331,7 +331,7 @@ jq -e \
     .data."instance-id" == $instance and
     .data."volume-id" == $volume and
     .data.device == $device and
-    .data."attachment-type" == "PARAVIRTUALIZED" and
+    (.data."attachment-type" | ascii_downcase) == "paravirtualized" and
     .data."is-read-only" == false and
     .data."is-shareable" == false and
     .data."lifecycle-state" == "ATTACHED"

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -373,6 +373,18 @@ grep -Fq 'kubectl --request-timeout=15s get node' "$finalizer" ||
   fail "k3s finalizer node lookup does not have a bounded request timeout"
 grep -Fq -- '--shape-name flexible' "$finalizer" ||
   fail "k3s finalizer does not create a flexible OCI load balancer"
+grep -Fq '(.data."attachment-type" | ascii_downcase) == "paravirtualized"' \
+  "$finalizer" ||
+  fail "k3s finalizer does not normalize OCI attachment type casing"
+jq -e '
+  (.data."attachment-type" | ascii_downcase) == "paravirtualized"
+' <<< '{"data":{"attachment-type":"paravirtualized"}}' >/dev/null ||
+  fail "provider-reported lowercase paravirtualized attachment was rejected"
+if jq -e '
+    (.data."attachment-type" | ascii_downcase) == "paravirtualized"
+  ' <<< '{"data":{"attachment-type":"iscsi"}}' >/dev/null; then
+  fail "non-paravirtualized attachment type was accepted"
+fi
 grep -Fq -- '--health-checker-protocol TCP' "$finalizer" ||
   fail "k3s finalizer does not use TCP load balancer health checks"
 grep -Fq 'ensure_listener betstan-http 80 betstan-http' "$finalizer" ||


### PR DESCRIPTION
Promotes the fail-closed OCI infrastructure correction from PR #141. Infrastructure run 30960644309 attached the approved zero-cost Mongo volume, then rejected the provider lowercase paravirtualized enum. This normalizes only enum casing while retaining every attachment identity and safety check. No application code, architecture, Azure behavior, topology, or cost gate changes. Full OCI contracts and protected dev checks pass.