### PR TITLE
fix(oci): materialize migration kubeconfigs

### DIFF
--- a/.github/workflows/oci-migrate.yml
+++ b/.github/workflows/oci-migrate.yml
@@ -360,6 +360,15 @@ jobs:
           cluster-name: ${{ env.AZURE_CLUSTER_NAME }}
           admin: false
 
+      - name: Materialize isolated Azure kubeconfig
+        run: |
+          set -euo pipefail
+          [[ -n "${KUBE_CONFIG_PATH:-}" ]]
+          [[ "$KUBE_CONFIG_PATH" == "$RUNNER_TEMP/"* ]]
+          [[ "$AZURE_KUBECONFIG" == "$RUNNER_TEMP/"* ]]
+          [ -f "$KUBE_CONFIG_PATH" ] && [ ! -L "$KUBE_CONFIG_PATH" ]
+          install -m 600 -- "$KUBE_CONFIG_PATH" "$AZURE_KUBECONFIG"
+
       - name: Install pinned OCI CLI
         id: oci_cli
         env:
@@ -607,7 +616,7 @@ jobs:
                 --output json
           )"
           jq -e '
-            length >= 1 and
+            type == "array" and
             all(.[]; any(.instanceView.statuses[]?;
               .code == "PowerState/deallocated"))
           ' <<<"$vmss_instances" >/dev/null
@@ -781,7 +790,7 @@ jobs:
                 --output json
           )"
           jq -e '
-            length >= 1 and
+            type == "array" and
             all(.[]; any(.instanceView.statuses[]?;
               .code == "PowerState/deallocated"))
           ' <<<"$vmss_instances" >/dev/null
@@ -798,12 +807,19 @@ jobs:
         env:
           HOME: ${{ runner.temp }}/azure-home
         run: |
+          cleanup_status=0
           az logout >/dev/null 2>&1 || true
+          case "${KUBE_CONFIG_PATH:-}" in
+            "$RUNNER_TEMP/"*) rm -f -- "$KUBE_CONFIG_PATH" || cleanup_status=1 ;;
+            "") ;;
+            *) cleanup_status=1 ;;
+          esac
           rm -rf \
             "$RUNNER_TEMP/azure-home" \
             "$RUNNER_TEMP/oci-home" \
             "$RUNNER_TEMP/oci-migration-transport" \
-            "$RUNNER_TEMP/oci-migration-health"
+            "$RUNNER_TEMP/oci-migration-health" || cleanup_status=1
+          exit "$cleanup_status"
 
   public-validate:
     needs: migrate
@@ -1009,6 +1025,15 @@ jobs:
           cluster-name: ${{ env.AZURE_CLUSTER_NAME }}
           admin: false
 
+      - name: Materialize finalization Azure kubeconfig
+        run: |
+          set -euo pipefail
+          [[ -n "${KUBE_CONFIG_PATH:-}" ]]
+          [[ "$KUBE_CONFIG_PATH" == "$RUNNER_TEMP/"* ]]
+          [[ "$AZURE_KUBECONFIG" == "$RUNNER_TEMP/"* ]]
+          [ -f "$KUBE_CONFIG_PATH" ] && [ ! -L "$KUBE_CONFIG_PATH" ]
+          install -m 600 -- "$KUBE_CONFIG_PATH" "$AZURE_KUBECONFIG"
+
       - name: Install pinned finalization OCI CLI
         id: final_oci_cli
         env:
@@ -1189,7 +1214,7 @@ jobs:
                 --output json
           )"
           jq -e '
-            length >= 1 and
+            type == "array" and
             all(.[]; any(.instanceView.statuses[]?;
               .code == "PowerState/deallocated"))
           ' <<<"$vmss_instances" >/dev/null
@@ -1380,12 +1405,19 @@ jobs:
         env:
           HOME: ${{ runner.temp }}/azure-finalize
         run: |
+          cleanup_status=0
           az logout >/dev/null 2>&1 || true
+          case "${KUBE_CONFIG_PATH:-}" in
+            "$RUNNER_TEMP/"*) rm -f -- "$KUBE_CONFIG_PATH" || cleanup_status=1 ;;
+            "") ;;
+            *) cleanup_status=1 ;;
+          esac
           rm -rf \
             "$RUNNER_TEMP/azure-finalize" \
             "$RUNNER_TEMP/oci-finalize" \
             "$RUNNER_TEMP/oci-migration-finalize" \
-            "$RUNNER_TEMP/betstan-k3s-finalize"
+            "$RUNNER_TEMP/betstan-k3s-finalize" || cleanup_status=1
+          exit "$cleanup_status"
 
       - name: Build sanitized successful migration summary
         id: success_summary

--- a/infra/azure/agents/retire-production-stan.sh
+++ b/infra/azure/agents/retire-production-stan.sh
@@ -595,7 +595,7 @@ else
     --name "$vmss_name" \
     --expand instanceView -o json |
     jq -e '
-      length >= 1 and
+      type == "array" and
       all(.[]; any(.instanceView.statuses[]?;
         .code == "PowerState/deallocated"))
     ' >/dev/null ||

--- a/infra/azure/agents/test-retire-production-stan.sh
+++ b/infra/azure/agents/test-retire-production-stan.sh
@@ -192,6 +192,8 @@ case "${1:-} ${2:-}" in
   "vmss list-instances")
     if [[ "${STUB_RUNNING_VMSS:-0}" == "1" ]]; then
       printf '%s\n' '[{"instanceView":{"statuses":[{"code":"PowerState/running"}]}}]'
