### PR TITLE
fix(oci): promote admission-safe www redirect

### DIFF
--- a/infra/oci/helm/ingress-nginx-k3s-values.yaml
+++ b/infra/oci/helm/ingress-nginx-k3s-values.yaml
@@ -1,5 +1,10 @@
 controller:
   replicaCount: 1
+  config:
+    server-snippet: |
+      if ($host = "www.betstan.xyz") {
+        return 308 https://betstan.xyz$request_uri;
+      }
   image:
     tag: v1.15.1
     digest: sha256:594ceea76b01c592858f803f9ff4d2cb40542cae2060410b2c95f75907d659e1

--- a/infra/oci/helm/ingress-nginx-values.yaml
+++ b/infra/oci/helm/ingress-nginx-values.yaml
@@ -1,5 +1,10 @@
 controller:
   replicaCount: 1
+  config:
+    server-snippet: |
+      if ($host = "www.betstan.xyz") {
+        return 308 https://betstan.xyz$request_uri;
+      }
   image:
     tag: v1.15.1
     digest: sha256:594ceea76b01c592858f803f9ff4d2cb40542cae2060410b2c95f75907d659e1

--- a/infra/oci/k8s/ingress.yaml
+++ b/infra/oci/k8s/ingress.yaml
@@ -142,8 +142,7 @@ kind: Ingress
 metadata:
   name: gaming-oci-www-redirect
   annotations:
-    nginx.ingress.kubernetes.io/permanent-redirect: https://__OCI_CANONICAL_HOST__$request_uri
-    nginx.ingress.kubernetes.io/permanent-redirect-code: "308"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx
   tls:

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -283,9 +283,12 @@ abort "canonical certificate SAN set differs" unless canonical_certificate.dig(
 redirect = by_kind.fetch("Ingress").find {
   |ingress| ingress.dig("metadata", "name") == "gaming-oci-www-redirect"
 }
-abort "www redirect target differs" unless redirect.dig(
-  "metadata", "annotations", "nginx.ingress.kubernetes.io/permanent-redirect"
-) == 'https://betstan.xyz$request_uri'
+abort "www ingress must leave HTTP for the canonical redirect" unless redirect.dig(
+  "metadata", "annotations", "nginx.ingress.kubernetes.io/ssl-redirect"
+) == "false"
+abort "www ingress contains an admission-rejected redirect variable" if redirect.dig(
+  "metadata", "annotations"
+).key?("nginx.ingress.kubernetes.io/permanent-redirect")
 puts "oci_rendered_topology=PASS"
 RUBY
 grep -Fq "apply_documents 'Certificate:^betstan-oci-(canonical-)?tls$'" \
@@ -371,6 +374,10 @@ for ingress_values in \
     fail "ingress-nginx digest differs from the reviewed multi-architecture image"
   ! grep -Eq "strict-validate-path-type:[[:space:]]*['\"]?false" "$ingress_values" ||
     fail "ingress-nginx strict path validation was disabled"
+  grep -Fq 'if ($host = "www.betstan.xyz") {' "$ingress_values" ||
+    fail "ingress-nginx lacks the exact www redirect host guard"
+  grep -Fq 'return 308 https://betstan.xyz$request_uri;' "$ingress_values" ||
+    fail "ingress-nginx does not preserve the www request URI in its HTTPS redirect"
 done
 grep -Fq '"gaming-auth-mongo": "sha256:3d715950d83061ff2fbc910d12d3703212538cacf6b3003e3736fa5c7f51a2e1"' \
   "$OCI_DIR/agents/health-check-stan.sh" ||


### PR DESCRIPTION
Promote the exact protected redirect hotfix after ingress-nginx rejected the variable-bearing annotation. The controller-owned redirect preserves path/query and forces canonical HTTPS.