### PR TITLE
fix(oci): handle deallocated AKS source

### DIFF
--- a/.github/workflows/oci-migrate.yml
+++ b/.github/workflows/oci-migrate.yml
@@ -310,18 +310,27 @@ jobs:
             echo "resource_id_hash=$actual_hash"
             echo "touched=true"
           } >> "$GITHUB_OUTPUT"
-          [ "$(jq -r '.provisioningState // empty' <<<"$before")" = "Succeeded" ]
+          provisioning="$(jq -r '.provisioningState // empty' <<<"$before")"
           power="$(jq -r '.powerState.code // empty' <<<"$before")"
-          [ "$power" = "Running" ] || [ "$power" = "Stopped" ]
-          if [ "$power" = "Stopped" ]; then
-            ./infra/oci/scripts/bounded-command.py \
-              --timeout-seconds 1500 --attempts 1 \
-              --classification azure-cluster-start -- \
-              az aks start \
-                --resource-group "$AZURE_RESOURCE_GROUP" \
-                --name "$AZURE_CLUSTER_NAME" \
-                --only-show-errors
-          fi
+          case "$power" in
+            Running)
+              [ "$provisioning" = "Succeeded" ]
+              ;;
+            Stopped|Deallocated)
+              [ "$provisioning" = "Succeeded" ] ||
+                [ "$provisioning" = "Failed" ]
+              ./infra/oci/scripts/bounded-command.py \
+                --timeout-seconds 1500 --attempts 1 \
+                --classification azure-cluster-start -- \
+                az aks start \
+                  --resource-group "$AZURE_RESOURCE_GROUP" \
+                  --name "$AZURE_CLUSTER_NAME" \
+                  --only-show-errors
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
           after="$(
             ./infra/oci/scripts/bounded-command.py \
               --timeout-seconds 60 --attempts 3 \
@@ -352,6 +361,7 @@ jobs:
           admin: false
 
       - name: Install pinned OCI CLI
+        id: oci_cli
         env:
           HOME: ${{ runner.temp }}/oci-home
         run: ./infra/oci/scripts/install-cli.sh
@@ -542,17 +552,25 @@ jobs:
           actual_hash="$(printf '%s' "$resource_id" | sha256sum | awk '{print $1}')"
           [ "$actual_hash" = "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256" ]
           power="$(jq -r '.powerState.code' <<<"$before")"
-          if [ "$power" = "Running" ] || [ "$power" = "Starting" ]; then
-            ./infra/oci/scripts/bounded-command.py \
-              --timeout-seconds 1200 --attempts 1 \
-              --classification azure-cluster-stop -- \
-              az aks stop \
-                --resource-group "$AZURE_RESOURCE_GROUP" \
-                --name "$AZURE_CLUSTER_NAME" \
-                --only-show-errors
-          else
-            [ "$power" = "Stopped" ]
-          fi
+          provisioning="$(jq -r '.provisioningState // empty' <<<"$before")"
+          case "$power" in
+            Running|Starting)
+              ./infra/oci/scripts/bounded-command.py \
+                --timeout-seconds 1200 --attempts 1 \
+                --classification azure-cluster-stop -- \
+                az aks stop \
+                  --resource-group "$AZURE_RESOURCE_GROUP" \
+                  --name "$AZURE_CLUSTER_NAME" \
+                  --only-show-errors
+              ;;
+            Stopped|Deallocated)
+              [ "$provisioning" = "Succeeded" ] ||
+                [ "$provisioning" = "Failed" ]
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
           after="$(
             ./infra/oci/scripts/bounded-command.py \
               --timeout-seconds 60 --attempts 3 \
@@ -562,8 +580,11 @@ jobs:
                 --name "$AZURE_CLUSTER_NAME" \
                 --output json
           )"
