### PR TITLE
Promote OCI load balancer backend stability fix

### DIFF
--- a/infra/oci/scripts/provision.sh
+++ b/infra/oci/scripts/provision.sh
@@ -315,6 +315,16 @@ if [[ "$MODE" == "cloud" ]]; then
           tcpOptions:{destinationPortRange:{min:$port,max:$port}}
         }'
       )"
+      # Keep the regional LB data path bounded when a backend connection does
+      # not retain the source NSG identity.
+      ensure_nsg_rule "${nsg_ids[worker]}" "lb-subnet-to-nodeport-${port}" "$(
+        jq -cn --arg source "$OCI_LB_SUBNET_CIDR" --argjson port "$port" '{
+          direction:"INGRESS", protocol:"6", sourceType:"CIDR_BLOCK",
+          source:$source, isStateless:false,
+          description:("lb-subnet-to-nodeport-" + ($port|tostring)),
+          tcpOptions:{destinationPortRange:{min:$port,max:$port}}
+        }'
+      )"
     done
   fi
   ensure_nsg_rule "${nsg_ids[worker]}" "worker-internet-egress" '{
@@ -349,6 +359,16 @@ if [[ "$MODE" == "cloud" ]]; then
           tcpOptions:{destinationPortRange:{min:$port,max:$port}}
         }'
       )"
+      # Mirror the dedicated-subnet path on egress without opening any other
+      # worker port or external destination.
+      ensure_nsg_rule "${nsg_ids[lb]}" "lb-to-worker-subnet-${port}" "$(
+        jq -cn --arg destination "$OCI_WORKER_SUBNET_CIDR" --argjson port "$port" '{
+          direction:"EGRESS", protocol:"6", destinationType:"CIDR_BLOCK",
+          destination:$destination, isStateless:false,
+          description:("lb-to-worker-subnet-" + ($port|tostring)),
+          tcpOptions:{destinationPortRange:{min:$port,max:$port}}
+        }'
+      )"
     done
   fi
   if [[ "$OCI_RUNTIME_MODE" == "k3s" ]]; then
@@ -358,13 +378,17 @@ if [[ "$MODE" == "cloud" ]]; then
       "bastion-to-worker-6443",
       "lb-to-nodeport-30080",
       "lb-to-nodeport-30443",
+      "lb-subnet-to-nodeport-30080",
+      "lb-subnet-to-nodeport-30443",
       "worker-internet-egress"
     ]'
     assert_nsg_rule_set "${nsg_ids[lb]}" '[
       "world-to-lb-80",
       "world-to-lb-443",
       "lb-to-worker-30080",
-      "lb-to-worker-30443"
+      "lb-to-worker-30443",
+      "lb-to-worker-subnet-30080",
+      "lb-to-worker-subnet-30443"
     ]'
   fi
 

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -31,6 +31,23 @@ grep -Fq 'https: 30443' "$OCI_DIR/helm/ingress-nginx-k3s-values.yaml" ||
   fail "k3s HTTPS NodePort differs"
 ! grep -Fq 'type: LoadBalancer' "$OCI_DIR/helm/ingress-nginx-k3s-values.yaml" ||
   fail "k3s Kubernetes assets create a LoadBalancer service"
+provisioner="$OCI_DIR/scripts/provision.sh"
+grep -Fq -- "--arg source \"\$OCI_LB_SUBNET_CIDR\"" "$provisioner" ||
+  fail "k3s worker NSG lacks the dedicated load-balancer subnet path"
+grep -Fq "description:(\"lb-subnet-to-nodeport-\" + (\$port|tostring))" \
+  "$provisioner" ||
+  fail "k3s worker NSG lacks exact subnet-to-NodePort rules"
+grep -Fq -- "--arg destination \"\$OCI_WORKER_SUBNET_CIDR\"" "$provisioner" ||
+  fail "k3s load-balancer NSG lacks the dedicated worker subnet path"
+grep -Fq "description:(\"lb-to-worker-subnet-\" + (\$port|tostring))" \
+  "$provisioner" ||
+  fail "k3s load-balancer NSG lacks exact subnet-to-worker rules"
+for description in \
+  lb-subnet-to-nodeport-30080 lb-subnet-to-nodeport-30443 \
+  lb-to-worker-subnet-30080 lb-to-worker-subnet-30443; do
+  grep -Fq "\"$description\"" "$provisioner" ||
+    fail "k3s exact NSG rule set omits $description"
+done
 grep -Fq 'path: /var/lib/betstan/mongo' "$OCI_DIR/k8s/overlays/k3s/kustomization.yaml" ||
   fail "k3s Mongo local PV path differs"
 grep -Fq '__OCI_K3S_NODE_NAME__' "$OCI_DIR/k8s/overlays/k3s/kustomization.yaml" ||


### PR DESCRIPTION
Promotes exact dev e7a17a31c18bf294cdaa6e05a56eec5593f0841a. Diff is only the deployment-only OCI NSG fix from PR 156. A master merge triggers production-build and then oci-production-build; production-deploy, oci-capacity-acquire, oci-infrastructure, oci-production-deploy, and oci-migrate remain manual. Azure deployment is not dispatched. No application, image, topology, Azure, or paid-resource change. Image inputs remain unchanged from e819935a9e892666177826355c699a16bfe95166. Exact infrastructure reconciliation and OCI deployment remain separately gated after new master and build provenance exist.