### PR TITLE
fix(oci): validate accessible browser brand

### DIFF
--- a/infra/oci/agents/oci-live-smoke.spec.js
+++ b/infra/oci/agents/oci-live-smoke.spec.js
@@ -6,7 +6,7 @@ test('OCI signup, logout, login, and navigation journey', async ({ page }) => {
   const password = `Oc1-${suffix}`.slice(0, 20);
 
   await page.goto('/', { waitUntil: 'domcontentloaded' });
-  await expect(page.locator('body')).toContainText('BetStan');
+  await expect(page.getByRole('link', { name: 'BetStan', exact: true })).toBeVisible();
   await page.getByTitle('Create account').click();
   await page.getByLabel('Username', { exact: true }).fill(username);
   await page.getByLabel('Password', { exact: true }).fill(password);

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -26,6 +26,13 @@ PYTHONPYCACHEPREFIX="$WORK_DIR/pycache" \
   python3 -m py_compile "$OCI_DIR/agents/health-contract.py"
 node --check "$OCI_DIR/agents/playwright.config.js"
 node --check "$OCI_DIR/agents/oci-live-smoke.spec.js"
+grep -Fq "getByRole('link', { name: 'BetStan', exact: true })" \
+  "$OCI_DIR/agents/oci-live-smoke.spec.js" ||
+  fail "OCI browser check does not use the accessible BetStan brand"
+if grep -Fq "locator('body')).toContainText('BetStan')" \
+    "$OCI_DIR/agents/oci-live-smoke.spec.js"; then
+  fail "OCI browser check still relies on image alt text appearing in body text"
+fi
 
 # shellcheck source=../scripts/lib.sh
 source "$OCI_DIR/scripts/lib.sh"


### PR DESCRIPTION
Promotes the protected dev fix for the only failed gate in deployment 30974991027. Its exact rollout, protected cluster health, certificate readiness, digests, Mongo, RabbitMQ, resource pressure, and deployment provenance all passed. The credential-free browser job then falsely searched `body.textContent` for an image-backed `BetStan` accessible name. The exact diagnostics accessibility tree proves one navigation link named `BetStan`; this uses Playwright’s exact role locator and adds regression coverage. No application code, image inputs, architecture, manifests, cloud resources, Azure behavior, or safety gate changes.