-          [ "$(jq -r '.provisioningState' <<<"$after")" = "Succeeded" ]
-          [ "$(jq -r '.powerState.code' <<<"$after")" = "Stopped" ]
+          after_provisioning="$(jq -r '.provisioningState // empty' <<<"$after")"
+          after_power="$(jq -r '.powerState.code // empty' <<<"$after")"
+          [ "$after_provisioning" = "Succeeded" ] ||
+            [ "$after_provisioning" = "Failed" ]
+          [ "$after_power" = "Stopped" ] || [ "$after_power" = "Deallocated" ]
           node_resource_group="$(jq -r '.nodeResourceGroup // empty' <<<"$after")"
           [[ "$node_resource_group" =~ ^MC_[A-Za-z0-9._()/-]+$ ]]
           mapfile -t vmss_names < <(
@@ -594,8 +615,8 @@ jobs:
             "stop_timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
             "cluster_name=betstan-aks" \
             "cluster_resource_id_sha256=$actual_hash" \
-            "provisioning_state=Succeeded" \
-            "power_state=Stopped" \
+            "provisioning_state=$after_provisioning" \
+            "power_state=$after_power" \
             > artifacts/oci-migration/azure-stop.env
 
       - name: Upload sanitized migration phase and provenance
@@ -649,7 +670,10 @@ jobs:
           fi
 
       - name: Close ephemeral OCI Bastion access
-        if: always() && env.OCI_RUNTIME_MODE == 'k3s'
+        if: >-
+          always() &&
+          env.OCI_RUNTIME_MODE == 'k3s' &&
+          steps.oci_cli.outcome == 'success'
         env:
           HOME: ${{ runner.temp }}/oci-home
           KUBECONFIG: ${{ env.OCI_KUBECONFIG }}
@@ -702,17 +726,25 @@ jobs:
           actual_hash="$(printf '%s' "$resource_id" | sha256sum | awk '{print $1}')"
           [ "$actual_hash" = "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256" ]
           power="$(jq -r '.powerState.code' <<<"$cluster")"
-          if [ "$power" = "Running" ] || [ "$power" = "Starting" ]; then
-            ./infra/oci/scripts/bounded-command.py \
-              --timeout-seconds 1200 --attempts 1 \
-              --classification azure-cluster-stop -- \
-              az aks stop \
-                --resource-group "$AZURE_RESOURCE_GROUP" \
-                --name "$AZURE_CLUSTER_NAME" \
-                --only-show-errors
-          else
-            [ "$power" = "Stopped" ]
-          fi
+          provisioning="$(jq -r '.provisioningState // empty' <<<"$cluster")"
+          case "$power" in
+            Running|Starting)
+              ./infra/oci/scripts/bounded-command.py \
+                --timeout-seconds 1200 --attempts 1 \
+                --classification azure-cluster-stop -- \
+                az aks stop \
+                  --resource-group "$AZURE_RESOURCE_GROUP" \
+                  --name "$AZURE_CLUSTER_NAME" \
+                  --only-show-errors
+              ;;
+            Stopped|Deallocated)
+              [ "$provisioning" = "Succeeded" ] ||
+                [ "$provisioning" = "Failed" ]
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
           after="$(
             ./infra/oci/scripts/bounded-command.py \
               --timeout-seconds 60 --attempts 3 \
@@ -722,8 +754,11 @@ jobs:
                 --name "$AZURE_CLUSTER_NAME" \
                 --output json
           )"
