### PR TITLE
fix(oci): make load balancer return paths explicit

### DIFF
--- a/infra/oci/scripts/provision.sh
+++ b/infra/oci/scripts/provision.sh
@@ -105,6 +105,11 @@ ensure_nsg_rule() {
       and (($matches[0]."source-type" // null) == ($expected.sourceType // null))
       and (($matches[0].destination // null) == ($expected.destination // null))
       and (($matches[0]."destination-type" // null) == ($expected.destinationType // null))
+      and (($matches[0]."is-stateless" // null) == ($expected.isStateless // null))
+      and (($matches[0]."tcp-options"."source-port-range".min // null) ==
+        ($expected.tcpOptions.sourcePortRange.min // null))
+      and (($matches[0]."tcp-options"."source-port-range".max // null) ==
+        ($expected.tcpOptions.sourcePortRange.max // null))
       and (($matches[0]."tcp-options"."destination-port-range".min // null) ==
         ($expected.tcpOptions.destinationPortRange.min // null))
       and (($matches[0]."tcp-options"."destination-port-range".max // null) ==
@@ -340,6 +345,20 @@ if [[ "$MODE" == "cloud" ]]; then
         tcpOptions:{destinationPortRange:{min:$port,max:$port}}
       }'
     )"
+    # Keep the public response leg independently allowlisted. The initiating
+    # listener rule remains stateful, while this exact source-port rule avoids
+    # making successful SYN-ACK delivery depend only on tracked return state.
+    ensure_nsg_rule "${nsg_ids[lb]}" "lb-to-world-return-${port}" "$(
+      jq -cn --argjson port "$port" '{
+        direction:"EGRESS", protocol:"6", destinationType:"CIDR_BLOCK",
+        destination:"0.0.0.0/0", isStateless:false,
+        description:("lb-to-world-return-" + ($port|tostring)),
+        tcpOptions:{
+          sourcePortRange:{min:$port,max:$port},
+          destinationPortRange:{min:1024,max:65535}
+        }
+      }'
+    )"
   done
   if [[ "$OCI_RUNTIME_MODE" == "oke" ]]; then
     ensure_nsg_rule "${nsg_ids[lb]}" "lb-to-worker-nodeports" "$(
@@ -369,6 +388,20 @@ if [[ "$MODE" == "cloud" ]]; then
           tcpOptions:{destinationPortRange:{min:$port,max:$port}}
         }'
       )"
+      # A backend SYN-ACK returns from the fixed NodePort to an ephemeral load
+      # balancer port. Allow that leg explicitly so a healthy node response is
+      # not dependent only on the load balancer's tracked egress state.
+      ensure_nsg_rule "${nsg_ids[lb]}" "worker-to-lb-return-${port}" "$(
+        jq -cn --arg source "$OCI_WORKER_SUBNET_CIDR" --argjson port "$port" '{
+          direction:"INGRESS", protocol:"6", sourceType:"CIDR_BLOCK",
+          source:$source, isStateless:false,
+          description:("worker-to-lb-return-" + ($port|tostring)),
+          tcpOptions:{
+            sourcePortRange:{min:$port,max:$port},
+            destinationPortRange:{min:1024,max:65535}
+          }
+        }'
+      )"
     done
   fi
   if [[ "$OCI_RUNTIME_MODE" == "k3s" ]]; then
@@ -385,10 +418,14 @@ if [[ "$MODE" == "cloud" ]]; then
     assert_nsg_rule_set "${nsg_ids[lb]}" '[
       "world-to-lb-80",
       "world-to-lb-443",
+      "lb-to-world-return-80",
+      "lb-to-world-return-443",
       "lb-to-worker-30080",
       "lb-to-worker-30443",
       "lb-to-worker-subnet-30080",
-      "lb-to-worker-subnet-30443"
+      "lb-to-worker-subnet-30443",
+      "worker-to-lb-return-30080",
+      "worker-to-lb-return-30443"
     ]'
   fi
 

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -42,9 +42,25 @@ grep -Fq -- "--arg destination \"\$OCI_WORKER_SUBNET_CIDR\"" "$provisioner" ||
 grep -Fq "description:(\"lb-to-worker-subnet-\" + (\$port|tostring))" \
   "$provisioner" ||
   fail "k3s load-balancer NSG lacks exact subnet-to-worker rules"
+grep -Fq "description:(\"lb-to-world-return-\" + (\$port|tostring))" \
+  "$provisioner" ||
+  fail "k3s load-balancer NSG lacks explicit public return rules"
+grep -Fq "description:(\"worker-to-lb-return-\" + (\$port|tostring))" \
+  "$provisioner" ||
+  fail "k3s load-balancer NSG lacks explicit backend return rules"
+grep -Fq "sourcePortRange:{min:\$port,max:\$port}" "$provisioner" ||
+  fail "k3s load-balancer return rules do not bind their source ports"
+grep -Fq 'destinationPortRange:{min:1024,max:65535}' "$provisioner" ||
+  fail "k3s load-balancer return rules do not bind ephemeral destinations"
+grep -Fq '"is-stateless" // null' "$provisioner" ||
+  fail "managed NSG reconciliation does not verify statefulness"
+grep -Fq '"source-port-range".min // null' "$provisioner" ||
+  fail "managed NSG reconciliation does not verify source-port bounds"
 for description in \
   lb-subnet-to-nodeport-30080 lb-subnet-to-nodeport-30443 \
-  lb-to-worker-subnet-30080 lb-to-worker-subnet-30443; do
+  lb-to-worker-subnet-30080 lb-to-worker-subnet-30443 \
+  lb-to-world-return-80 lb-to-world-return-443 \
+  worker-to-lb-return-30080 worker-to-lb-return-30443; do
   grep -Fq "\"$description\"" "$provisioner" ||
     fail "k3s exact NSG rule set omits $description"
 done


### PR DESCRIPTION
## Summary
- explicitly allow tightly bounded load-balancer public response traffic from ports 80/443 to client ephemeral ports
- explicitly allow backend SYN-ACK traffic from fixed NodePorts 30080/30443 to load-balancer ephemeral ports
- verify managed NSG statefulness and source-port ranges during reconciliation

## Evidence
- public probes failed with resets/timeouts while direct ingress and local NodePorts were healthy
- node packet capture observed repeated backend SYN-ACKs with no load-balancer ACK and no node RST
- OCI BackendTimeouts increased for both backend sets and both load-balancer hosts during the same probe window
- node iptables DROP/REJECT, VNIC conntrack-full, VNIC egress security, and throttle metrics remained zero

## Safety
- deployment-only; no application/image inputs changed
- no resource, bandwidth, architecture, or cost changes
- ingress remains ports 80/443 only; backend remains exact NodePorts and private subnet
- all rules remain stateful

## Validation
- full OCI offline contract PASS
- focused k3s runtime contract PASS
- required pre-commit/ingress/workflow inventory gates PASS
- OCI actionlint PASS
- shell syntax and targeted shellcheck PASS
- immutable image inputs unchanged from approved reuse source and current master