### PR TITLE
fix(oci): support strict ACME challenge paths

### DIFF
--- a/infra/oci/agents/health-check-stan.sh
+++ b/infra/oci/agents/health-check-stan.sh
@@ -264,8 +264,8 @@ import sys
 
 pods = json.load(open(sys.argv[1], encoding="utf-8"))
 expected = {
-    "gaming-auth-mongo": "sha256:c319ea11661a662ce212de699b01dc08891e4c95e8c7a058d366d70eb3804782",
-    "gaming-rabbitmq": "sha256:c571b0e76ec0f56e64b36c962d8ff7c04854031974ccde763844087df75b245c",
+    "gaming-auth-mongo": "sha256:3d715950d83061ff2fbc910d12d3703212538cacf6b3003e3736fa5c7f51a2e1",
+    "gaming-rabbitmq": "sha256:6033d0c2f4e9eb49dda9623067a96d317bc7b550513bd18532fbd3cd9a941c1b",
 }
 with open(sys.argv[2], encoding="utf-8") as handle:
     for row in csv.reader(handle, delimiter="\t"):

--- a/infra/oci/helm/ingress-nginx-k3s-values.yaml
+++ b/infra/oci/helm/ingress-nginx-k3s-values.yaml
@@ -1,8 +1,8 @@
 controller:
   replicaCount: 1
   image:
-    tag: v1.12.1
-    digest: sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b
+    tag: v1.15.1
+    digest: sha256:594ceea76b01c592858f803f9ff4d2cb40542cae2060410b2c95f75907d659e1
   admissionWebhooks:
     enabled: true
     patch:

--- a/infra/oci/helm/ingress-nginx-values.yaml
+++ b/infra/oci/helm/ingress-nginx-values.yaml
@@ -1,8 +1,8 @@
 controller:
   replicaCount: 1
   image:
-    tag: v1.12.1
-    digest: sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b
+    tag: v1.15.1
+    digest: sha256:594ceea76b01c592858f803f9ff4d2cb40542cae2060410b2c95f75907d659e1
   admissionWebhooks:
     enabled: true
     patch:

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -262,8 +262,23 @@ load_balancer_declarations="$(
   fail "OCI assets must declare exactly one LoadBalancer service"
 grep -Fq 'oci.oraclecloud.com/load-balancer-type: "lb"' "$OCI_DIR/helm/ingress-nginx-values.yaml"
 grep -Fq 'oci-load-balancer-security-list-management-mode: "None"' "$OCI_DIR/helm/ingress-nginx-values.yaml"
-grep -Fq 'digest: sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b' \
-  "$OCI_DIR/helm/ingress-nginx-values.yaml"
+for ingress_values in \
+  "$OCI_DIR/helm/ingress-nginx-values.yaml" \
+  "$OCI_DIR/helm/ingress-nginx-k3s-values.yaml"; do
+  grep -Fq 'tag: v1.15.1' "$ingress_values" ||
+    fail "ingress-nginx does not support strict ACME challenge paths"
+  grep -Fq 'digest: sha256:594ceea76b01c592858f803f9ff4d2cb40542cae2060410b2c95f75907d659e1' \
+    "$ingress_values" ||
+    fail "ingress-nginx digest differs from the reviewed multi-architecture image"
+  ! grep -Eq "strict-validate-path-type:[[:space:]]*['\"]?false" "$ingress_values" ||
+    fail "ingress-nginx strict path validation was disabled"
+done
+grep -Fq '"gaming-auth-mongo": "sha256:3d715950d83061ff2fbc910d12d3703212538cacf6b3003e3736fa5c7f51a2e1"' \
+  "$OCI_DIR/agents/health-check-stan.sh" ||
+  fail "Mongo health identity differs from the requested immutable index"
+grep -Fq '"gaming-rabbitmq": "sha256:6033d0c2f4e9eb49dda9623067a96d317bc7b550513bd18532fbd3cd9a941c1b"' \
+  "$OCI_DIR/agents/health-check-stan.sh" ||
+  fail "RabbitMQ health identity differs from the requested immutable index"
 grep -Fq 'shape-flex-min: "10"' "$OCI_DIR/helm/ingress-nginx-values.yaml"
 grep -Fq 'shape-flex-max: "10"' "$OCI_DIR/helm/ingress-nginx-values.yaml"
 


### PR DESCRIPTION
Exact deploy 30971302708 rolled out every workload and passed application/API/browser, Mongo, RabbitMQ, resource, and zero-cost checks, but protected health failed because the pinned ingress-nginx v1.12.1 admission rule rejects the cert-manager `/.well-known/acme-challenge/...` Exact path. The already-pinned chart 4.15.1 defaults to controller v1.15.1, whose strict validator explicitly permits `.` while retaining strict path validation. This updates both OCI controller values to that exact reviewed multi-architecture digest; no validation is disabled. Live k3s evidence also showed containerd reports the requested immutable index digest for Mongo/RabbitMQ imageID, so health now compares those exact pinned index digests rather than their platform manifests. No application code, architecture, topology, Azure path, paid resource, or cost gate changes.