-          [ "$(jq -r '.provisioningState' <<<"$after")" = "Succeeded" ]
-          [ "$(jq -r '.powerState.code' <<<"$after")" = "Stopped" ]
+          after_provisioning="$(jq -r '.provisioningState // empty' <<<"$after")"
+          after_power="$(jq -r '.powerState.code // empty' <<<"$after")"
+          [ "$after_provisioning" = "Succeeded" ] ||
+            [ "$after_provisioning" = "Failed" ]
+          [ "$after_power" = "Stopped" ] || [ "$after_power" = "Deallocated" ]
           node_resource_group="$(jq -r '.nodeResourceGroup // empty' <<<"$after")"
           [[ "$node_resource_group" =~ ^MC_[A-Za-z0-9._()/-]+$ ]]
           mapfile -t vmss_names < <(
@@ -754,8 +789,8 @@ jobs:
             "stop_timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
             "cluster_name=betstan-aks" \
             "cluster_resource_id_sha256=$actual_hash" \
-            "provisioning_state=Succeeded" \
-            "power_state=Stopped" \
+            "provisioning_state=$after_provisioning" \
+            "power_state=$after_power" \
             > artifacts/oci-migration/azure-stop.env
 
       - name: Remove isolated migration client state and transports
@@ -975,6 +1010,7 @@ jobs:
           admin: false
 
       - name: Install pinned finalization OCI CLI
+        id: final_oci_cli
         env:
           HOME: ${{ runner.temp }}/oci-finalize
         run: ./infra/oci/scripts/install-cli.sh
@@ -1097,19 +1133,26 @@ jobs:
           resource_id="$(jq -r '.id // empty' <<<"$before")"
           actual_hash="$(printf '%s' "$resource_id" | sha256sum | awk '{print $1}')"
           [ "$actual_hash" = "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256" ]
-          [ "$(jq -r '.provisioningState' <<<"$before")" = "Succeeded" ]
+          provisioning="$(jq -r '.provisioningState // empty' <<<"$before")"
           power="$(jq -r '.powerState.code' <<<"$before")"
-          if [ "$power" = "Running" ] || [ "$power" = "Starting" ]; then
-            ./infra/oci/scripts/bounded-command.py \
-              --timeout-seconds 1200 --attempts 1 \
-              --classification azure-cluster-stop -- \
-              az aks stop \
-                --resource-group "$AZURE_RESOURCE_GROUP" \
-                --name "$AZURE_CLUSTER_NAME" \
-                --only-show-errors
-          else
-            [ "$power" = "Stopped" ]
-          fi
+          case "$power" in
+            Running|Starting)
+              ./infra/oci/scripts/bounded-command.py \
+                --timeout-seconds 1200 --attempts 1 \
+                --classification azure-cluster-stop -- \
+                az aks stop \
+                  --resource-group "$AZURE_RESOURCE_GROUP" \
+                  --name "$AZURE_CLUSTER_NAME" \
+                  --only-show-errors
+              ;;
+            Stopped|Deallocated)
+              [ "$provisioning" = "Succeeded" ] ||
+                [ "$provisioning" = "Failed" ]
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
           after="$(
             ./infra/oci/scripts/bounded-command.py \
               --timeout-seconds 60 --attempts 3 \
@@ -1119,8 +1162,11 @@ jobs:
                 --name "$AZURE_CLUSTER_NAME" \
                 --output json
           )"
-          [ "$(jq -r '.provisioningState' <<<"$after")" = "Succeeded" ]
-          [ "$(jq -r '.powerState.code' <<<"$after")" = "Stopped" ]
+          after_provisioning="$(jq -r '.provisioningState // empty' <<<"$after")"
+          after_power="$(jq -r '.powerState.code // empty' <<<"$after")"
+          [ "$after_provisioning" = "Succeeded" ] ||
+            [ "$after_provisioning" = "Failed" ]
+          [ "$after_power" = "Stopped" ] || [ "$after_power" = "Deallocated" ]
           node_resource_group="$(jq -r '.nodeResourceGroup // empty' <<<"$after")"
           [[ "$node_resource_group" =~ ^MC_[A-Za-z0-9._()/-]+$ ]]
           mapfile -t vmss_names < <(
@@ -1151,8 +1197,8 @@ jobs:
             "stop_timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
             "cluster_name=betstan-aks" \
             "cluster_resource_id_sha256=$actual_hash" \
-            "provisioning_state=Succeeded" \
-            "aks_power_state=Stopped" \
+            "provisioning_state=$after_provisioning" \
+            "aks_power_state=$after_power" \
             "vmss_instances_deallocated=true" \
             > artifacts/oci-migration-final/azure-stop.env
 
@@ -1279,7 +1325,10 @@ jobs:
 
       - name: Close finalization Bastion access
         id: bastion_cleanup
-        if: always() && env.OCI_RUNTIME_MODE == 'k3s'
+        if: >-
+          always() &&
+          env.OCI_RUNTIME_MODE == 'k3s' &&
+          steps.final_oci_cli.outcome == 'success'
         env:
           HOME: ${{ runner.temp }}/oci-finalize
           KUBECONFIG: ${{ env.OCI_KUBECONFIG }}
@@ -1371,6 +1420,22 @@ jobs:
             printf '%s' "$value"
           }
 
