### PR TITLE
fix(oci): make Mongo mount retry idempotent

### DIFF
--- a/infra/oci/scripts/finalize-k3s.sh
+++ b/infra/oci/scripts/finalize-k3s.sh
@@ -407,15 +407,15 @@ else
   printf '%s\n' "$fstab_entry" | sudo tee -a /etc/fstab >/dev/null
 fi
 sudo mkdir -p "$mount_path"
-if mountpoint -q "$mount_path"; then
-  [[ "$(findmnt -n -o UUID --target "$mount_path")" == "$uuid" ]] ||
+if sudo mountpoint -q "$mount_path"; then
+  [[ "$(sudo findmnt -n -o UUID --target "$mount_path")" == "$uuid" ]] ||
     { echo "Mongo path is mounted from an unexpected volume" >&2; exit 1; }
 else
   sudo mount "$mount_path"
 fi
 sudo chown 999:999 "$mount_path"
 sudo chmod 0700 "$mount_path"
-sudo test "$(findmnt -n -o FSTYPE --target "$mount_path")" = ext4
+sudo test "$(sudo findmnt -n -o FSTYPE --target "$mount_path")" = ext4
 sudo systemctl is-active --quiet k3s
 REMOTE
 

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -451,5 +451,11 @@ grep -Fq 'ensure_listener betstan-https 443 betstan-https' "$finalizer" ||
   fail "k3s finalizer lacks the exact HTTPS listener"
 grep -Fq 'UUID=$uuid' "$finalizer" ||
   fail "k3s finalizer does not persist the Mongo mount by UUID"
+grep -Fq 'if sudo mountpoint -q "$mount_path"; then' "$finalizer" ||
+  fail "k3s finalizer checks the protected Mongo mount without privilege"
+grep -Fq 'sudo findmnt -n -o UUID --target "$mount_path"' "$finalizer" ||
+  fail "k3s finalizer cannot validate the protected Mongo mount UUID"
+grep -Fq 'sudo findmnt -n -o FSTYPE --target "$mount_path"' "$finalizer" ||
+  fail "k3s finalizer cannot validate the protected Mongo filesystem"
 
 echo "oci_k3s_runtime_contract=PASS"


### PR DESCRIPTION
Infrastructure finalize run 30964980233 correctly found the retained Mongo volume already mounted after a prior partial attempt, but its unprivileged mountpoint probe could not inspect the protected 0700 Mongo path and attempted a duplicate mount. This deployment-only fix performs mountpoint and findmnt validation with sudo, still requiring the exact UUID and ext4 filesystem. No application code, architecture, topology, Azure behavior, or safety gate changes. Full OCI contracts pass.