### PR TITLE
fix(oci): normalize RabbitMQ queue output

### DIFF
--- a/infra/oci/agents/health-check-stan.sh
+++ b/infra/oci/agents/health-check-stan.sh
@@ -355,14 +355,16 @@ queue_output="$(
   kubectl exec -n "$OCI_K8S_NAMESPACE" "$rabbit_pod" -- \
     rabbitmqctl list_queues --quiet name messages_ready messages_unacknowledged consumers
 )"
-queue_count="$(awk 'NF >= 4 {count++} END {print count+0}' <<<"$queue_output")"
-queue_backlog="$(awk 'NF >= 4 {sum += $2 + $3} END {print sum+0}' <<<"$queue_output")"
+queue_rows="$(oci_rabbitmq_queue_rows <<<"$queue_output")" ||
+  oci_die "RabbitMQ queue output is malformed"
+queue_count="$(awk 'NF {count++} END {print count+0}' <<<"$queue_rows")"
+queue_backlog="$(awk '{sum += $2 + $3} END {print sum+0}' <<<"$queue_rows")"
 all_consumers=true
-awk 'NF >= 4 && $4 < 1 {bad=1} END {exit bad}' <<<"$queue_output" || all_consumers=false
+awk '$4 < 1 {bad=1} END {exit bad}' <<<"$queue_rows" || all_consumers=false
 queue_baseline_match=false
 if [[ -n "${OCI_RABBITMQ_BASELINE_FILE:-}" ]]; then
   [[ -f "$OCI_RABBITMQ_BASELINE_FILE" ]] || oci_die "RabbitMQ baseline file is missing"
-  observed_names="$(awk 'NF >= 4 {print $1}' <<<"$queue_output" | sort)"
+  observed_names="$(awk '{print $1}' <<<"$queue_rows" | sort)"
   expected_names="$(sort "$OCI_RABBITMQ_BASELINE_FILE")"
   [[ "$observed_names" == "$expected_names" ]] && queue_baseline_match=true
 elif [[ "$queue_count" == "17" ]]; then

--- a/infra/oci/scripts/deploy.sh
+++ b/infra/oci/scripts/deploy.sh
@@ -216,23 +216,26 @@ rabbit_pod="$(
 )"
 [[ -n "$rabbit_pod" ]] || oci_die "RabbitMQ pod is missing after rollout"
 rabbit_baseline_ready=0
+queue_rows=""
 for _ in $(seq 1 60); do
   queue_state="$(
     kubectl exec -n "$OCI_K8S_NAMESPACE" "$rabbit_pod" -- \
       rabbitmqctl list_queues --quiet name messages_ready messages_unacknowledged consumers \
       2>/dev/null || true
   )"
-  queue_count="$(awk 'NF >= 4 {count++} END {print count+0}' <<<"$queue_state")"
-  if [[ "$queue_count" == "17" ]] &&
-      awk 'NF >= 4 && $4 < 1 {bad=1} END {exit bad}' <<<"$queue_state"; then
-    rabbit_baseline_ready=1
-    break
+  if queue_rows="$(oci_rabbitmq_queue_rows <<<"$queue_state")"; then
+    queue_count="$(awk 'NF {count++} END {print count+0}' <<<"$queue_rows")"
+    if [[ "$queue_count" == "17" ]] &&
+        awk '$4 < 1 {bad=1} END {exit bad}' <<<"$queue_rows"; then
+      rabbit_baseline_ready=1
+      break
+    fi
   fi
   sleep 5
 done
 [[ "$rabbit_baseline_ready" == "1" ]] ||
   oci_die "RabbitMQ did not establish the expected 17-consumer baseline"
-awk 'NF >= 4 {print $1}' <<<"$queue_state" | sort > "$OUTPUT_DIR/rabbitmq-baseline.txt"
+awk '{print $1}' <<<"$queue_rows" | sort > "$OUTPUT_DIR/rabbitmq-baseline.txt"
 
 apply_documents 'Ingress:^gaming-oci-ingress$'
 

--- a/infra/oci/scripts/lib.sh
+++ b/infra/oci/scripts/lib.sh
@@ -168,6 +168,32 @@ oci_normalize_list_json() {
   printf '%s\n' "$response"
 }
 
+oci_rabbitmq_queue_rows() {
+  awk '
+    /^[[:space:]]*$/ { next }
+    NF == 4 &&
+      $1 == "name" &&
+      $2 == "messages_ready" &&
+      $3 == "messages_unacknowledged" &&
+      $4 == "consumers" {
+        if (header_seen) {
+          exit 2
+        }
+        header_seen = 1
+        next
+      }
+    NF != 4 ||
+      $2 !~ /^[0-9]+$/ ||
+      $3 !~ /^[0-9]+$/ ||
+      $4 !~ /^[0-9]+$/ {
+        exit 2
+      }
+    {
+      print $1 "\t" $2 "\t" $3 "\t" $4
+    }
+  '
+}
+
 oci_assert_repository_root() {
   [[ -f "$OCI_ROOT_DIR/CONTRIBUTING.md" && -d "$OCI_ROOT_DIR/infra/k8s" ]] ||
     oci_die "unable to identify the BetStan repository root"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -33,6 +33,26 @@ source "$OCI_DIR/scripts/lib.sh"
   fail "empty OCI array response was not normalized"
 [[ "$(oci_normalize_list_json "" items)" == '{"data":{"items":[]}}' ]] ||
   fail "empty OCI items response was not normalized"
+queue_fixture="$(
+  printf '%s\n' \
+    'name messages_ready messages_unacknowledged consumers' \
+    'event_new_event 0 0 1' \
+    'bet_place_bet 2 1 3'
+)"
+queue_rows="$(oci_rabbitmq_queue_rows <<<"$queue_fixture")" ||
+  fail "RabbitMQ queue output with a header was rejected"
+[[ "$(awk 'NF {count++} END {print count+0}' <<<"$queue_rows")" == "2" ]] ||
+  fail "RabbitMQ header was counted as a queue"
+[[ "$(awk '{sum += $2 + $3} END {print sum+0}' <<<"$queue_rows")" == "3" ]] ||
+  fail "RabbitMQ normalized backlog differs"
+[[ "$(awk '{sum += $4} END {print sum+0}' <<<"$queue_rows")" == "4" ]] ||
+  fail "RabbitMQ normalized consumer count differs"
+if oci_rabbitmq_queue_rows <<<'name messages_ready messages_unacknowledged consumers extra' >/dev/null; then
+  fail "malformed RabbitMQ queue output was accepted"
+fi
+if oci_rabbitmq_queue_rows <<<$'name messages_ready messages_unacknowledged consumers\nname messages_ready messages_unacknowledged consumers' >/dev/null; then
+  fail "duplicate RabbitMQ queue headers were accepted"
+fi
 redacted="$(
   printf '%s\n' \
     'Authorization: Bearer header-secret' \


### PR DESCRIPTION
Promotes the protected dev fix for the exact live failure in OCI deploy 30969183001. All application workloads rolled out and live diagnostics showed exactly 17 queues with active consumers and zero backlog; the gate falsely counted the canonical rabbitmqctl header. The active deploy and protected-health paths now share strict, fail-closed header normalization with contract coverage. OCI image inputs remain unchanged from e819935a9e892666177826355c699a16bfe95166. No application code, image content, architecture, topology, Azure path, cloud resources, or zero-cost gates change.