+          get_env_field() {
+            local file="$1"
+            local key="$2"
+            local value
+            value="$(awk -F= -v key="$key" '
+              $1 == key {
+                print substr($0, index($0, "=") + 1)
+                count++
+              }
+              END {
+                if (count != 1) exit 1
+              }
+            ' "$file")"
+            printf '%s' "$value"
+          }
+
           migration_id="$(get_phase_field migration-id)"
           source_sha="$(get_phase_field original-source-sha)"
           run_id="$(get_phase_field owner-run-id)"
@@ -1387,6 +1452,8 @@ jobs:
           target_signatures="$(get_phase_field target-signature-manifest-sha256)"
           azure_cluster_fingerprint="$(get_phase_field azure-cluster-fingerprint)"
           final_journal_sha256="$(sha256sum "$phase_file" | awk '{print $1}')"
+          stop_provisioning="$(get_env_field "$stop_file" provisioning_state)"
+          aks_power_state="$(get_env_field "$stop_file" aks_power_state)"
 
           [[ "$migration_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]]
@@ -1408,10 +1475,12 @@ jobs:
           [ "$azure_cluster_fingerprint" = \
             "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256" ]
           [[ "$final_journal_sha256" =~ ^[0-9a-f]{64}$ ]]
-          grep -Fxq "provisioning_state=Succeeded" "$stop_file"
+          [ "$stop_provisioning" = "Succeeded" ] ||
+            [ "$stop_provisioning" = "Failed" ]
+          [ "$aks_power_state" = "Stopped" ] ||
+            [ "$aks_power_state" = "Deallocated" ]
           grep -Fxq "cluster_resource_id_sha256=$azure_cluster_fingerprint" \
             "$stop_file"
-          grep -Fxq "aks_power_state=Stopped" "$stop_file"
           grep -Fxq "vmss_instances_deallocated=true" "$stop_file"
 
           mkdir -p artifacts/oci-migration-success
@@ -1437,7 +1506,7 @@ jobs:
             "oci_reopened_healthy=true" \
             "azure_writers_frozen=true" \
             "azure_cluster_resource_id_sha256=$azure_cluster_fingerprint" \
-            "aks_power_state=Stopped" \
+            "aks_power_state=$aks_power_state" \
             "vmss_instances_deallocated=true" \
             "azure_cluster_stopped_deallocated=true" \
             > artifacts/oci-migration-success/migration-summary.env

--- a/.github/workflows/oci-migration-recovery.yml
+++ b/.github/workflows/oci-migration-recovery.yml
@@ -198,8 +198,18 @@ jobs:
           power="$(jq -r '.powerState.code // empty' <<<"$cluster_json")"
           actual_hash="$(printf '%s' "$resource_id" | sha256sum | awk '{print $1}')"
           [ "$actual_hash" = "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256" ]
-          [ "$provisioning" = "Succeeded" ]
-          [ "$power" = "Running" ] || [ "$power" = "Stopped" ]
+          case "$power" in
+            Running)
+              [ "$provisioning" = "Succeeded" ]
+              ;;
+            Stopped|Deallocated)
+              [ "$provisioning" = "Succeeded" ] ||
+                [ "$provisioning" = "Failed" ]
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
           {
             echo "power=$power"
             echo "resource_id_hash=$actual_hash"
@@ -230,7 +240,8 @@ jobs:
           AZURE_ACTUAL_CLUSTER_RESOURCE_ID_SHA256: ${{ steps.cluster.outputs.resource_id_hash }}
         run: |
           set -euo pipefail
-          if [ "${{ steps.cluster.outputs.power }}" = "Stopped" ]; then
+          if [ "${{ steps.cluster.outputs.power }}" = "Stopped" ] ||
+             [ "${{ steps.cluster.outputs.power }}" = "Deallocated" ]; then
             printf '%s\n' \
               "safe_to_stop=true" \
               "defer=false" \
@@ -272,18 +283,24 @@ jobs:
           [ "$actual_hash" = "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256" ]
           power="$(jq -r '.powerState.code // empty' <<<"$before")"
           provisioning="$(jq -r '.provisioningState // empty' <<<"$before")"
-          [ "$provisioning" = "Succeeded" ]
-          if [ "$power" = "Running" ] || [ "$power" = "Starting" ]; then
-            ./infra/oci/scripts/bounded-command.py \
-              --timeout-seconds 1200 --attempts 1 \
-              --classification azure-cluster-stop -- \
-              az aks stop \
-                --resource-group "$AZURE_RESOURCE_GROUP" \
-                --name "$AZURE_CLUSTER_NAME" \
-                --only-show-errors
-          else
-            [ "$power" = "Stopped" ]
-          fi
+          case "$power" in
+            Running|Starting)
+              ./infra/oci/scripts/bounded-command.py \
+                --timeout-seconds 1200 --attempts 1 \
+                --classification azure-cluster-stop -- \
+                az aks stop \
+                  --resource-group "$AZURE_RESOURCE_GROUP" \
+                  --name "$AZURE_CLUSTER_NAME" \
+                  --only-show-errors
+              ;;
+            Stopped|Deallocated)
+              [ "$provisioning" = "Succeeded" ] ||
+                [ "$provisioning" = "Failed" ]
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
           after="$(
             ./infra/oci/scripts/bounded-command.py \
               --timeout-seconds 60 --attempts 3 \
