### PR TITLE
fix(oci): stabilize load balancer backend path

### DIFF
--- a/infra/oci/scripts/provision.sh
+++ b/infra/oci/scripts/provision.sh
@@ -315,6 +315,16 @@ if [[ "$MODE" == "cloud" ]]; then
           tcpOptions:{destinationPortRange:{min:$port,max:$port}}
         }'
       )"
+      # Keep the regional LB data path bounded when a backend connection does
+      # not retain the source NSG identity.
+      ensure_nsg_rule "${nsg_ids[worker]}" "lb-subnet-to-nodeport-${port}" "$(
+        jq -cn --arg source "$OCI_LB_SUBNET_CIDR" --argjson port "$port" '{
+          direction:"INGRESS", protocol:"6", sourceType:"CIDR_BLOCK",
+          source:$source, isStateless:false,
+          description:("lb-subnet-to-nodeport-" + ($port|tostring)),
+          tcpOptions:{destinationPortRange:{min:$port,max:$port}}
+        }'
+      )"
     done
   fi
   ensure_nsg_rule "${nsg_ids[worker]}" "worker-internet-egress" '{
@@ -349,6 +359,16 @@ if [[ "$MODE" == "cloud" ]]; then
           tcpOptions:{destinationPortRange:{min:$port,max:$port}}
         }'
       )"
+      # Mirror the dedicated-subnet path on egress without opening any other
+      # worker port or external destination.
+      ensure_nsg_rule "${nsg_ids[lb]}" "lb-to-worker-subnet-${port}" "$(
+        jq -cn --arg destination "$OCI_WORKER_SUBNET_CIDR" --argjson port "$port" '{
+          direction:"EGRESS", protocol:"6", destinationType:"CIDR_BLOCK",
+          destination:$destination, isStateless:false,
+          description:("lb-to-worker-subnet-" + ($port|tostring)),
+          tcpOptions:{destinationPortRange:{min:$port,max:$port}}
+        }'
+      )"
     done
   fi
   if [[ "$OCI_RUNTIME_MODE" == "k3s" ]]; then
@@ -358,13 +378,17 @@ if [[ "$MODE" == "cloud" ]]; then
       "bastion-to-worker-6443",
       "lb-to-nodeport-30080",
       "lb-to-nodeport-30443",
+      "lb-subnet-to-nodeport-30080",
+      "lb-subnet-to-nodeport-30443",
       "worker-internet-egress"
     ]'
     assert_nsg_rule_set "${nsg_ids[lb]}" '[
       "world-to-lb-80",
       "world-to-lb-443",
       "lb-to-worker-30080",
-      "lb-to-worker-30443"
+      "lb-to-worker-30443",
+      "lb-to-worker-subnet-30080",
+      "lb-to-worker-subnet-30443"
     ]'
   fi
 

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -31,6 +31,23 @@ grep -Fq 'https: 30443' "$OCI_DIR/helm/ingress-nginx-k3s-values.yaml" ||
   fail "k3s HTTPS NodePort differs"
 ! grep -Fq 'type: LoadBalancer' "$OCI_DIR/helm/ingress-nginx-k3s-values.yaml" ||
   fail "k3s Kubernetes assets create a LoadBalancer service"
+provisioner="$OCI_DIR/scripts/provision.sh"
+grep -Fq -- "--arg source \"\$OCI_LB_SUBNET_CIDR\"" "$provisioner" ||
+  fail "k3s worker NSG lacks the dedicated load-balancer subnet path"
+grep -Fq "description:(\"lb-subnet-to-nodeport-\" + (\$port|tostring))" \
+  "$provisioner" ||
+  fail "k3s worker NSG lacks exact subnet-to-NodePort rules"
+grep -Fq -- "--arg destination \"\$OCI_WORKER_SUBNET_CIDR\"" "$provisioner" ||
+  fail "k3s load-balancer NSG lacks the dedicated worker subnet path"
+grep -Fq "description:(\"lb-to-worker-subnet-\" + (\$port|tostring))" \
+  "$provisioner" ||
+  fail "k3s load-balancer NSG lacks exact subnet-to-worker rules"
+for description in \
+  lb-subnet-to-nodeport-30080 lb-subnet-to-nodeport-30443 \
+  lb-to-worker-subnet-30080 lb-to-worker-subnet-30443; do
+  grep -Fq "\"$description\"" "$provisioner" ||
+    fail "k3s exact NSG rule set omits $description"
+done
 grep -Fq 'path: /var/lib/betstan/mongo' "$OCI_DIR/k8s/overlays/k3s/kustomization.yaml" ||
   fail "k3s Mongo local PV path differs"
 grep -Fq '__OCI_K3S_NODE_NAME__' "$OCI_DIR/k8s/overlays/k3s/kustomization.yaml" ||


### PR DESCRIPTION
## Problem

Final exact-SHA deploy run 30977637571 passed protected cluster validation but failed public validation on intermittent LB-to-backend resets. Independent probes reproduced 6/100 failures on both HTTP and HTTPS, while OCI `BackendTimeouts` recorded the failures. Direct ingress was 30/30 and both local NodePorts were 200/200; the node was Ready with no pressure, conntrack exhaustion, restarts, or ingress errors.

## Deployment-only fix

- retain the existing NSG-to-NSG rules;
- add stateful CIDR rules limited to the dedicated LB and worker subnets;
- allow only exact NodePorts 30080 and 30443;
- assert the complete exact rule set offline.

No application, image, topology, Azure, or paid-resource change.

## Validation

- full `infra/oci/tests/test-contract.sh`: PASS
- `compare-image-inputs.sh e819935... 957d622...`: UNCHANGED
- `pre-commit-infra-check-stan.sh`: PASS
- ingress routing guard: PASS
- workflow trigger guard/inventory: PASS; production workflow set unchanged
- offline YAML, bash syntax, focused shellcheck, diff/secret scan: PASS