### PR TITLE
fix(oci): pin backend runtime user numerically

### DIFF
--- a/infra/oci/k8s/patches/resources.yaml
+++ b/infra/oci/k8s/patches/resources.yaml
@@ -18,5 +18,7 @@
     capabilities:
       drop: [ALL]
     runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
     seccompProfile:
       type: RuntimeDefault

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -156,6 +156,23 @@ abort "resource requests/limits missing" unless workloads.all? {
     |container| container.dig("resources", "requests") && container.dig("resources", "limits")
   }
 }
+backend_names = %w[
+  gaming-auth-depl gaming-bet-depl gaming-backoffice-depl gaming-event-depl
+  gaming-gamemaster-depl gaming-moderation-depl gaming-resulting-depl
+  gaming-slip-depl
+]
+backends = by_kind.fetch("Deployment").select {
+  |deployment| backend_names.include?(deployment.dig("metadata", "name"))
+}
+abort "eight backend deployments required" unless backends.length == 8
+abort "backend numeric non-root identity differs" unless backends.all? {
+  |deployment| deployment.dig(
+    "spec", "template", "spec", "containers", 0, "securityContext"
+  ).then {
+    |context| context["runAsNonRoot"] == true &&
+      context["runAsUser"] == 1000 && context["runAsGroup"] == 1000
+  }
+}
 mongo = by_kind.fetch("StatefulSet").first
 abort "base StatefulSet claim template survived OCI patch" if mongo.dig("spec", "volumeClaimTemplates")
 abort "Mongo does not use the explicit 50Gi claim" unless mongo.dig(


### PR DESCRIPTION
OCI deployment run 30966763173 failed closed on the first backend because Kubernetes could not verify the inherited non-numeric image user node under runAsNonRoot. This deployment-manifest-only fix pins the eight Node backend containers to their existing numeric node identity, UID/GID 1000, while preserving runAsNonRoot, dropped capabilities, no privilege escalation, and RuntimeDefault seccomp. No image inputs, application code, architecture, topology, Azure behavior, or cost gates change. Full rendered OCI contracts pass.