@@ -293,14 +310,17 @@ jobs:
                 --name "$AZURE_CLUSTER_NAME" \
                 --output json
           )"
-          [ "$(jq -r '.provisioningState' <<<"$after")" = "Succeeded" ]
-          [ "$(jq -r '.powerState.code' <<<"$after")" = "Stopped" ]
+          after_provisioning="$(jq -r '.provisioningState // empty' <<<"$after")"
+          after_power="$(jq -r '.powerState.code // empty' <<<"$after")"
+          [ "$after_provisioning" = "Succeeded" ] ||
+            [ "$after_provisioning" = "Failed" ]
+          [ "$after_power" = "Stopped" ] || [ "$after_power" = "Deallocated" ]
           printf '%s\n' \
             "stop_timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
             "cluster_name=betstan-aks" \
             "cluster_resource_id_sha256=$actual_hash" \
-            "provisioning_state=Succeeded" \
-            "power_state=Stopped" \
+            "provisioning_state=$after_provisioning" \
+            "power_state=$after_power" \
             > artifacts/azure-migration-recovery/stop.env
 
       - name: Upload sanitized recovery evidence

--- a/infra/azure/agents/retire-production-stan.sh
+++ b/infra/azure/agents/retire-production-stan.sh
@@ -505,7 +505,10 @@ require_summary_value oci_reopened_healthy true
 require_summary_value azure_writers_frozen true
 require_summary_value azure_cluster_resource_id_sha256 \
   "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256"
-require_summary_value aks_power_state Stopped
+summary_power_state="$(env_value "$SUMMARY_FILE" aks_power_state)"
+[[ "$summary_power_state" == "Stopped" ||
+  "$summary_power_state" == "Deallocated" ]] ||
+  die "migration success summary does not prove a stopped AKS control plane"
 require_summary_value vmss_instances_deallocated true
 require_summary_value azure_cluster_stopped_deallocated true
 require_positive_integer journal_generation
@@ -563,7 +566,9 @@ else
     die "live AKS resource identity differs from the approved fingerprint"
   [[ "$(jq -r .nodeResourceGroup "$cluster_json")" == "$AZURE_EXPECTED_NODE_RESOURCE_GROUP" ]] ||
     die "live AKS managed resource group differs"
-  [[ "$(jq -r '.powerState.code' "$cluster_json")" == "Stopped" ]] ||
+  live_power_state="$(jq -r '.powerState.code // empty' "$cluster_json")"
+  [[ "$live_power_state" == "Stopped" ||
+    "$live_power_state" == "Deallocated" ]] ||
     die "AKS control plane is not stopped"
   CLUSTER_ETAG="$(jq -r '.etag // empty' "$cluster_json")"
   [[ -n "$CLUSTER_ETAG" ]] ||

--- a/infra/azure/agents/test-retire-production-stan.sh
+++ b/infra/azure/agents/test-retire-production-stan.sh
@@ -142,11 +142,13 @@ case "${1:-} ${2:-}" in
     fi
     ;;
   "aks show")
-    jq -n --arg id "$STUB_CLUSTER_ID" '{
+    jq -n \
+      --arg id "$STUB_CLUSTER_ID" \
+      --arg power "${STUB_AKS_POWER_STATE:-Stopped}" '{
       id:$id,
       etag:"fixture-etag",
       nodeResourceGroup:"MC_betstan-rg_betstan-aks_eastus",
