### PR TITLE
fix(oci): allow only the load balancer reserved IP

### DIFF
--- a/infra/oci/scripts/inventory.sh
+++ b/infra/oci/scripts/inventory.sh
@@ -149,6 +149,10 @@ inventory="$(
                 ."freeform-tags".provider == "oci" and
                 ."freeform-tags"["expected-monthly-cost"] == "0"
               ),
+              public_ip_count: ([
+                ."ip-addresses"[]?
+                | select(."is-public" == true)
+              ] | length),
               state: ."lifecycle-state"
             }
         ],
@@ -168,10 +172,20 @@ inventory="$(
         reserved_public_ips: [
           $public_ips.data[]?
           | select(."lifecycle-state" != "TERMINATED")
+          | . as $public_ip
           | {
               lifetime,
               assigned: (."assigned-entity-id" != null),
-              scope
+              scope,
+              load_balancer_owned: (
+                ([
+                  $load_balancers.data[]?
+                  | select(."lifecycle-state" != "DELETED")
+                  | ."ip-addresses"[]?
+                  | select(."is-public" == true)
+                  | ."ip-address"
+                ] | index($public_ip."ip-address")) != null
+              )
             }
         ],
         bastions: [
@@ -221,7 +235,12 @@ jq -e --argjson ocpus "$OCI_A1_OCPUS" --argjson memory "$OCI_A1_MEMORY_GB" \
     .nat_gateway_count == 0 and
     .service_gateway_count == 0 and
     .internet_gateway_count <= 1 and
-    (.reserved_public_ips | length) == 0 and
+    ([.reserved_public_ips[] | select(
+      .lifetime != "RESERVED" or .assigned != true or
+      .scope != "REGION" or .load_balancer_owned != true
+    )] | length) == 0 and
+    (.reserved_public_ips | length) ==
+      ([.load_balancers[].public_ip_count] | add // 0) and
     .network_load_balancer_count == 0 and
     ([.clusters[] | select(.type != "BASIC_CLUSTER")] | length) == 0 and
     ([.node_pools[] | select(
@@ -238,6 +257,7 @@ jq -e --argjson ocpus "$OCI_A1_OCPUS" --argjson memory "$OCI_A1_MEMORY_GB" \
     ([.load_balancers[] | select(
       .shape != "flexible" or
       .managed != true or
+      .public_ip_count != 1 or
       .minimum_mbps != $lb_min or .maximum_mbps != $lb_max
     )] | length) == 0 and
     (([.block_volumes[].size_gb] | add // 0) +

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -117,6 +117,11 @@ cat > "$WORK_DIR/responses/load-balancers.json" <<'JSON'
     "minimum-bandwidth-in-mbps":10,
     "maximum-bandwidth-in-mbps":10
   },
+  "ip-addresses":[{
+    "ip-address":"192.0.2.10",
+    "is-public":true,
+    "reserved-ip":null
+  }],
   "freeform-tags":{
     "betstan-managed":"true",
     "provider":"oci",
@@ -138,7 +143,13 @@ cat > "$WORK_DIR/responses/service-gateways.json" <<'JSON'
 {"data":[]}
 JSON
 cat > "$WORK_DIR/responses/public-ips.json" <<'JSON'
-{"data":[]}
+{"data":[{
+  "ip-address":"192.0.2.10",
+  "lifecycle-state":"ASSIGNED",
+  "lifetime":"RESERVED",
+  "assigned-entity-id":"ocid1.privateip.oc1..fixture",
+  "scope":"REGION"
+}]}
 JSON
 cat > "$WORK_DIR/responses/bastions.json" <<'JSON'
 {"data":[{
@@ -196,6 +207,53 @@ jq -e '
 ' "$WORK_DIR/k3s-inventory.json" >/dev/null ||
   fail "valid direct-k3s inventory was rejected"
 
+cat > "$WORK_DIR/responses/public-ips.json" <<'JSON'
+{"data":[{
+  "ip-address":"192.0.2.11",
+  "lifecycle-state":"ASSIGNED",
+  "lifetime":"RESERVED",
+  "assigned-entity-id":"ocid1.privateip.oc1..unrelated",
+  "scope":"REGION"
+}]}
+JSON
+if env "${inventory_env[@]}" \
+    INVENTORY_MODE=complete \
+    OUTPUT_FILE="$WORK_DIR/unrelated-reserved-ip-inventory.json" \
+    "$OCI_DIR/scripts/inventory.sh" >/dev/null 2>&1; then
+  fail "unrelated reserved public IP was accepted"
+fi
+
+cat > "$WORK_DIR/responses/public-ips.json" <<'JSON'
+{"data":[{
+  "ip-address":"192.0.2.10",
+  "lifecycle-state":"ASSIGNED",
+  "lifetime":"RESERVED",
+  "assigned-entity-id":"ocid1.privateip.oc1..fixture",
+  "scope":"REGION"
+},{
+  "ip-address":"192.0.2.11",
+  "lifecycle-state":"ASSIGNED",
+  "lifetime":"RESERVED",
+  "assigned-entity-id":"ocid1.privateip.oc1..extra",
+  "scope":"REGION"
+}]}
+JSON
+if env "${inventory_env[@]}" \
+    INVENTORY_MODE=complete \
+    OUTPUT_FILE="$WORK_DIR/extra-reserved-ip-inventory.json" \
+    "$OCI_DIR/scripts/inventory.sh" >/dev/null 2>&1; then
+  fail "extra reserved public IP was accepted"
+fi
+
+cat > "$WORK_DIR/responses/public-ips.json" <<'JSON'
+{"data":[{
+  "ip-address":"192.0.2.10",
+  "lifecycle-state":"ASSIGNED",
+  "lifetime":"RESERVED",
+  "assigned-entity-id":"ocid1.privateip.oc1..fixture",
+  "scope":"REGION"
+}]}
+JSON
 cat > "$WORK_DIR/responses/clusters.json" <<'JSON'
 {"data":[{
   "name":"unexpected-oke",


### PR DESCRIPTION
Infrastructure finalize run 30963262968 installed the approved add-ons and created the single flexible 10/10 Mbps load balancer, then failed closed because the inventory rejected every regional reserved IP—including the sole public IP owned by that approved load balancer. This deployment-only fix correlates reserved IPs to public addresses on the managed load balancer, requires exactly one public address per present load balancer, and still rejects unrelated or extra reserved IPs. No application code, architecture, Azure behavior, topology, or cost threshold changes. Full OCI contracts and a live complete-inventory regression pass.