+    elif [[ "${STUB_EMPTY_VMSS:-0}" == "1" ]]; then
+      printf '%s\n' '[]'
     else
       printf '%s\n' '[{"instanceView":{"statuses":[{"code":"PowerState/deallocated"}]}}]'
     fi
@@ -437,6 +439,8 @@ run_plan "$WORK_DIR/good" |
 
 run_plan "$WORK_DIR/deallocated" STUB_AKS_POWER_STATE=Deallocated |
   grep -Eq '^azure_retirement=READY_TO_CONFIRM inventory_sha256=[0-9a-f]{64} resources=28$'
+run_plan "$WORK_DIR/empty-vmss" STUB_EMPTY_VMSS=1 |
+  grep -Eq '^azure_retirement=READY_TO_CONFIRM inventory_sha256=[0-9a-f]{64} resources=28$'
 if run_plan "$WORK_DIR/running-control-plane" STUB_AKS_POWER_STATE=Running \
     >"$WORK_DIR/running-control-plane.out" 2>&1; then
   echo "retirement fixture accepted a running AKS control plane" >&2
@@ -511,4 +515,4 @@ for crash_point in aks managed primary; do
     grep -qx 'AZURE_RESOURCES_RETIRED cost_verification=pending_delayed_reporting'
 done
 
-printf 'azure_retirement_contract=PASS scenarios=14\n'
+printf 'azure_retirement_contract=PASS scenarios=15\n'

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -64,6 +64,12 @@ conversation summaries are not authority.
   of `Succeeded`/`Stopped`. Accept that combination only as the exact
   pre-start or already-deallocated state, then require `Succeeded`/`Running`
   after start and independently prove VMSS deallocation after stop.
+- `azure/aks-set-context` writes a runner-generated kubeconfig and exports
+  `KUBE_CONFIG_PATH`; it does not honor a preselected output path. Materialize
+  that file into each reviewed isolated path before dual-cluster operations.
+- A stopped AKS VMSS may retain deallocated instances or contain zero
+  instances. Both prove that no node compute is running when the exact VMSS
+  resource identity has already been verified.
 - A stopped AKS cluster still incurs disk, load-balancer, public-IP, snapshot,
   and monitoring charges.
 - Azure retirement is complete only after the AKS and managed resource groups,

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -601,6 +601,15 @@ grep -Fq 'OCI_MIGRATION_AZURE_CREDENTIALS' "$migrate_workflow"
 grep -Fq 'OCI_MIGRATION_AGE_IDENTITY' "$migrate_workflow"
 grep -Fq 'az aks start' "$migrate_workflow"
 grep -Fq 'az aks stop' "$migrate_workflow"
+[[ "$(grep -Fc 'type == "array" and' "$migrate_workflow")" -ge 3 ]] ||
+  fail "Azure stop paths do not safely accept an empty VMSS instance set"
+! grep -Fq 'length >= 1 and' "$migrate_workflow" ||
+  fail "Azure stop paths incorrectly require a retained VMSS instance"
+[[ "$(grep -Fc 'install -m 600 -- "$KUBE_CONFIG_PATH" "$AZURE_KUBECONFIG"' \
+  "$migrate_workflow")" -eq 2 ]] ||
+  fail "Azure action kubeconfigs are not materialized at both isolated paths"
+[[ "$(grep -Fc 'exit "$cleanup_status"' "$migrate_workflow")" -eq 2 ]] ||
+  fail "unexpected kubeconfig paths can bypass credential cleanup"
 [[ "$(grep -Fc 'Stopped|Deallocated)' "$migrate_workflow")" -ge 4 ]] ||
   fail "migration does not accept both Azure stopped-state representations"
 grep -Fq '[ "$provisioning" = "Failed" ]' "$migrate_workflow" ||

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -305,6 +305,15 @@ for literal in \
 done
 [[ "$(grep -Fc 'az vmss list-instances' "$MIGRATION_WORKFLOW")" -ge 3 ]] ||
   fail "every Azure stop path does not independently verify VMSS deallocation"
+[[ "$(grep -Fc 'type == "array" and' "$MIGRATION_WORKFLOW")" -ge 3 ]] ||
+  fail "Azure stop paths do not safely accept an empty VMSS instance set"
+! grep -Fq 'length >= 1 and' "$MIGRATION_WORKFLOW" ||
+  fail "Azure stop paths incorrectly require a retained VMSS instance"
+[[ "$(grep -Fc 'install -m 600 -- "$KUBE_CONFIG_PATH" "$AZURE_KUBECONFIG"' \
+  "$MIGRATION_WORKFLOW")" -eq 2 ]] ||
+  fail "Azure action kubeconfigs are not materialized at both isolated paths"
+[[ "$(grep -Fc 'exit "$cleanup_status"' "$MIGRATION_WORKFLOW")" -eq 2 ]] ||
+  fail "unexpected kubeconfig paths can bypass credential cleanup"
 [[ "$(grep -Fc 'Stopped|Deallocated)' "$MIGRATION_WORKFLOW")" -ge 4 ]] ||
   fail "migration does not accept both Azure stopped-state representations"
 grep -Fq '[ "$provisioning" = "Failed" ]' "$MIGRATION_WORKFLOW" ||


### PR DESCRIPTION
## Summary
- materialize `azure/aks-set-context` output into both reviewed isolated kubeconfig paths
- clean runner-generated kubeconfig credentials on every path
- accept a verified empty AKS VMSS instance set as no running compute

## Validation
- OCI and migration-recovery contracts
- Azure retirement fixtures (15 scenarios)
- Actionlint, ShellCheck, and independent safety review