-      powerState:{code:"Stopped"},
+      powerState:{code:$power},
       provisioningState:"Failed"
     }'
     ;;
@@ -274,7 +276,7 @@ target_signature_aggregate_sha256=${target_signature}
 oci_reopened_healthy=true
 azure_writers_frozen=true
 azure_cluster_resource_id_sha256=${STUB_CLUSTER_DIGEST}
-aks_power_state=Stopped
+aks_power_state=${STUB_AKS_POWER_STATE:-Stopped}
 vmss_instances_deallocated=true
 azure_cluster_stopped_deallocated=true
 final_journal_sha256=$(printf 'c%.0s' {1..64})
@@ -409,6 +411,7 @@ run_plan() {
     PATH="$BIN_DIR:$PATH" \
     STUB_AZ_LOG="$WORK_DIR/az.log" \
     STUB_CLUSTER_ID="$CLUSTER_ID" \
+    STUB_AKS_POWER_STATE=Stopped \
     STUB_PRIMARY_JSON="$WORK_DIR/primary.json" \
     STUB_MANAGED_JSON="$WORK_DIR/managed.json" \
     STUB_DELETE_PHASE_FILE="$WORK_DIR/delete-phase" \
@@ -431,6 +434,15 @@ run_plan "$WORK_DIR/good" |
   grep -Eq '^azure_retirement=READY_TO_CONFIRM inventory_sha256=[0-9a-f]{64} resources=28$'
 ! grep -Eq 'aks delete|group delete' "$WORK_DIR/az.log" ||
   { echo "plan mode issued a destructive Azure command" >&2; exit 1; }
+
+run_plan "$WORK_DIR/deallocated" STUB_AKS_POWER_STATE=Deallocated |
+  grep -Eq '^azure_retirement=READY_TO_CONFIRM inventory_sha256=[0-9a-f]{64} resources=28$'
+if run_plan "$WORK_DIR/running-control-plane" STUB_AKS_POWER_STATE=Running \
+    >"$WORK_DIR/running-control-plane.out" 2>&1; then
+  echo "retirement fixture accepted a running AKS control plane" >&2
+  exit 1
+fi
+grep -Fq 'NO_GO azure_retirement_reason=' "$WORK_DIR/running-control-plane.out"
 
 for failure_mode in \
   STUB_BAD_RUN STUB_BAD_PARITY STUB_UNKNOWN_RESOURCE STUB_RUNNING_VMSS \
@@ -499,4 +511,4 @@ for crash_point in aks managed primary; do
     grep -qx 'AZURE_RESOURCES_RETIRED cost_verification=pending_delayed_reporting'
 done
 
-printf 'azure_retirement_contract=PASS scenarios=12\n'
+printf 'azure_retirement_contract=PASS scenarios=14\n'

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -60,6 +60,10 @@ conversation summaries are not authority.
 
 - AKS control-plane power fields can disagree with VMSS instance power. Use
   instance view and Cost Management to determine running compute.
+- A stopped legacy AKS control plane can report `Failed`/`Deallocated` instead
+  of `Succeeded`/`Stopped`. Accept that combination only as the exact
+  pre-start or already-deallocated state, then require `Succeeded`/`Running`
+  after start and independently prove VMSS deallocation after stop.
 - A stopped AKS cluster still incurs disk, load-balancer, public-IP, snapshot,
   and monitoring charges.
 - Azure retirement is complete only after the AKS and managed resource groups,

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -601,6 +601,13 @@ grep -Fq 'OCI_MIGRATION_AZURE_CREDENTIALS' "$migrate_workflow"
 grep -Fq 'OCI_MIGRATION_AGE_IDENTITY' "$migrate_workflow"
 grep -Fq 'az aks start' "$migrate_workflow"
 grep -Fq 'az aks stop' "$migrate_workflow"
+[[ "$(grep -Fc 'Stopped|Deallocated)' "$migrate_workflow")" -ge 4 ]] ||
+  fail "migration does not accept both Azure stopped-state representations"
+grep -Fq '[ "$provisioning" = "Failed" ]' "$migrate_workflow" ||
+  fail "migration cannot restart the exact failed/deallocated source"
+[[ "$(grep -Ec "steps\\.(final_)?oci_cli\\.outcome == 'success'" \
+  "$migrate_workflow")" -eq 2 ]] ||
+  fail "migration can run Bastion cleanup before an OCI CLI is installed"
 ! grep -Eq 'az aks (create|update|delete)|az aks nodepool' "$migrate_workflow" ||
   fail "migration workflow can create, resize, or delete Azure compute"
 grep -Fq 'if: always()' "$infra_workflow"
@@ -621,6 +628,10 @@ grep -Fq 'group: azure-migration-recovery' "$recovery_workflow"
 grep -Fq 'cancel-in-progress: true' "$recovery_workflow"
 grep -Fq 'actions: write' "$recovery_workflow"
 grep -Fq 'az aks stop' "$recovery_workflow"
+[[ "$(grep -Fc 'Stopped|Deallocated)' "$recovery_workflow")" -ge 2 ]] ||
+  fail "recovery does not accept both Azure stopped-state representations"
+grep -Fq '[ "$provisioning" = "Failed" ]' "$recovery_workflow" ||
+  fail "recovery rejects a safely deallocated failed AKS control plane"
 ! grep -Eq \
   'OCI_MIGRATION_AZURE_CREDENTIALS|OCI_CI_PRIVATE_KEY_PEM|OCI_K3S_SSH_PRIVATE_KEY|OCI_MIGRATION_AGE_IDENTITY' \
   "$recovery_workflow" ||

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -291,7 +291,7 @@ for literal in \
   'oci_reopened_healthy=true' \
   'azure_writers_frozen=true' \
   'azure_cluster_resource_id_sha256=' \
-  'aks_power_state=Stopped' \
+  '"aks_power_state=$aks_power_state"' \
   'vmss_instances_deallocated=true' \
   'azure_cluster_stopped_deallocated=true' \
   'for attempt in 1 2 3; do' \
@@ -305,6 +305,13 @@ for literal in \
 done
 [[ "$(grep -Fc 'az vmss list-instances' "$MIGRATION_WORKFLOW")" -ge 3 ]] ||
   fail "every Azure stop path does not independently verify VMSS deallocation"
+[[ "$(grep -Fc 'Stopped|Deallocated)' "$MIGRATION_WORKFLOW")" -ge 4 ]] ||
+  fail "migration does not accept both Azure stopped-state representations"
+grep -Fq '[ "$provisioning" = "Failed" ]' "$MIGRATION_WORKFLOW" ||
+  fail "migration cannot restart the exact failed/deallocated source"
+[[ "$(grep -Ec "steps\\.(final_)?oci_cli\\.outcome == 'success'" \
+  "$MIGRATION_WORKFLOW")" -eq 2 ]] ||
+  fail "migration can run Bastion cleanup before an OCI CLI is installed"
 ! grep -Eq 'az aks (create|update|delete)|az aks nodepool' "$MIGRATION_WORKFLOW" ||
   fail "migration workflow can create, resize, or delete Azure"
 
@@ -341,6 +348,10 @@ done
   fail "recovery workflow receives broader migration or OCI credentials"
 ! grep -Eq 'az aks (start|create|update|delete)|az aks nodepool' "$RECOVERY_WORKFLOW" ||
   fail "recovery workflow exceeds stop/read-only Azure permissions"
+[[ "$(grep -Fc 'Stopped|Deallocated)' "$RECOVERY_WORKFLOW")" -ge 2 ]] ||
+  fail "recovery does not accept both Azure stopped-state representations"
+grep -Fq '[ "$provisioning" = "Failed" ]' "$RECOVERY_WORKFLOW" ||
+  fail "recovery rejects a safely deallocated failed AKS control plane"
 ! grep -Eq 'scale deployment .*--replicas [1-9]' "$RECOVERY" ||
   fail "recovery script can reopen Azure applications"
 for literal in \


### PR DESCRIPTION
## Summary
- accept the exact failed/deallocated AKS source only as a safe pre-start or stopped state
- preserve actual stopped-state evidence through migration recovery and Azure retirement
- gate both Bastion cleanup paths on OCI CLI availability

## Validation
- OCI and migration recovery contracts
- Azure retirement fixtures (14 scenarios)
- Actionlint and ShellCheck
- independent safety review