### PR TITLE
release: promote OCI Mongo cutover

### DIFF
--- a/.github/agents/betstan-migration-recovery.agent.md
+++ b/.github/agents/betstan-migration-recovery.agent.md
@@ -39,8 +39,12 @@ read-only and prefer the checked-in recovery workflow and scripts.
   zero. Clear every partial application database and retry the full export and
   restore from the preserved Azure source.
 - Keep Mongo writes and RabbitMQ publishes locked throughout public and
-  protected validation. Record `cutover-committed` only after final parity
-  under both locks, then unlock idempotently.
+  protected validation. Because Mongo's `fsyncLock` is cleared by a container
+  restart, also require the mirrored, controller-level HTTP mutation fence
+  before ingress reopens and verify the directive in the running NGINX
+  configuration. Pre-commit public checks are read-only. Record
+  `cutover-committed` only after final parity under all three fences, then
+  unlock idempotently and remove the HTTP fence last.
 - After `cutover-committed`, never retry from Azure. OCI may have accepted new
   production writes; recover only forward through any remaining unlock and
   completion steps.

--- a/.github/agents/betstan-mongo-migration.agent.md
+++ b/.github/agents/betstan-mongo-migration.agent.md
@@ -57,7 +57,9 @@ This agent owns only in-AKS legacy-to-shared Mongo consolidation. The
 cross-cloud Azure-to-OCI exact replacement is owned by
 `.github/agents/betstan-migration-recovery.agent.md` and
 `.github/workflows/oci-migrate.yml`. Do not apply this agent's retained-backup
-or reverse-copy model to that explicitly approved no-backup replacement.
+or reverse-copy model to that explicitly approved no-backup replacement. That
+replacement must pair its process-local Mongo lock with the journaled
+ingress-nginx HTTP mutation fence until the cutover is committed.
 
 Use:
 
@@ -100,7 +102,16 @@ the same journal identity and verified private artifacts.
 
 ### Preflight
 
-- Require exact server-version and FCV compatibility for all eight sources.
+- Read exact live image digests, server versions, and FCVs for all eight
+  sources; legacy mutable image references and repository history are not
+  runtime evidence.
+- Persist each source pod UID, container ID, restart count, digest, version,
+  and FCV in both journals. Recheck that identity before and after every
+  signature and dump, and abort on any pod or container recreation even if the
+  replacement appears Ready.
+- Require exact source/target server-version and FCV compatibility. If OCI
+  needs alignment, keep ingress and writers frozen and follow every supported,
+  digest-pinned intermediate binary and FCV transition during deployment.
 - Verify exact live legacy `MONGO_URI` values and the eight logical database
   names.
 - Verify target capacity, expandable StorageClass, retained auth PVC identity,

--- a/.github/workflows/oci-migrate.yml
+++ b/.github/workflows/oci-migrate.yml
@@ -851,22 +851,15 @@ jobs:
           [ "$OCI_REDIRECT_URL" = "https://www.betstan.xyz" ]
           [[ "$OCI_DIAGNOSTIC_URL" =~ ^https://[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\.nip\.io$ ]]
 
-      - name: Install browser validation dependencies
-        run: |
-          cd client
-          npm ci
-          npx playwright install --with-deps chromium
-
-      - name: Run full public OCI validation without cloud credentials
+      - name: Run read-only public OCI validation with mutation fence
         env:
           OCI_PUBLIC_URL: ${{ needs.migrate.outputs.public_url }}
           OCI_REDIRECT_URL: ${{ needs.migrate.outputs.redirect_url }}
           OCI_DIAGNOSTIC_URL: ${{ needs.migrate.outputs.diagnostic_url }}
-          OCI_CLUSTER_CHECKS_ALREADY_PASSED: "1"
-          MAX_LOOPS: "3"
-          SLEEP_SECONDS: "20"
+          OCI_EXPECT_HTTP_MUTATION_FENCE: "1"
+          STABILITY_ATTEMPTS: "10"
           OUTPUT_DIR: ${{ runner.temp }}/oci-public-validation
-        run: ./infra/oci/agents/validation-loop-stan.sh
+        run: ./infra/oci/agents/smoke-liveness-stan.sh
 
       - name: Remove public validation output
         if: always()
@@ -1123,8 +1116,8 @@ jobs:
             ./infra/oci/scripts/migrate-from-azure.sh fail-closed
           fi
 
-      - name: Fail closed if final success transition itself fails
-        if: always() && steps.transition.outcome == 'failure'
+      - name: Fail closed unless final success transition completed
+        if: always() && steps.transition.outcome != 'success'
         env:
           HOME: ${{ runner.temp }}/oci-finalize
           GH_TOKEN: ${{ github.token }}
@@ -1419,17 +1412,74 @@ jobs:
             "$RUNNER_TEMP/betstan-k3s-finalize" || cleanup_status=1
           exit "$cleanup_status"
 
+  post-commit-validate:
+    needs: [migrate, public-validate, finalize]
+    if: >-
+      always() &&
+      github.run_attempt == 1 &&
+      needs.migrate.result == 'success' &&
+      needs.public-validate.result == 'success' &&
+      needs.finalize.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: oci-migration
+    env:
+      SOURCE_SHA: ${{ inputs.approved_sha }}
+      AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256: ${{ vars.AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256 }}
+    steps:
+      - name: Checkout exact committed migration without credentials
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.approved_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate post-commit public identity
+        env:
+          OCI_PUBLIC_URL: ${{ needs.migrate.outputs.public_url }}
+          OCI_REDIRECT_URL: ${{ needs.migrate.outputs.redirect_url }}
+          OCI_DIAGNOSTIC_URL: ${{ needs.migrate.outputs.diagnostic_url }}
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [ "$GITHUB_RUN_ATTEMPT" = "1" ]
+          [ "$(git rev-parse HEAD)" = "$SOURCE_SHA" ]
+          [ "$OCI_PUBLIC_URL" = "https://betstan.xyz" ]
+          [ "$OCI_REDIRECT_URL" = "https://www.betstan.xyz" ]
+          [[ "$OCI_DIAGNOSTIC_URL" =~ ^https://[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\.nip\.io$ ]]
+
+      - name: Download exact completed phase and Azure stop evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-migration-final-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/oci-migration-final
+
+      - name: Install browser validation dependencies
+        run: |
+          cd client
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Validate public write path after committed fence removal
+        id: post_commit_validation
+        env:
+          OCI_PUBLIC_URL: ${{ needs.migrate.outputs.public_url }}
+          OCI_REDIRECT_URL: ${{ needs.migrate.outputs.redirect_url }}
+          OCI_DIAGNOSTIC_URL: ${{ needs.migrate.outputs.diagnostic_url }}
+          OCI_EXPECT_HTTP_MUTATION_FENCE: "0"
+          OCI_CLUSTER_CHECKS_ALREADY_PASSED: "1"
+          MAX_LOOPS: "3"
+          SLEEP_SECONDS: "20"
+          OUTPUT_DIR: ${{ runner.temp }}/oci-post-commit-validation
+        run: ./infra/oci/agents/validation-loop-stan.sh
+
+      - name: Remove post-commit public validation output
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/oci-post-commit-validation"
+
       - name: Build sanitized successful migration summary
         id: success_summary
-        if: >-
-          always() &&
-          env.PUBLIC_VALIDATION_RESULT == 'success' &&
-          steps.transition.outcome == 'success' &&
-          steps.azure_stop.outcome == 'success' &&
-          steps.final_artifact.outcome == 'success' &&
-          steps.revoke.outcome != 'failure' &&
-          steps.bastion_cleanup.outcome != 'failure' &&
-          steps.final_client_cleanup.outcome == 'success'
         run: |
           set -euo pipefail
           phase_file=artifacts/oci-migration-final/phase.env
@@ -1478,6 +1528,7 @@ jobs:
           journal_phase="$(get_phase_field phase)"
           boundary="$(get_phase_field destructive-boundary)"
           recovery_required="$(get_phase_field recovery-required)"
+          http_write_fence="$(get_phase_field http-write-fence)"
           database_count="$(get_phase_field database-count)"
           logical_parity="$(get_phase_field logical-parity)"
           source_signatures="$(get_phase_field signature-manifest-sha256)"
@@ -1499,6 +1550,7 @@ jobs:
           [ "$journal_phase" = "completed" ]
           [ "$boundary" = "true" ]
           [ "$recovery_required" = "false" ]
+          [ "$http_write_fence" = "false" ]
           [ "$database_count" = "8" ]
           [ "$logical_parity" = "true" ]
           [[ "$source_signatures" =~ ^[0-9a-f]{64}$ ]]
@@ -1536,6 +1588,7 @@ jobs:
             "source_signature_aggregate_sha256=$source_signatures" \
             "target_signature_aggregate_sha256=$target_signatures" \
             "oci_reopened_healthy=true" \
+            "http_mutation_fence_removed=true" \
             "azure_writers_frozen=true" \
             "azure_cluster_resource_id_sha256=$azure_cluster_fingerprint" \
             "aks_power_state=$aks_power_state" \

--- a/infra/azure/agents/retire-production-stan.sh
+++ b/infra/azure/agents/retire-production-stan.sh
@@ -471,6 +471,7 @@ fencing_generation
 final_journal_sha256
 github_run_attempt
 github_run_id
+http_mutation_fence_removed
 journal_generation
 journal_heartbeat_epoch
 journal_sequence
@@ -502,6 +503,7 @@ require_summary_value destructive_boundary_crossed true
 require_summary_value database_count 8
 require_summary_value logical_source_target_parity true
 require_summary_value oci_reopened_healthy true
+require_summary_value http_mutation_fence_removed true
 require_summary_value azure_writers_frozen true
 require_summary_value azure_cluster_resource_id_sha256 \
   "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256"

--- a/infra/azure/agents/test-retire-production-stan.sh
+++ b/infra/azure/agents/test-retire-production-stan.sh
@@ -257,6 +257,8 @@ elif [[ "${1:-} ${2:-}" == "run download" ]]; then
   target_signature="$(printf 'a%.0s' {1..64})"
   [[ "${STUB_BAD_PARITY:-0}" != "1" ]] ||
     target_signature="$(printf 'b%.0s' {1..64})"
+  fence_removed=true
+  [[ "${STUB_FENCE_RETAINED:-0}" != "1" ]] || fence_removed=false
   cat > "$directory/migration-summary.env" <<ENV
 schema=betstan.oci-migration-success.v1
 migration_id=migration-fixture
@@ -276,6 +278,7 @@ logical_source_target_parity=true
 source_signature_aggregate_sha256=$(printf 'a%.0s' {1..64})
 target_signature_aggregate_sha256=${target_signature}
 oci_reopened_healthy=true
+http_mutation_fence_removed=${fence_removed}
 azure_writers_frozen=true
 azure_cluster_resource_id_sha256=${STUB_CLUSTER_DIGEST}
 aks_power_state=${STUB_AKS_POWER_STATE:-Stopped}
@@ -450,7 +453,7 @@ grep -Fq 'NO_GO azure_retirement_reason=' "$WORK_DIR/running-control-plane.out"
 
 for failure_mode in \
   STUB_BAD_RUN STUB_BAD_PARITY STUB_UNKNOWN_RESOURCE STUB_RUNNING_VMSS \
-  STUB_WRONG_SUBSCRIPTION STUB_GROUP_API_FAIL; do
+  STUB_WRONG_SUBSCRIPTION STUB_GROUP_API_FAIL STUB_FENCE_RETAINED; do
   if run_plan "$WORK_DIR/${failure_mode}" "$failure_mode=1" \
       >"$WORK_DIR/${failure_mode}.out" 2>&1; then
     echo "retirement fixture unexpectedly passed: $failure_mode" >&2
@@ -515,4 +518,4 @@ for crash_point in aks managed primary; do
     grep -qx 'AZURE_RESOURCES_RETIRED cost_verification=pending_delayed_reporting'
 done
 
-printf 'azure_retirement_contract=PASS scenarios=15\n'
+printf 'azure_retirement_contract=PASS scenarios=16\n'

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -47,9 +47,29 @@ conversation summaries are not authority.
 - The approved migration is an exact logical replacement with no retained
   backup. Once OCI target mutation begins, previous OCI data is unrecoverable.
 - No retained backup or old-OCI rollback exists.
+- The legacy Azure Mongo manifests use the mutable `mongo` image reference.
+  Read and record every live source image digest, server version, and FCV
+  before target mutation; repository history does not prove source runtime.
+  Bind the capture to each pod UID, container ID, restart count, digest,
+  version, and FCV. Persist that complete manifest in both journals and recheck
+  it around every dump so a restart cannot silently pull a different image.
+- Never skip Mongo's supported upgrade sequence to align the disposable OCI
+  target. Freeze ingress and writers, move 7.0 to the exact pinned 8.0 binary,
+  advance FCV to 8.0, then move to the exact pinned 8.2 binary and FCV 8.2.
+  A failed or interrupted deployment remains closed and resumes only from one
+  of those reviewed image/version/FCV states.
 - Keep Azure disks until OCI database signatures and full application health
   pass. After destructive failure, keep OCI closed and retry the complete
   replacement from Azure; never expose mixed data.
+- Mongo `fsyncLock` is process-local and disappears if the Mongo container
+  restarts. Before reopening ingress for pre-commit checks, add the reviewed
+  ingress-nginx ConfigMap fence that rejects mutating HTTP methods, verify it
+  in the running NGINX configuration, and mirror its state in both journals.
+  Keep it across every pre-commit failure and remove it only after
+  `cutover-committed` and both internal write locks are released.
+- Pre-commit public checks must be read-only and prove the HTTP mutation fence.
+  Run the mutating browser journey only after commit and fence removal; never
+  let a validation write invalidate the certified source/target signatures.
 - A stale heartbeat does not authorize blind lock deletion. Verify the owner
   run is conclusively inactive, both cluster locks and fingerprints agree, and
   the fencing generation is advanced atomically.

--- a/infra/oci/agents/health-check-stan.sh
+++ b/infra/oci/agents/health-check-stan.sh
@@ -284,15 +284,20 @@ import sys
 
 pods = json.load(open(sys.argv[1], encoding="utf-8"))
 expected = {
-    "gaming-auth-mongo": "sha256:3d715950d83061ff2fbc910d12d3703212538cacf6b3003e3736fa5c7f51a2e1",
-    "gaming-rabbitmq": "sha256:6033d0c2f4e9eb49dda9623067a96d317bc7b550513bd18532fbd3cd9a941c1b",
+    "gaming-auth-mongo": {
+        "sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3",
+        "sha256:21ca0269db1ebbd1c59f5cbc04928d7e3f6ab6186d7ceafc8fa489c0486525b4",
+    },
+    "gaming-rabbitmq": {
+        "sha256:6033d0c2f4e9eb49dda9623067a96d317bc7b550513bd18532fbd3cd9a941c1b",
+    },
 }
 with open(sys.argv[2], encoding="utf-8") as handle:
     for row in csv.reader(handle, delimiter="\t"):
         if not row:
             continue
         service, _, _, _, platform_digest = row
-        expected[f"gaming-{service}"] = platform_digest
+        expected[f"gaming-{service}"] = {platform_digest}
 
 result = []
 for pod in pods.get("items", []):
@@ -306,8 +311,11 @@ for pod in pods.get("items", []):
             reasons.append(waiting)
         if terminated:
             reasons.append(terminated)
-        digest = expected.get(status.get("name"))
-        if not digest or not status.get("imageID", "").endswith("@" + digest):
+        digests = expected.get(status.get("name"), set())
+        if not any(
+            status.get("imageID", "").endswith("@" + digest)
+            for digest in digests
+        ):
             digest_match = False
     if pod.get("status", {}).get("reason"):
         reasons.append(pod["status"]["reason"])
@@ -355,6 +363,22 @@ PY
 
 mongo_pod="$(kubectl get pods -n "$OCI_K8S_NAMESPACE" -l app=gaming-auth-mongo -o jsonpath='{.items[0].metadata.name}')"
 [[ -n "$mongo_pod" ]] || oci_die "Mongo pod is missing"
+mongo_runtime_json="$(
+  kubectl exec -n "$OCI_K8S_NAMESPACE" "$mongo_pod" -- \
+    mongosh --quiet --eval '
+      const result=db.adminCommand({getParameter:1,featureCompatibilityVersion:1});
+      if (result.ok !== 1) throw new Error("FCV read failed");
+      print(JSON.stringify({
+        version:db.version(),
+        majorMinor:db.version().split(".").slice(0,2).join("."),
+        fcv:result.featureCompatibilityVersion.version
+      }));
+    '
+)"
+jq -e '
+  .version == "8.2.12" and .majorMinor == "8.2" and .fcv == "8.2"
+' <<<"$mongo_runtime_json" >/dev/null ||
+  oci_die "Mongo runtime differs from exact version 8.2.12 and FCV 8.2"
 database_json="$(
   kubectl exec -n "$OCI_K8S_NAMESPACE" "$mongo_pod" -- \
     mongosh --quiet --eval \
@@ -486,6 +510,7 @@ jq -n \
   --argjson mongo_pvc_count "$mongo_pvc_count" \
   --argjson mongo_pvc_bound "$mongo_pvc_bound" \
   --argjson mongo_pvc_gib "$mongo_pvc_gib" \
+  --argjson mongo_runtime "$mongo_runtime_json" \
   --argjson databases "$database_json" \
   --argjson services "$service_health" \
   --argjson queue_count "$queue_count" \
@@ -534,6 +559,9 @@ jq -n \
       pvc_count: $mongo_pvc_count,
       pvc_bound: $mongo_pvc_bound,
       pvc_gib: $mongo_pvc_gib,
+      version: $mongo_runtime.version,
+      major_minor: $mongo_runtime.majorMinor,
+      fcv: $mongo_runtime.fcv,
       logical_databases: $databases
     },
     services: $services,

--- a/infra/oci/agents/health-contract.py
+++ b/infra/oci/agents/health-contract.py
@@ -172,6 +172,12 @@ def validate(snapshot):
     require(mongo.get("pvc_bound") is True, "mongo-pvc-unbound", "Mongo PVC is not Bound")
     require(mongo.get("pvc_gib") == 50, "mongo-pvc-size", "Mongo PVC was not created at 50 GiB")
     require(
+        mongo.get("version") == "8.2.12" and mongo.get("major_minor") == "8.2",
+        "mongo-version",
+        "Mongo runtime is not the reviewed 8.2.12 release",
+    )
+    require(mongo.get("fcv") == "8.2", "mongo-fcv", "Mongo FCV is not 8.2")
+    require(
         set(mongo.get("logical_databases", [])) == EXPECTED_DATABASES,
         "mongo-databases",
         "Mongo does not contain exactly the eight logical database names",

--- a/infra/oci/agents/smoke-liveness-stan.sh
+++ b/infra/oci/agents/smoke-liveness-stan.sh
@@ -8,6 +8,7 @@ DIAGNOSTIC_URL="${OCI_DIAGNOSTIC_URL:-}"
 EXPECTED_HOME_MARKER="${OCI_EXPECTED_HOME_MARKER:-BetStan.xyz demo app}"
 REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-25}"
 STABILITY_ATTEMPTS="${STABILITY_ATTEMPTS:-10}"
+EXPECT_HTTP_MUTATION_FENCE="${OCI_EXPECT_HTTP_MUTATION_FENCE:-0}"
 OUTPUT_DIR="${OUTPUT_DIR:-$ROOT_DIR/artifacts/oci-smoke}"
 WORK_DIR="$OUTPUT_DIR/.work"
 
@@ -25,6 +26,9 @@ fail() {
   fail "diagnostic URL must be an HTTPS IPv4-derived nip.io hostname"
 [[ "$STABILITY_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] ||
   fail "STABILITY_ATTEMPTS must be positive"
+[[ "$EXPECT_HTTP_MUTATION_FENCE" == "0" ||
+   "$EXPECT_HTTP_MUTATION_FENCE" == "1" ]] ||
+  fail "OCI_EXPECT_HTTP_MUTATION_FENCE must be 0 or 1"
 for command in curl dig jq openssl; do
   command -v "$command" >/dev/null 2>&1 || fail "$command is unavailable"
 done
@@ -94,6 +98,20 @@ require_served_certificate() {
   done
   openssl x509 -in "$certificate" -checkend 604800 -noout >/dev/null ||
     fail "$label certificate expires within seven days"
+}
+
+require_http_mutation_fence() {
+  local url="$1"
+  local label="$2"
+  local status
+  status="$(
+    curl --silent --show-error --max-time "$REQUEST_TIMEOUT" \
+      --request POST --header 'Content-Type: application/json' \
+      --data '{}' --output "$WORK_DIR/${label}.body" \
+      --write-out '%{http_code}' "${url}/api/auth/signup"
+  )" || fail "$label mutation-fence request failed"
+  [[ "$status" == "503" ]] ||
+    fail "$label mutating request bypassed the HTTP maintenance fence"
 }
 
 require_exact_dns "$canonical_host" canonical
@@ -179,6 +197,11 @@ diagnostic_content_type="$(
 jq -e 'type == "object" and has("currentUser")' "$diagnostic_body" >/dev/null ||
   fail "diagnostic API JSON shape is invalid"
 
+if [[ "$EXPECT_HTTP_MUTATION_FENCE" == "1" ]]; then
+  require_http_mutation_fence "$PUBLIC_URL" canonical
+  require_http_mutation_fence "$DIAGNOSTIC_URL" diagnostic
+fi
+
 for _ in $(seq 1 "$STABILITY_ATTEMPTS"); do
   curl --fail --silent --show-error --max-time "$REQUEST_TIMEOUT" \
     --output /dev/null "${PUBLIC_URL}/" ||
@@ -188,4 +211,5 @@ for _ in $(seq 1 "$STABILITY_ATTEMPTS"); do
     fail "diagnostic stability probe failed"
 done
 
-printf 'oci_smoke_liveness=PASS canonical_https=1 www_redirect=1 diagnostic_https=1 dns_match=1 api_json=1\n'
+printf 'oci_smoke_liveness=PASS canonical_https=1 www_redirect=1 diagnostic_https=1 dns_match=1 api_json=1 http_mutation_fence=%s\n' \
+  "$EXPECT_HTTP_MUTATION_FENCE"

--- a/infra/oci/agents/test-health-contract-stan.sh
+++ b/infra/oci/agents/test-health-contract-stan.sh
@@ -48,6 +48,8 @@ run_failure platform-digest '.platform_workloads[0].image="mutable"' platform-di
 run_failure empty-endpoint '.services[0].ready_endpoints=false' empty-endpoint
 run_failure extra-mongo '.mongo.statefulset_count=2' extra-mongo
 run_failure unbound-pvc '.mongo.pvc_bound=false' mongo-pvc-unbound
+run_failure mongo-version '.mongo.version="7.0.21"|.mongo.major_minor="7.0"' mongo-version
+run_failure mongo-fcv '.mongo.fcv="8.0"' mongo-fcv
 run_failure digest-mismatch '.pods[0].digest_match=false' digest-mismatch
 run_failure restart-increase '.pods[0].restarts=1' restart-increase
 run_failure oom-kill '.pods[0].last_reason="OOMKilled"' pod-failure-reason
@@ -83,17 +85,24 @@ set -euo pipefail
 output=/dev/null
 headers=/dev/null
 url=""
+method=GET
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --output) output="$2"; shift 2 ;;
     --dump-header) headers="$2"; shift 2 ;;
     --write-out) shift 2 ;;
     --max-time) shift 2 ;;
-    --silent|--show-error) shift ;;
+    --request) method="$2"; shift 2 ;;
+    --header|--data) shift 2 ;;
+    --silent|--show-error|--fail) shift ;;
     *) url="$1"; shift ;;
   esac
 done
-if [[ "$url" == http://betstan.xyz/* ]]; then
+if [[ "$method" == "POST" && "${STUB_MUTATION_FENCE:-0}" == "1" ]]; then
+  printf 'HTTP/2 503\r\ncontent-type: text/html\r\n\r\n' > "$headers"
+  printf 'maintenance' > "$output"
+  printf '503'
+elif [[ "$url" == http://betstan.xyz/* ]]; then
   location="https://betstan.xyz/${url#http://betstan.xyz/}"
   printf 'HTTP/1.1 308 Permanent Redirect\r\nLocation: %s\r\n\r\n' "$location" > "$headers"
   : > "$output"
@@ -205,6 +214,27 @@ PATH="$WORK_DIR/bin:$PATH" \
   OCI_REDIRECT_URL=https://www.betstan.xyz \
   OCI_DIAGNOSTIC_URL=https://203.0.113.10.nip.io \
   OUTPUT_DIR="$WORK_DIR/smoke-good" "$OCI_DIR/agents/smoke-liveness-stan.sh" >/dev/null
+PATH="$WORK_DIR/bin:$PATH" \
+STUB_MUTATION_FENCE=1 \
+OCI_EXPECT_HTTP_MUTATION_FENCE=1 \
+OCI_PUBLIC_URL=https://betstan.xyz \
+OCI_REDIRECT_URL=https://www.betstan.xyz \
+OCI_DIAGNOSTIC_URL=https://203.0.113.10.nip.io \
+OUTPUT_DIR="$WORK_DIR/smoke-fenced" \
+  "$OCI_DIR/agents/smoke-liveness-stan.sh" >/dev/null
+if PATH="$WORK_DIR/bin:$PATH" \
+    OCI_EXPECT_HTTP_MUTATION_FENCE=1 \
+    OCI_PUBLIC_URL=https://betstan.xyz \
+    OCI_REDIRECT_URL=https://www.betstan.xyz \
+    OCI_DIAGNOSTIC_URL=https://203.0.113.10.nip.io \
+    OUTPUT_DIR="$WORK_DIR/smoke-unfenced" \
+    "$OCI_DIR/agents/smoke-liveness-stan.sh" \
+    >"$WORK_DIR/smoke-unfenced.out" 2>&1; then
+  echo "missing HTTP mutation fence unexpectedly passed" >&2
+  exit 1
+fi
+grep -Fq 'mutating request bypassed the HTTP maintenance fence' \
+  "$WORK_DIR/smoke-unfenced.out"
 if PATH="$WORK_DIR/bin:$PATH" STUB_BAD_API=1 \
   OCI_PUBLIC_URL=https://betstan.xyz \
   OCI_REDIRECT_URL=https://www.betstan.xyz \
@@ -279,4 +309,4 @@ if OCI_PUBLIC_URL=https://betstan.xyz \
   exit 1
 fi
 
-echo "oci_health_fixture_contract=PASS scenarios=38"
+echo "oci_health_fixture_contract=PASS scenarios=40"

--- a/infra/oci/k8s/base/kustomization.yaml
+++ b/infra/oci/k8s/base/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
 images:
   - name: mongo
     newName: docker.io/library/mongo
-    digest: sha256:3d715950d83061ff2fbc910d12d3703212538cacf6b3003e3736fa5c7f51a2e1
+    digest: sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
   - name: rabbitmq
     newName: docker.io/library/rabbitmq
     digest: sha256:6033d0c2f4e9eb49dda9623067a96d317bc7b550513bd18532fbd3cd9a941c1b

--- a/infra/oci/scripts/deploy.sh
+++ b/infra/oci/scripts/deploy.sh
@@ -138,6 +138,22 @@ apply_documents() {
   printf '%s' "$rendered" | kubectl apply -f -
 }
 
+mongo_target_image="$(
+  ruby -ryaml - "$RENDERED_FILE" <<'RUBY'
+documents = YAML.load_stream(File.read(ARGV.fetch(0))).compact
+mongo = documents.find { |document|
+  document["kind"] == "StatefulSet" &&
+    document.dig("metadata", "name") == "gaming-auth-mongo-depl"
+}
+abort "rendered Mongo StatefulSet is missing" unless mongo
+containers = mongo.dig("spec", "template", "spec", "containers") || []
+container = containers.find { |item| item["name"] == "gaming-auth-mongo" }
+abort "rendered Mongo container is missing" unless container
+puts container.fetch("image")
+RUBY
+)"
+mongo_upgrade_state_file="$OUTPUT_DIR/mongo-upgrade.env"
+
 apply_documents "Namespace:^${OCI_K8S_NAMESPACE}$"
 
 printf '%s' "$OCI_JWT_KEY" |
@@ -169,13 +185,17 @@ kubectl patch serviceaccount default -n "$OCI_K8S_NAMESPACE" --type merge \
 
 apply_documents 'PersistentVolume:^gaming-auth-mongo-data$'
 apply_documents 'PersistentVolumeClaim:^gaming-auth-mongo-data$'
+kubectl wait pvc/gaming-auth-mongo-data -n "$OCI_K8S_NAMESPACE" \
+  --for=jsonpath='{.status.phase}'=Bound --timeout=10m
 apply_documents 'ClusterIssuer:^letsencrypt-prod$'
 apply_documents 'Service:^gaming-(auth-mongo|shared-mongo)-srv$'
+OCI_K8S_NAMESPACE="$OCI_K8S_NAMESPACE" \
+MONGO_TARGET_IMAGE="$mongo_target_image" \
+MONGO_UPGRADE_STATE_FILE="$mongo_upgrade_state_file" \
+  "$SCRIPT_DIR/upgrade-mongo.sh" prepare
 apply_documents 'StatefulSet:^gaming-auth-mongo-depl$'
 kubectl rollout status statefulset/gaming-auth-mongo-depl \
   -n "$OCI_K8S_NAMESPACE" --timeout=10m
-kubectl wait pvc/gaming-auth-mongo-data -n "$OCI_K8S_NAMESPACE" \
-  --for=jsonpath='{.status.phase}'=Bound --timeout=10m
 mongo_pod="$(
   kubectl get pods -n "$OCI_K8S_NAMESPACE" -l app=gaming-auth-mongo \
     -o jsonpath='{.items[0].metadata.name}'
@@ -192,6 +212,10 @@ for _ in $(seq 1 60); do
   sleep 5
 done
 [[ "$mongo_ready" == "1" ]] || oci_die "Mongo did not become ready before deployment"
+OCI_K8S_NAMESPACE="$OCI_K8S_NAMESPACE" \
+MONGO_TARGET_IMAGE="$mongo_target_image" \
+MONGO_UPGRADE_STATE_FILE="$mongo_upgrade_state_file" \
+  "$SCRIPT_DIR/upgrade-mongo.sh" finalize
 for database in \
   gaming_auth gaming_bet gaming_backoffice gaming_event \
   gaming_gamemaster gaming_moderation gaming_resulting gaming_slip; do
@@ -325,5 +349,10 @@ public_data_services="$(
   printf 'deployment_run_attempt=%s\n' "${GITHUB_RUN_ATTEMPT:-1}"
 } > "$OUTPUT_DIR/provenance.txt"
 rm -f "$RENDERED_FILE"
+
+OCI_K8S_NAMESPACE="$OCI_K8S_NAMESPACE" \
+MONGO_TARGET_IMAGE="$mongo_target_image" \
+MONGO_UPGRADE_STATE_FILE="$mongo_upgrade_state_file" \
+  "$SCRIPT_DIR/upgrade-mongo.sh" resume
 
 oci_log "oci_deploy=PASS source_sha=$SOURCE_SHA workloads_sequential=1"

--- a/infra/oci/scripts/migrate-from-azure.sh
+++ b/infra/oci/scripts/migrate-from-azure.sh
@@ -41,6 +41,21 @@ RUNNER_CAPACITY_MULTIPLIER="${RUNNER_CAPACITY_MULTIPLIER:-2}"
 RUNNER_CAPACITY_RESERVE_BYTES="${RUNNER_CAPACITY_RESERVE_BYTES:-2147483648}"
 SIGNATURE_SCRIPT="$SCRIPT_DIR/mongo-canonical-signature.js"
 STATE_HELPER="$SCRIPT_DIR/migration-state.py"
+MONGO_REVIEWED_VERSION=8.2.12
+MONGO_REVIEWED_FCV=8.2
+MONGO_REVIEWED_INDEX_DIGEST=sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
+MONGO_REVIEWED_AMD64_MANIFEST=sha256:41afd6e1183f57e4e4d03ab733070671fca8553da2b36f15d6e3fc9760494d17
+MONGO_REVIEWED_ARM64_MANIFEST=sha256:21ca0269db1ebbd1c59f5cbc04928d7e3f6ab6186d7ceafc8fa489c0486525b4
+MONGO_REVIEWED_TARGET_IMAGE="docker.io/library/mongo@$MONGO_REVIEWED_INDEX_DIGEST"
+INGRESS_CONTROLLER_NAMESPACE="ingress-nginx"
+INGRESS_CONTROLLER_CONFIGMAP="ingress-nginx-controller"
+INGRESS_BASE_SERVER_SNIPPET="if (\$host = \"www.betstan.xyz\") {
+  return 308 https://betstan.xyz\$request_uri;
+}"
+INGRESS_HTTP_WRITE_FENCE_DIRECTIVE="if (\$request_method !~ ^(GET|HEAD|OPTIONS)\$) {
+  return 503;
+}"
+INGRESS_FENCED_SERVER_SNIPPET="${INGRESS_BASE_SERVER_SNIPPET}"$'\n'"${INGRESS_HTTP_WRITE_FENCE_DIRECTIVE}"
 
 APP_SERVICES=(auth bet backoffice event gamemaster moderation resulting slip client)
 BACKEND_SERVICES=(auth bet backoffice event gamemaster moderation resulting slip)
@@ -72,7 +87,12 @@ azure_baseline=""
 oci_baseline=""
 target_mongo_pod=""
 target_mongo_image=""
+target_mongo_uid=""
+target_mongo_image_id=""
+target_mongo_container_id=""
+target_mongo_restart_count=""
 target_runtime_signature=""
+source_mongo_manifest=""
 last_committed_phase=""
 
 state_boundary_text() {
@@ -94,7 +114,7 @@ simulate() {
   local points=(
     azure-start azure-provisioning azure-freeze source-queue-drain runner-capacity
     archive-capture corrupt-archive disposable-validation cancellation hang
-    target-queue-drain oci-freeze
+    target-queue-drain oci-freeze http-write-fence-install
   )
   mkdir -p "$(dirname "$output")"
   for point in "${points[@]}"; do
@@ -105,11 +125,24 @@ simulate() {
         "destructive_boundary=$boundary" \
         "recovery_required=$recovery" \
         "oci_state=$oci_state" \
+        "http_write_fence=false" \
         "azure_apps=frozen" \
         "azure_stopped=true" >"$output"
       return 97
     fi
   done
+  if [[ "$fail_at" == "http-write-fence-installed-crash" ]]; then
+    printf '%s\n' \
+      "result=failed" \
+      "failure_point=$fail_at" \
+      "destructive_boundary=false" \
+      "recovery_required=false" \
+      "oci_state=closed" \
+      "http_write_fence=true" \
+      "azure_apps=frozen" \
+      "azure_stopped=true" >"$output"
+    return 97
+  fi
   boundary=true
   oci_state=closed
   for point in post-boundary-cancellation post-boundary-hang; do
@@ -121,6 +154,7 @@ simulate() {
         "destructive_boundary=$boundary" \
         "recovery_required=$recovery" \
         "oci_state=$oci_state" \
+        "http_write_fence=true" \
         "azure_apps=frozen" \
         "azure_stopped=true" >"$output"
       return 97
@@ -138,6 +172,7 @@ simulate() {
           "destructive_boundary=$boundary" \
           "recovery_required=$recovery" \
           "oci_state=$oci_state" \
+          "http_write_fence=true" \
           "azure_apps=frozen" \
           "azure_stopped=true" >"$output"
         return 97
@@ -146,7 +181,8 @@ simulate() {
   done
   for point in \
     rabbitmq-recreate restart-auth restart-client mongo-write-lock \
-    rabbitmq-write-lock protected-health public-health; do
+    rabbitmq-write-lock http-write-fence-runtime \
+    mongo-restart-during-public-health protected-health public-health; do
     if [[ "$fail_at" == "$point" ]]; then
       recovery=true
       printf '%s\n' \
@@ -155,6 +191,7 @@ simulate() {
         "destructive_boundary=$boundary" \
         "recovery_required=$recovery" \
         "oci_state=closed" \
+        "http_write_fence=true" \
         "azure_apps=frozen" \
         "azure_stopped=true" >"$output"
       return 97
@@ -168,6 +205,7 @@ simulate() {
         "destructive_boundary=true" \
         "recovery_required=false" \
         "oci_state=committed-locked" \
+        "http_write_fence=true" \
         "azure_apps=frozen" \
         "azure_stopped=true" >"$output"
       return 97
@@ -179,6 +217,7 @@ simulate() {
         "destructive_boundary=true" \
         "recovery_required=false" \
         "oci_state=committed-mongo-writable" \
+        "http_write_fence=true" \
         "azure_apps=frozen" \
         "azure_stopped=true" >"$output"
       return 97
@@ -190,6 +229,19 @@ simulate() {
         "destructive_boundary=true" \
         "recovery_required=false" \
         "oci_state=committed-writable" \
+        "http_write_fence=true" \
+        "azure_apps=frozen" \
+        "azure_stopped=true" >"$output"
+      return 97
+      ;;
+    http-write-fence-removed)
+      printf '%s\n' \
+        "result=failed" \
+        "failure_point=$fail_at" \
+        "destructive_boundary=true" \
+        "recovery_required=false" \
+        "oci_state=committed-writable" \
+        "http_write_fence=false" \
         "azure_apps=frozen" \
         "azure_stopped=true" >"$output"
       return 97
@@ -201,6 +253,7 @@ simulate() {
         "destructive_boundary=true" \
         "recovery_required=false" \
         "oci_state=forward-only" \
+        "http_write_fence=true" \
         "azure_apps=frozen" \
         "azure_stopped=true" >"$output"
       return 98
@@ -212,6 +265,7 @@ simulate() {
     "destructive_boundary=true" \
     "recovery_required=false" \
     "oci_state=healthy" \
+    "http_write_fence=false" \
     "exact_database_count=8" \
     "azure_apps=frozen" \
     "azure_stopped=true" >"$output"
@@ -666,6 +720,7 @@ state_new_documents() {
     "transfer-manifest-sha256="
     "mongo-write-lock=false"
     "rabbitmq-write-lock=false"
+    "http-write-fence=false"
   )
   local lock_values=(
     "schema-version=1"
@@ -880,6 +935,10 @@ state_acquire() {
   last_committed_phase="$(state_value phase)"
   [[ "$state_boundary" == "true" ]] && state_boundary=1 || state_boundary=0
   [[ "$state_recovery" == "true" ]] && state_recovery=1 || state_recovery=0
+  if [[ "$(state_optional_value http-write-fence)" == "true" ||
+        "$(http_write_fence_config_status)" == "true" ]]; then
+    oci_frozen=1
+  fi
   printf 'timestamp\tsequence\tphase\tfencing_token\tdestructive_boundary\trecovery_required\n' \
     >"$JOURNAL_FILE"
 }
@@ -1174,6 +1233,128 @@ baseline_value() {
   return 1
 }
 
+http_write_fence_config_status() {
+  local snippet
+  snippet="$(kube_capture oci ingress-config-read 30 2 \
+    get configmap "$INGRESS_CONTROLLER_CONFIGMAP" \
+    -n "$INGRESS_CONTROLLER_NAMESPACE" \
+    -o jsonpath='{.data.server-snippet}')"
+  case "$snippet" in
+    "$INGRESS_BASE_SERVER_SNIPPET")
+      printf false
+      ;;
+    "$INGRESS_FENCED_SERVER_SNIPPET")
+      printf true
+      ;;
+    *)
+      migration_die \
+        "ingress controller server-snippet differs from the reviewed baseline or mutation fence"
+      ;;
+  esac
+}
+
+set_http_write_fence_config() {
+  local expected="$1"
+  local current desired patch
+  [[ "$expected" == "true" || "$expected" == "false" ]] ||
+    migration_die "HTTP write fence state must be true or false"
+  current="$(http_write_fence_config_status)"
+  [[ "$current" == "$expected" ]] && return 0
+  if [[ "$expected" == "true" ]]; then
+    desired="$INGRESS_FENCED_SERVER_SNIPPET"
+  else
+    desired="$INGRESS_BASE_SERVER_SNIPPET"
+  fi
+  patch="$(migration_raw ingress-config-patch 30 1 \
+    jq -cn --arg snippet "$desired" \
+      '{data:{"server-snippet":$snippet}}')"
+  kube_run oci ingress-config-patch "$COMMAND_TIMEOUT_SECONDS" 2 \
+    patch configmap "$INGRESS_CONTROLLER_CONFIGMAP" \
+    -n "$INGRESS_CONTROLLER_NAMESPACE" \
+    --type merge --patch "$patch" >/dev/null
+  [[ "$(http_write_fence_config_status)" == "$expected" ]] ||
+    migration_die "ingress HTTP write fence ConfigMap did not reach the requested state"
+}
+
+http_write_fence_runtime_status() {
+  local deployment_state desired available pods_json pod_count pod_names
+  local pod rendered fence_line fenced_count=0
+  deployment_state="$(kube_capture oci ingress-workload-read 30 2 \
+    get deployment ingress-nginx-controller \
+    -n "$INGRESS_CONTROLLER_NAMESPACE" \
+    -o jsonpath='{.spec.replicas}|{.status.availableReplicas}')"
+  IFS='|' read -r desired available <<<"$deployment_state"
+  available="${available:-0}"
+  [[ "$desired" =~ ^[1-9][0-9]*$ && "$available" == "$desired" ]] ||
+    migration_die "ingress controller is not fully available for mutation-fence validation"
+  pods_json="$(kube_capture oci ingress-pod-read 30 2 \
+    get pods -n "$INGRESS_CONTROLLER_NAMESPACE" \
+    -l app.kubernetes.io/component=controller -o json)"
+  pod_count="$(migration_raw ingress-pod-count 30 1 \
+    jq '.items | length' <<<"$pods_json")"
+  [[ "$pod_count" == "$desired" ]] ||
+    migration_die "ingress controller pod count differs from its available replicas"
+  migration_raw ingress-pod-readiness 30 1 jq -e '
+    all(.items[];
+      .metadata.deletionTimestamp == null and
+      .status.phase == "Running" and
+      any(.status.conditions[]?;
+        .type == "Ready" and .status == "True"))
+  ' <<<"$pods_json" >/dev/null ||
+    migration_die "an ingress controller pod is not stably Ready"
+  pod_names="$(migration_raw ingress-pod-names 30 1 \
+    jq -r '.items[].metadata.name' <<<"$pods_json")"
+  [[ "$(awk 'NF {count++} END {print count+0}' <<<"$pod_names")" == "$pod_count" ]] ||
+    migration_die "ingress controller pod-name inventory is incomplete"
+  fence_line="${INGRESS_HTTP_WRITE_FENCE_DIRECTIVE%%$'\n'*}"
+  while IFS= read -r pod; do
+    [[ -n "$pod" ]] || continue
+    rendered="$(kube_capture oci ingress-runtime-read 60 2 \
+      exec -n "$INGRESS_CONTROLLER_NAMESPACE" "$pod" -- \
+      sh -c 'nginx -T 2>&1')"
+    grep -Fq 'return 308 https://betstan.xyz$request_uri;' <<<"$rendered" ||
+      migration_die "running ingress controller lost the reviewed www redirect"
+    if grep -Fq "$fence_line" <<<"$rendered"; then
+      fenced_count=$((fenced_count + 1))
+    fi
+  done <<<"$pod_names"
+  if [[ "$fenced_count" == "$pod_count" ]]; then
+    printf true
+  elif [[ "$fenced_count" == "0" ]]; then
+    printf false
+  else
+    migration_die "ingress controller replicas disagree on the HTTP write fence"
+  fi
+}
+
+wait_http_write_fence_runtime() {
+  local expected="$1"
+  local attempt actual=""
+  for attempt in $(seq 1 30); do
+    if actual="$(http_write_fence_runtime_status)" &&
+        [[ "$actual" == "$expected" ]]; then
+      return 0
+    fi
+    migration_sleep 2
+  done
+  migration_die \
+    "running ingress controller HTTP write fence did not reach state $expected"
+}
+
+install_http_write_fence() {
+  state_assert_fence
+  set_http_write_fence_config true
+  state_advance http-write-fence-installed \
+    "$(state_boundary_text)" "$(state_recovery_text)" \
+    "http-write-fence=true"
+  migration_failure_hook http-write-fence-install
+}
+
+remove_http_write_fence() {
+  set_http_write_fence_config false
+  wait_http_write_fence_runtime false
+}
+
 wait_deployment_zero() {
   local provider="$1"
   local namespace="$2"
@@ -1399,6 +1580,18 @@ unlock_rabbitmq_writes() {
     migration_die "OCI RabbitMQ publish permission was not restored"
 }
 
+verify_cutover_write_locks() {
+  [[ "$(state_optional_value mongo-write-lock)" == "true" &&
+    "$(target_write_lock_status)" == "true" &&
+    "$(state_optional_value rabbitmq-write-lock)" == "true" &&
+    "$(rabbitmq_write_permission)" == "^$" &&
+    "$(state_optional_value http-write-fence)" == "true" &&
+    "$(http_write_fence_config_status)" == "true" &&
+    "$(http_write_fence_runtime_status)" == "true" ]] ||
+    migration_die \
+      "OCI data, messaging, or external HTTP write fence changed before parity certification"
+}
+
 mongo_runtime() {
   mongo_eval "$1" "$2" '
     const result=db.adminCommand({getParameter:1,featureCompatibilityVersion:1});
@@ -1409,6 +1602,26 @@ mongo_runtime() {
       fcv:result.featureCompatibilityVersion.version
     }));
   '
+}
+
+mongo_runtime_is_reviewed() {
+  migration_raw mongo-runtime 30 1 jq -e \
+    --arg version "$MONGO_REVIEWED_VERSION" \
+    --arg fcv "$MONGO_REVIEWED_FCV" '
+      .version == $version and
+      .majorMinor == $fcv and
+      .fcv == $fcv
+    ' <<<"$1" >/dev/null
+}
+
+source_mongo_image_is_reviewed() {
+  [[ "$1" == *"@$MONGO_REVIEWED_INDEX_DIGEST" ||
+    "$1" == *"@$MONGO_REVIEWED_AMD64_MANIFEST" ]]
+}
+
+target_mongo_image_is_reviewed() {
+  [[ "$1" == *"@$MONGO_REVIEWED_INDEX_DIGEST" ||
+    "$1" == *"@$MONGO_REVIEWED_ARM64_MANIFEST" ]]
 }
 
 mongo_non_system_databases() {
@@ -1486,9 +1699,12 @@ mongo_signature_docker() {
 
 validate_source_topology() {
   local statefulsets expected_count=0 mapping service database sts pod pvc
-  local sts_json pod_json claim phase runtime digest non_system expected_json
+  local sts_json pod_json claim phase runtime digest uid container_id restart_count
+  local non_system expected_json
   local runtime_reference="" digest_reference="" source_pvcs target_statefulsets
-  local expected_uri actual_uri
+  local expected_uri actual_uri source_rows
+  source_rows="${source_mongo_manifest}.rows"
+  : >"$source_rows"
   statefulsets="$(kube_capture azure source-statefulsets 30 2 \
     get statefulsets -n "$AZURE_NAMESPACE" -o json)"
   expected_count="$(
@@ -1544,8 +1760,19 @@ validate_source_topology() {
       migration_die "Azure Mongo pod is not Ready: $pod"
     digest="$(migration_raw source-pod 30 1 jq -r \
       '.status.containerStatuses[0].imageID // empty' <<<"$pod_json")"
-    [[ "$digest" =~ @sha256:[0-9a-f]{64}$ ]] ||
-      migration_die "Azure Mongo image digest is not immutable: $pod"
+    source_mongo_image_is_reviewed "$digest" ||
+      migration_die "Azure Mongo image differs from the reviewed 8.2.12 release: $pod"
+    uid="$(migration_raw source-pod 30 1 jq -r '.metadata.uid // empty' <<<"$pod_json")"
+    [[ "$uid" =~ ^[a-z0-9-]+$ ]] ||
+      migration_die "Azure Mongo pod UID is unreadable: $pod"
+    container_id="$(migration_raw source-pod 30 1 jq -r \
+      '.status.containerStatuses[0].containerID // empty' <<<"$pod_json")"
+    [[ "$container_id" =~ ^[a-z0-9+.-]+://[a-zA-Z0-9._:-]+$ ]] ||
+      migration_die "Azure Mongo container ID is unreadable: $pod"
+    restart_count="$(migration_raw source-pod 30 1 jq -r \
+      '.status.containerStatuses[0].restartCount // empty' <<<"$pod_json")"
+    [[ "$restart_count" =~ ^[0-9]+$ ]] ||
+      migration_die "Azure Mongo restart count is unreadable: $pod"
     if [[ -z "$digest_reference" ]]; then
       digest_reference="$digest"
     else
@@ -1554,14 +1781,16 @@ validate_source_topology() {
     fi
     runtime="$(mongo_runtime azure "$pod")"
     migration_raw mongo-runtime 30 1 jq -e \
-      '.majorMinor != null and .fcv != null' <<<"$runtime" >/dev/null ||
+      '.version != null and .majorMinor != null and .fcv != null' <<<"$runtime" >/dev/null ||
       migration_die "Azure Mongo version/FCV is unreadable: $pod"
+    mongo_runtime_is_reviewed "$runtime" ||
+      migration_die "Azure Mongo runtime differs from exact version 8.2.12 and FCV 8.2: $pod"
     if [[ -z "$runtime_reference" ]]; then
       runtime_reference="$(migration_raw mongo-runtime 30 1 jq -c \
-        '{majorMinor,fcv}' <<<"$runtime")"
+        '{version,majorMinor,fcv}' <<<"$runtime")"
     else
       [[ "$(migration_raw mongo-runtime 30 1 jq -c \
-        '{majorMinor,fcv}' <<<"$runtime")" == "$runtime_reference" ]] ||
+        '{version,majorMinor,fcv}' <<<"$runtime")" == "$runtime_reference" ]] ||
         migration_die "Azure Mongo version/FCV differs across sources"
     fi
     non_system="$(mongo_non_system_databases azure "$pod")"
@@ -1569,7 +1798,31 @@ validate_source_topology() {
       '[$database]')"
     [[ "$non_system" == "$expected_json" ]] ||
       migration_die "Azure source inventory is not exact for $database"
+    migration_raw source-manifest 30 1 jq -cn \
+      --arg pod "$pod" \
+      --arg uid "$uid" \
+      --arg image_id "$digest" \
+      --arg container_id "$container_id" \
+      --arg restart_count "$restart_count" \
+      --argjson runtime "$runtime" \
+      '{
+        pod:$pod,
+        uid:$uid,
+        image_id:$image_id,
+        container_id:$container_id,
+        restart_count:$restart_count,
+        runtime:$runtime
+      }' >>"$source_rows"
   done
+  migration_raw source-manifest 30 1 jq -cs 'sort_by(.pod)' \
+    "$source_rows" >"$source_mongo_manifest"
+  rm -f "$source_rows"
+  [[ "$(migration_raw source-manifest 30 1 jq 'length' "$source_mongo_manifest")" == "8" ]] ||
+    migration_die "Azure Mongo identity manifest does not contain all eight sources"
+  migration_log "azure_mongo_runtime=$(
+    migration_raw mongo-runtime 30 1 jq -r \
+      '.version + "/fcv-" + .fcv' <<<"$runtime_reference"
+  )"
 
   target_statefulsets="$(kube_capture oci target-statefulsets 30 2 \
     get statefulsets -n "$OCI_K8S_NAMESPACE" -o json)"
@@ -1596,17 +1849,37 @@ validate_source_topology() {
   target_mongo_image="$(kube_capture oci target-image 30 2 \
     get statefulset gaming-auth-mongo-depl -n "$OCI_K8S_NAMESPACE" \
     -o jsonpath='{.spec.template.spec.containers[0].image}')"
-  [[ "$target_mongo_image" =~ @sha256:[0-9a-f]{64}$ ]] ||
-    migration_die "OCI Mongo image must be digest-pinned"
-  digest="$(kube_capture oci target-image 30 2 \
-    get pod "$target_mongo_pod" -n "$OCI_K8S_NAMESPACE" \
-    -o jsonpath='{.status.containerStatuses[0].imageID}')"
-  [[ "$digest" =~ @sha256:[0-9a-f]{64}$ ]] ||
-    migration_die "OCI running Mongo image digest is not immutable"
+  [[ "$target_mongo_image" == "$MONGO_REVIEWED_TARGET_IMAGE" ]] ||
+    migration_die "OCI Mongo does not request the reviewed 8.2.12 image"
+  pod_json="$(kube_capture oci target-image 30 2 \
+    get pod "$target_mongo_pod" -n "$OCI_K8S_NAMESPACE" -o json)"
+  target_mongo_uid="$(migration_raw target-image 30 1 jq -r \
+    '.metadata.uid // empty' <<<"$pod_json")"
+  [[ "$target_mongo_uid" =~ ^[a-z0-9-]+$ ]] ||
+    migration_die "OCI Mongo pod UID is unreadable"
+  target_mongo_image_id="$(migration_raw target-image 30 1 jq -r \
+    '.status.containerStatuses[0].imageID // empty' <<<"$pod_json")"
+  target_mongo_image_is_reviewed "$target_mongo_image_id" ||
+    migration_die "OCI running Mongo image differs from the reviewed ARM64 release"
+  target_mongo_container_id="$(migration_raw target-image 30 1 jq -r \
+    '.status.containerStatuses[0].containerID // empty' <<<"$pod_json")"
+  [[ "$target_mongo_container_id" =~ ^[a-z0-9+.-]+://[a-zA-Z0-9._:-]+$ ]] ||
+    migration_die "OCI Mongo container ID is unreadable"
+  target_mongo_restart_count="$(migration_raw target-image 30 1 jq -r \
+    '.status.containerStatuses[0].restartCount // empty' <<<"$pod_json")"
+  [[ "$target_mongo_restart_count" =~ ^[0-9]+$ ]] ||
+    migration_die "OCI Mongo restart count is unreadable"
   target_runtime_signature="$(mongo_runtime oci "$target_mongo_pod")"
+  mongo_runtime_is_reviewed "$target_runtime_signature" ||
+    migration_die "OCI Mongo runtime differs from exact version 8.2.12 and FCV 8.2"
+  migration_log "oci_mongo_runtime=$(
+    migration_raw mongo-runtime 30 1 jq -r \
+      '.version + "/fcv-" + .fcv' <<<"$target_runtime_signature"
+  )"
   [[ "$(migration_raw mongo-runtime 30 1 jq -c \
-    '{majorMinor,fcv}' <<<"$target_runtime_signature")" == "$runtime_reference" ]] ||
-    migration_die "Azure and OCI Mongo major version/FCV differ"
+    '{version,majorMinor,fcv}' <<<"$target_runtime_signature")" == "$runtime_reference" ]] ||
+    migration_die "Azure and OCI Mongo version/FCV differ"
+  verify_target_mongo_identity
   non_system="$(mongo_non_system_databases oci "$target_mongo_pod")"
   migration_raw target-inventory 30 1 jq -e \
     --argjson expected "$(expected_database_json)" '
@@ -1622,6 +1895,142 @@ validate_source_topology() {
   done
 }
 
+restore_source_mongo_manifest_from_state() {
+  local required="$1"
+  local content expected_hash actual_hash
+  content="$(state_optional_value source-mongo-identities)"
+  expected_hash="$(state_optional_value source-mongo-manifest-sha256)"
+  if [[ -z "$content" && -z "$expected_hash" && "$required" == "false" ]]; then
+    return
+  fi
+  [[ -n "$content" && "$expected_hash" =~ ^[0-9a-f]{64}$ ]] ||
+    migration_die "persisted Azure Mongo identity manifest is incomplete"
+  printf '%s\n' "$content" >"$source_mongo_manifest"
+  migration_raw source-manifest 30 1 jq -e \
+    --arg version "$MONGO_REVIEWED_VERSION" \
+    --arg fcv "$MONGO_REVIEWED_FCV" '
+      type == "array" and
+      length == 8 and
+      all(.[];
+        (.pod | type == "string") and
+        (.uid | test("^[a-z0-9-]+$")) and
+        (.image_id | type == "string") and
+        (.container_id | test("^[a-z0-9+.-]+://[a-zA-Z0-9._:-]+$")) and
+        (.restart_count | test("^[0-9]+$")) and
+        .runtime.version == $version and
+        .runtime.majorMinor == $fcv and
+        .runtime.fcv == $fcv
+      )
+    ' "$source_mongo_manifest" >/dev/null ||
+    migration_die "persisted Azure Mongo identity manifest is invalid"
+  actual_hash="$(migration_sha256 <"$source_mongo_manifest")"
+  [[ "$actual_hash" == "$expected_hash" ]] ||
+    migration_die "persisted Azure Mongo identity manifest hash differs"
+}
+
+verify_source_mongo_identity() {
+  local pod="$1"
+  local pod_json uid image_id container_id restart_count runtime expected
+  local expected_uid expected_image_id expected_container_id expected_restart_count
+  local expected_runtime actual_runtime
+  pod_json="$(kube_capture azure source-mongo-identity 30 2 \
+    get pod "$pod" -n "$AZURE_NAMESPACE" -o json)"
+  migration_raw source-mongo-identity 30 1 jq -e '
+    ([.status.conditions[] | select(
+      .type == "Ready" and .status == "True"
+    )] | length) == 1
+  ' <<<"$pod_json" >/dev/null ||
+    migration_die "Azure Mongo pod changed readiness during migration: $pod"
+  uid="$(migration_raw source-mongo-identity 30 1 jq -r \
+    '.metadata.uid // empty' <<<"$pod_json")"
+  image_id="$(migration_raw source-mongo-identity 30 1 jq -r \
+    '.status.containerStatuses[0].imageID // empty' <<<"$pod_json")"
+  container_id="$(migration_raw source-mongo-identity 30 1 jq -r \
+    '.status.containerStatuses[0].containerID // empty' <<<"$pod_json")"
+  restart_count="$(migration_raw source-mongo-identity 30 1 jq -r \
+    '.status.containerStatuses[0].restartCount // empty' <<<"$pod_json")"
+  source_mongo_image_is_reviewed "$image_id" ||
+    migration_die "Azure Mongo image drifted from the reviewed release: $pod"
+  runtime="$(mongo_runtime azure "$pod")"
+  mongo_runtime_is_reviewed "$runtime" ||
+    migration_die "Azure Mongo runtime drifted from version 8.2.12 and FCV 8.2: $pod"
+
+  if [[ -f "$source_mongo_manifest" ]]; then
+    expected="$(migration_raw source-manifest 30 1 jq -c \
+      --arg pod "$pod" '
+        [.[] | select(.pod == $pod)] |
+        if length == 1 then .[0] else empty end
+      ' "$source_mongo_manifest")"
+    [[ -n "$expected" ]] ||
+      migration_die "Azure Mongo pod is absent from the preflight identity manifest: $pod"
+    expected_uid="$(migration_raw source-manifest 30 1 jq -r \
+      '.uid' <<<"$expected")"
+    expected_image_id="$(migration_raw source-manifest 30 1 jq -r \
+      '.image_id' <<<"$expected")"
+    expected_container_id="$(migration_raw source-manifest 30 1 jq -r \
+      '.container_id' <<<"$expected")"
+    expected_restart_count="$(migration_raw source-manifest 30 1 jq -r \
+      '.restart_count' <<<"$expected")"
+    expected_runtime="$(migration_raw source-manifest 30 1 jq -c \
+      '.runtime | {version,majorMinor,fcv}' <<<"$expected")"
+    actual_runtime="$(migration_raw mongo-runtime 30 1 jq -c \
+      '{version,majorMinor,fcv}' <<<"$runtime")"
+    [[ "$uid" == "$expected_uid" &&
+      "$image_id" == "$expected_image_id" &&
+      "$container_id" == "$expected_container_id" &&
+      "$restart_count" == "$expected_restart_count" &&
+      "$actual_runtime" == "$expected_runtime" ]] ||
+      migration_die "Azure Mongo pod identity changed after preflight: $pod"
+  fi
+}
+
+verify_target_mongo_identity() {
+  local require_baseline="${1:-true}"
+  local desired_image pod_json uid image_id container_id restart_count runtime
+  local expected_runtime actual_runtime
+  [[ "$require_baseline" == "true" || "$require_baseline" == "false" ]] ||
+    migration_die "target Mongo identity validation mode is invalid"
+  desired_image="$(kube_capture oci target-mongo-identity 30 2 \
+    get statefulset gaming-auth-mongo-depl -n "$OCI_K8S_NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.containers[0].image}')"
+  [[ "$desired_image" == "$MONGO_REVIEWED_TARGET_IMAGE" ]] ||
+    migration_die "OCI Mongo desired image drifted from the reviewed release"
+  pod_json="$(kube_capture oci target-mongo-identity 30 2 \
+    get pod "$target_mongo_pod" -n "$OCI_K8S_NAMESPACE" -o json)"
+  migration_raw target-mongo-identity 30 1 jq -e '
+    ([.status.conditions[] | select(
+      .type == "Ready" and .status == "True"
+    )] | length) == 1
+  ' <<<"$pod_json" >/dev/null ||
+    migration_die "OCI Mongo pod changed readiness during migration"
+  uid="$(migration_raw target-mongo-identity 30 1 jq -r \
+    '.metadata.uid // empty' <<<"$pod_json")"
+  image_id="$(migration_raw target-mongo-identity 30 1 jq -r \
+    '.status.containerStatuses[0].imageID // empty' <<<"$pod_json")"
+  container_id="$(migration_raw target-mongo-identity 30 1 jq -r \
+    '.status.containerStatuses[0].containerID // empty' <<<"$pod_json")"
+  restart_count="$(migration_raw target-mongo-identity 30 1 jq -r \
+    '.status.containerStatuses[0].restartCount // empty' <<<"$pod_json")"
+  target_mongo_image_is_reviewed "$image_id" ||
+    migration_die "OCI Mongo image drifted from the reviewed ARM64 release"
+  runtime="$(mongo_runtime oci "$target_mongo_pod")"
+  mongo_runtime_is_reviewed "$runtime" ||
+    migration_die "OCI Mongo runtime drifted from version 8.2.12 and FCV 8.2"
+  if [[ "$require_baseline" == "true" ]]; then
+    [[ "$uid" == "$target_mongo_uid" &&
+      "$image_id" == "$target_mongo_image_id" &&
+      "$container_id" == "$target_mongo_container_id" &&
+      "$restart_count" == "$target_mongo_restart_count" ]] ||
+      migration_die "OCI Mongo pod identity changed after preflight"
+    expected_runtime="$(migration_raw mongo-runtime 30 1 jq -c \
+      '{version,majorMinor,fcv}' <<<"$target_runtime_signature")"
+    actual_runtime="$(migration_raw mongo-runtime 30 1 jq -c \
+      '{version,majorMinor,fcv}' <<<"$runtime")"
+    [[ "$actual_runtime" == "$expected_runtime" ]] ||
+      migration_die "OCI Mongo runtime changed after preflight"
+  fi
+}
+
 verify_source_mongo_stays_ready() {
   local mapping _service _database sts _pod _pvc ready replicas
   for mapping in "${DATABASE_MAPPINGS[@]}"; do
@@ -1633,6 +2042,7 @@ verify_source_mongo_stays_ready() {
       -o jsonpath='{.status.readyReplicas}')"
     [[ "$replicas" == "1" && "$ready" == "1" ]] ||
       migration_die "Azure Mongo StatefulSet changed during freeze: $sts"
+    verify_source_mongo_identity "$_pod"
   done
 }
 
@@ -1697,7 +2107,9 @@ capture_transfers() {
     IFS='|' read -r _service database _sts pod _pvc <<<"$mapping"
     signature="$signature_dir/${database}.source.json"
     archive="$transport_dir/${database}.archive.gz.age"
+    verify_source_mongo_identity "$pod"
     mongo_signature_kube azure "$pod" "$database" "$signature"
+    verify_source_mongo_identity "$pod"
     migration_maybe_heartbeat 1
     kube_raw azure mongo-transport "$STREAM_TIMEOUT_SECONDS" 1 \
       exec -n "$AZURE_NAMESPACE" "$pod" -- \
@@ -1708,6 +2120,7 @@ capture_transfers() {
     local statuses=("${PIPESTATUS[@]}")
     [[ "${statuses[0]}" == "0" && "${statuses[1]}" == "0" && -s "$archive" ]] ||
       migration_die "encrypted compressed transport capture failed for $database"
+    verify_source_mongo_identity "$pod"
     migration_maybe_heartbeat 1
     cipher_hash="$(migration_sha256 <"$archive")"
     signature_hash="$(migration_sha256 <"$signature")"
@@ -1755,12 +2168,13 @@ validate_transfers_disposable() {
     docker exec "$disposable_container" mongosh --quiet --eval '
       const result=db.adminCommand({getParameter:1,featureCompatibilityVersion:1});
       print(JSON.stringify({
+        version:db.version(),
         majorMinor:db.version().split(".").slice(0,2).join("."),
         fcv:result.featureCompatibilityVersion.version
       }));
     ' | migration_raw disposable-runtime-json 30 1 jq -c .)"
   expected_runtime="$(migration_raw mongo-runtime 30 1 jq -c \
-    '{majorMinor,fcv}' <<<"$target_runtime_signature")"
+    '{version,majorMinor,fcv}' <<<"$target_runtime_signature")"
   [[ "$disposable_runtime" == "$expected_runtime" ]] ||
     migration_die "disposable Mongo version/FCV differs from OCI target"
   for mapping in "${DATABASE_MAPPINGS[@]}"; do
@@ -1837,6 +2251,7 @@ freeze_oci() {
 
 drop_target_databases() {
   local inventory mapping _service database _sts _pod _pvc result
+  verify_target_mongo_identity
   inventory="$(mongo_non_system_databases oci "$target_mongo_pod")"
   migration_raw target-inventory 30 1 jq -e \
     --argjson expected "$(expected_database_json)" '
@@ -1849,6 +2264,7 @@ drop_target_databases() {
   for mapping in "${DATABASE_MAPPINGS[@]}"; do
     IFS='|' read -r _service database _sts _pod _pvc <<<"$mapping"
     state_assert_fence
+    verify_target_mongo_identity
     migration_failure_hook "before-drop-$database"
     result="$(mongo_eval oci "$target_mongo_pod" \
       "print(JSON.stringify(db.getSiblingDB('${database}').dropDatabase()));")"
@@ -1859,6 +2275,7 @@ drop_target_databases() {
         .some(item=>item.name==='${database}'));
     ")" == "false" ]] ||
       migration_die "OCI database remains visible after drop: $database"
+    verify_target_mongo_identity
     state_advance "dropped-$database" true true
     migration_failure_hook "after-drop-$database"
   done
@@ -1870,6 +2287,7 @@ restore_target_databases() {
     IFS='|' read -r _service database _sts _pod _pvc <<<"$mapping"
     archive="$transport_dir/${database}.archive.gz.age"
     state_assert_fence
+    verify_target_mongo_identity
     migration_failure_hook "before-restore-$database"
     migration_maybe_heartbeat 1
     migration_raw transport-decryption "$STREAM_TIMEOUT_SECONDS" 1 \
@@ -1881,6 +2299,7 @@ restore_target_databases() {
     local statuses=("${PIPESTATUS[@]}")
     [[ "${statuses[0]}" == "0" && "${statuses[1]}" == "0" ]] ||
       migration_die "OCI restore failed for $database"
+    verify_target_mongo_identity
     state_advance "restored-$database" true true
     migration_failure_hook "after-restore-$database"
   done
@@ -1892,6 +2311,7 @@ verify_target_exact() {
   local signature_args=()
   local target_manifest="$WORK_DIR/target-signature-manifest.tsv"
   : >"$target_manifest"
+  verify_target_mongo_identity
   inventory="$(mongo_non_system_databases oci "$target_mongo_pod")"
   [[ "$inventory" == "$(expected_database_json)" ]] ||
     migration_die "OCI application database inventory is not the exact eight-name set"
@@ -1899,7 +2319,9 @@ verify_target_exact() {
     IFS='|' read -r _service database _sts _pod _pvc <<<"$mapping"
     expected="$signature_dir/${database}.source.json"
     actual="$signature_dir/${database}.target.json"
+    verify_target_mongo_identity
     mongo_signature_kube oci "$target_mongo_pod" "$database" "$actual"
+    verify_target_mongo_identity
     cmp -s "$expected" "$actual" ||
       migration_die "OCI DB/collection/document/index/validator/options equality failed: $database"
     signature_hash="$(migration_sha256 <"$actual")"
@@ -1911,6 +2333,7 @@ verify_target_exact() {
   [[ "$source_aggregate" =~ ^[0-9a-f]{64}$ &&
     "$target_aggregate" == "$source_aggregate" ]] ||
     migration_die "aggregate source/target signature parity failed"
+  verify_target_mongo_identity
   state_advance target-exactly-validated true true \
     "database-count=8" \
     "logical-parity=true" \
@@ -1936,6 +2359,7 @@ restore_oci_baseline() {
         -n "$OCI_K8S_NAMESPACE" --timeout=9m
     fi
   done
+  set_http_write_fence_config false
   ingress="$(baseline_value "$oci_baseline" ingress)"
   scale_deployment oci ingress-nginx ingress-nginx-controller "$ingress"
   if (( ingress > 0 )); then
@@ -1948,6 +2372,7 @@ restore_oci_baseline() {
 
 close_oci() {
   freeze_ingress oci
+  set_http_write_fence_config true
   freeze_applications oci
   scale_deployment oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl 0
   wait_deployment_zero oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl \
@@ -1958,6 +2383,7 @@ close_oci() {
 recreate_rabbitmq_and_restart() {
   local service replicas ingress rows count names expected backlog bad
   state_assert_fence
+  verify_target_mongo_identity
   scale_deployment oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl 0
   wait_deployment_zero oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl \
     app=gaming-rabbitmq
@@ -1973,6 +2399,7 @@ recreate_rabbitmq_and_restart() {
 
   for service in "${BACKEND_SERVICES[@]}" client; do
     state_assert_fence
+    verify_target_mongo_identity
     replicas="$(baseline_value "$oci_baseline" "$service")"
     [[ "$replicas" =~ ^[1-9][0-9]*$ ]] ||
       migration_die "OCI successful baseline requires active $service replicas"
@@ -1999,11 +2426,18 @@ recreate_rabbitmq_and_restart() {
   [[ "$ingress" =~ ^[1-9][0-9]*$ ]] ||
     migration_die "OCI ingress baseline must be active for validation"
   state_assert_fence
+  verify_target_mongo_identity
+  [[ "$(state_optional_value http-write-fence)" == "true" &&
+    "$(http_write_fence_config_status)" == "true" ]] ||
+    migration_die "HTTP mutation fence is absent before ingress activation"
   scale_deployment oci ingress-nginx ingress-nginx-controller "$ingress"
   kube_run oci ingress-rollout 600 1 \
     rollout status deployment/ingress-nginx-controller \
     -n ingress-nginx --timeout=9m
-  state_advance awaiting-protected-health true true
+  wait_http_write_fence_runtime true
+  migration_failure_hook http-write-fence-runtime
+  state_advance awaiting-protected-health true true \
+    "http-write-fence=true"
 }
 
 verify_final_exact_state() {
@@ -2013,6 +2447,7 @@ verify_final_exact_state() {
   target_mongo_pod="$(kube_capture oci target-pod 30 2 \
     get pods -n "$OCI_K8S_NAMESPACE" -l app=gaming-auth-mongo \
     -o jsonpath='{.items[0].metadata.name}')"
+  verify_target_mongo_identity
   inventory="$(mongo_non_system_databases oci "$target_mongo_pod")"
   [[ "$inventory" == "$(expected_database_json)" ]] ||
     migration_die "final OCI database inventory is not exact"
@@ -2048,12 +2483,18 @@ verify_final_exact_state() {
   [[ "$count" == "17" && "$names" == "$expected_names" &&
     "$backlog" == "0" && "$bad" == "0" ]] ||
     migration_die "final OCI RabbitMQ state differs"
+  verify_target_mongo_identity
 }
 
 ensure_azure_frozen() {
   freeze_ingress azure
   freeze_applications azure
   verify_source_mongo_stays_ready
+}
+
+freeze_azure_after_commit() {
+  freeze_ingress azure
+  freeze_applications azure
 }
 
 cleanup() {
@@ -2064,6 +2505,7 @@ cleanup() {
   set +e
   local cleanup_failed=0
   local current_phase=""
+  local live_http_fence=""
   if [[ -n "$disposable_container" ]]; then
     migration_raw disposable-delete 60 2 \
       docker rm -f "$disposable_container" >/dev/null 2>&1 ||
@@ -2079,17 +2521,22 @@ cleanup() {
     if [[ "$state_boundary" == "1" ]]; then
       case "$current_phase" in
         cutover-committed | cutover-forward-recovery)
-          ensure_azure_frozen || cleanup_failed=1
-          state_advance cutover-forward-recovery true false ||
+          freeze_azure_after_commit || cleanup_failed=1
+          if live_http_fence="$(http_write_fence_config_status)"; then
+            state_advance cutover-forward-recovery true false \
+              "http-write-fence=$live_http_fence" || cleanup_failed=1
+          else
             cleanup_failed=1
+          fi
           ;;
         completed)
-          ensure_azure_frozen || cleanup_failed=1
+          freeze_azure_after_commit || cleanup_failed=1
           ;;
         *)
           close_oci || cleanup_failed=1
           ensure_azure_frozen || cleanup_failed=1
-          state_advance recovery-required true true || cleanup_failed=1
+          state_advance recovery-required true true \
+            "http-write-fence=true" || cleanup_failed=1
           ;;
       esac
     else
@@ -2099,12 +2546,14 @@ cleanup() {
       fi
       ensure_azure_frozen || baseline_restore_failed=1
       if [[ "$baseline_restore_failed" == "0" ]]; then
-        state_advance failed-before-destructive-boundary false false ||
+        state_advance failed-before-destructive-boundary false false \
+          "http-write-fence=false" ||
           cleanup_failed=1
         state_release || cleanup_failed=1
       else
         close_oci || cleanup_failed=1
-        state_advance pre-destructive-recovery-required false true ||
+        state_advance pre-destructive-recovery-required false true \
+          "http-write-fence=true" ||
           cleanup_failed=1
         cleanup_failed=1
       fi
@@ -2189,6 +2638,7 @@ validate_inputs() {
   signature_dir="$WORK_DIR/signatures"
   state_dir="$WORK_DIR/state"
   identity_file="$WORK_DIR/age-identity.txt"
+  source_mongo_manifest="$state_dir/source-mongo-identities.json"
   mkdir -p "$transport_dir" "$signature_dir" "$state_dir" \
     "$(dirname "$JOURNAL_FILE")" "$(dirname "$SUMMARY_FILE")"
   chmod 700 "$WORK_DIR" "$transport_dir" "$signature_dir" "$state_dir"
@@ -2199,6 +2649,7 @@ validate_inputs() {
 }
 
 main() {
+  local finalize_phase=""
   validate_inputs
   trap 'cleanup $?' EXIT
   trap 'cleanup 130' INT
@@ -2216,7 +2667,15 @@ main() {
       oci_baseline="$(baseline_capture oci)"
       state_acquire
       state_advance azure-inspected \
-        "$(state_boundary_text)" "$(state_recovery_text)"
+        "$(state_boundary_text)" "$(state_recovery_text)" \
+        "target-mongo-pod-uid=$target_mongo_uid" \
+        "target-mongo-image-id=$target_mongo_image_id" \
+        "target-mongo-container-id=$target_mongo_container_id" \
+        "target-mongo-restart-count=$target_mongo_restart_count" \
+        "target-mongo-runtime=$target_runtime_signature" \
+        "source-mongo-manifest-sha256=$(migration_sha256 <"$source_mongo_manifest")" \
+        "source-mongo-identities=$(migration_raw source-manifest 30 1 \
+          jq -c . "$source_mongo_manifest")"
       freeze_azure
       state_advance azure-writers-frozen \
         "$(state_boundary_text)" "$(state_recovery_text)"
@@ -2224,10 +2683,13 @@ main() {
       capture_transfers
       validate_transfers_disposable
       freeze_oci
+      install_http_write_fence
       unlock_target_writes_for_retry
+      verify_source_mongo_stays_ready
       drop_target_databases
       restore_target_databases
       verify_target_exact
+      verify_target_mongo_identity
       lock_target_writes
       recreate_rabbitmq_and_restart
       state_write_summary
@@ -2239,28 +2701,51 @@ main() {
       ;;
     finalize-success)
       state_load_owned
-      ensure_azure_frozen
+      finalize_phase="$(state_value phase)"
       target_mongo_pod="$(kube_capture oci target-pod 30 2 \
         get pods -n "$OCI_K8S_NAMESPACE" -l app=gaming-auth-mongo \
         -o jsonpath='{.items[0].metadata.name}')"
       [[ -n "$target_mongo_pod" ]] ||
         migration_die "OCI Mongo pod is missing for cutover finalization"
-      case "$(state_value phase)" in
+      case "$finalize_phase" in
         awaiting-protected-health)
-          [[ "$(state_optional_value mongo-write-lock)" == "true" &&
-            "$(target_write_lock_status)" == "true" &&
-            "$(state_optional_value rabbitmq-write-lock)" == "true" &&
-            "$(rabbitmq_write_permission)" == "^$" ]] ||
-            migration_die "OCI data or messaging writes were enabled before parity certification"
+          restore_source_mongo_manifest_from_state true
+          ensure_azure_frozen
+          target_mongo_uid="$(state_value target-mongo-pod-uid)"
+          target_mongo_image_id="$(state_value target-mongo-image-id)"
+          target_mongo_container_id="$(state_value target-mongo-container-id)"
+          target_mongo_restart_count="$(state_value target-mongo-restart-count)"
+          target_runtime_signature="$(state_value target-mongo-runtime)"
+          [[ "$target_mongo_uid" =~ ^[a-z0-9-]+$ ]] ||
+            migration_die "persisted OCI Mongo pod UID is invalid"
+          target_mongo_image_is_reviewed "$target_mongo_image_id" ||
+            migration_die "persisted OCI Mongo image identity is invalid"
+          [[ "$target_mongo_container_id" =~ ^[a-z0-9+.-]+://[a-zA-Z0-9._:-]+$ &&
+            "$target_mongo_restart_count" =~ ^[0-9]+$ ]] ||
+            migration_die "persisted OCI Mongo container identity is invalid"
+          mongo_runtime_is_reviewed "$target_runtime_signature" ||
+            migration_die "persisted OCI Mongo runtime identity is invalid"
+          verify_target_mongo_identity true
+          verify_cutover_write_locks
           verify_final_exact_state
+          verify_target_mongo_identity true
+          verify_cutover_write_locks
           state_advance cutover-committed true false \
-            "mongo-write-lock=true" "rabbitmq-write-lock=true"
+            "mongo-write-lock=true" "rabbitmq-write-lock=true" \
+            "http-write-fence=true"
           ;;
         cutover-committed | cutover-forward-recovery)
+          freeze_azure_after_commit
+          verify_target_mongo_identity false
           ;;
         completed)
+          freeze_azure_after_commit
+          verify_target_mongo_identity false
           [[ "$(target_write_lock_status)" == "false" &&
-            "$(rabbitmq_write_permission)" == ".*" ]] ||
+            "$(rabbitmq_write_permission)" == ".*" &&
+            "$(state_optional_value http-write-fence)" == "false" &&
+            "$(http_write_fence_config_status)" == "false" &&
+            "$(http_write_fence_runtime_status)" == "false" ]] ||
             migration_die "completed cutover retained a write lock"
           if [[ "$(state_lock_value state)" == "active" ]]; then
             state_release
@@ -2284,8 +2769,11 @@ main() {
       migration_failure_hook mongo-write-unlocked
       unlock_rabbitmq_writes
       migration_failure_hook rabbitmq-write-unlocked
+      remove_http_write_fence
+      migration_failure_hook http-write-fence-removed
       state_advance completed true false \
-        "mongo-write-lock=false" "rabbitmq-write-lock=false"
+        "mongo-write-lock=false" "rabbitmq-write-lock=false" \
+        "http-write-fence=false"
       state_release
       state_write_summary
       rm -rf "$WORK_DIR"
@@ -2296,25 +2784,29 @@ main() {
       ;;
     fail-closed)
       state_load_owned
+      restore_source_mongo_manifest_from_state false
       if [[ "$state_boundary" == "1" ]]; then
         case "$(state_value phase)" in
           cutover-committed | cutover-forward-recovery)
-            ensure_azure_frozen
-            state_advance cutover-forward-recovery true false
+            freeze_azure_after_commit
+            state_advance cutover-forward-recovery true false \
+              "http-write-fence=$(http_write_fence_config_status)"
             ;;
           completed)
-            ensure_azure_frozen
+            freeze_azure_after_commit
             ;;
           *)
             close_oci
             ensure_azure_frozen
-            state_advance recovery-required true true
+            state_advance recovery-required true true \
+              "http-write-fence=true"
             ;;
         esac
       else
         restore_oci_baseline
         ensure_azure_frozen
-        state_advance failed-before-destructive-boundary false false
+        state_advance failed-before-destructive-boundary false false \
+          "http-write-fence=false"
         if [[ "$(state_lock_value state)" == "active" ]]; then
           state_release
         fi

--- a/infra/oci/scripts/migration-state.py
+++ b/infra/oci/scripts/migration-state.py
@@ -249,6 +249,7 @@ def main() -> int:
         "transfer-manifest-sha256",
         "mongo-write-lock",
         "rabbitmq-write-lock",
+        "http-write-fence",
     )
     for key in allowed:
         if key in data:

--- a/infra/oci/scripts/upgrade-mongo.sh
+++ b/infra/oci/scripts/upgrade-mongo.sh
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+MODE="${1:-}"
+OCI_K8S_NAMESPACE="${OCI_K8S_NAMESPACE:-betstan-oci}"
+MONGO_TARGET_IMAGE="${MONGO_TARGET_IMAGE:-}"
+MONGO_UPGRADE_STATE_FILE="${MONGO_UPGRADE_STATE_FILE:-}"
+MONGO_UPGRADE_WAIT_ATTEMPTS="${MONGO_UPGRADE_WAIT_ATTEMPTS:-60}"
+MONGO_UPGRADE_SLEEP_SECONDS="${MONGO_UPGRADE_SLEEP_SECONDS:-5}"
+
+MONGO_STATEFULSET=gaming-auth-mongo-depl
+MONGO_CONTAINER=gaming-auth-mongo
+MONGO_SOURCE_VERSION=7.0.21
+MONGO_SOURCE_IMAGE="docker.io/library/mongo@sha256:3d715950d83061ff2fbc910d12d3703212538cacf6b3003e3736fa5c7f51a2e1"
+MONGO_TRANSITION_VERSION=8.0.29
+MONGO_TRANSITION_IMAGE="docker.io/library/mongo@sha256:de267922bc1153d923f5c9dc429f21c11faf18299080c1ce04d6d6007097fb06"
+MONGO_TARGET_VERSION=8.2.12
+MONGO_REVIEWED_TARGET_IMAGE="docker.io/library/mongo@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3"
+MONGO_TARGET_ARM64_MANIFEST=sha256:21ca0269db1ebbd1c59f5cbc04928d7e3f6ab6186d7ceafc8fa489c0486525b4
+MONGO_INSPECTOR_POD=betstan-mongo-storage-inspector
+
+APP_SERVICES=(
+  auth bet backoffice event gamemaster moderation resulting slip client
+)
+inspector_pod=""
+
+oci_require_command kubectl
+oci_require_command jq
+[[ "$MODE" == "prepare" || "$MODE" == "finalize" || "$MODE" == "resume" ]] ||
+  oci_die "Mongo upgrade mode must be prepare, finalize, or resume"
+[[ "$MONGO_TARGET_IMAGE" == "$MONGO_REVIEWED_TARGET_IMAGE" ]] ||
+  oci_die "Mongo target image differs from the reviewed 8.2.12 image"
+[[ -n "$MONGO_UPGRADE_STATE_FILE" ]] ||
+  oci_die "MONGO_UPGRADE_STATE_FILE is required"
+[[ "$MONGO_UPGRADE_WAIT_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] ||
+  oci_die "MONGO_UPGRADE_WAIT_ATTEMPTS must be a positive integer"
+[[ "$MONGO_UPGRADE_SLEEP_SECONDS" =~ ^[0-9]+$ ]] ||
+  oci_die "MONGO_UPGRADE_SLEEP_SECONDS must be a non-negative integer"
+
+cleanup() {
+  local rc="$1"
+  trap - EXIT INT TERM
+  if [[ -n "$inspector_pod" ]]; then
+    kubectl delete pod "$inspector_pod" -n "$OCI_K8S_NAMESPACE" \
+      --ignore-not-found --wait=true >/dev/null 2>&1 || true
+  fi
+  exit "$rc"
+}
+trap 'cleanup "$?"' EXIT
+trap 'cleanup 130' INT
+trap 'cleanup 143' TERM
+
+write_upgrade_state() {
+  local maintenance="$1"
+  mkdir -p "$(dirname "$MONGO_UPGRADE_STATE_FILE")"
+  umask 077
+  printf 'maintenance=%q\n' "$maintenance" > "$MONGO_UPGRADE_STATE_FILE"
+}
+
+read_upgrade_state() {
+  local maintenance=""
+  [[ -f "$MONGO_UPGRADE_STATE_FILE" ]] ||
+    oci_die "Mongo upgrade state file is missing"
+  # shellcheck disable=SC1090
+  source "$MONGO_UPGRADE_STATE_FILE"
+  [[ "$maintenance" == "true" || "$maintenance" == "false" ]] ||
+    oci_die "Mongo upgrade state is invalid"
+  printf '%s' "$maintenance"
+}
+
+mongo_pod() {
+  local pod
+  pod="$(
+    kubectl get pods -n "$OCI_K8S_NAMESPACE" -l app=gaming-auth-mongo \
+      -o jsonpath='{.items[0].metadata.name}'
+  )"
+  [[ -n "$pod" ]] || oci_die "Mongo pod is missing during version alignment"
+  printf '%s' "$pod"
+}
+
+mongo_runtime() {
+  local pod runtime
+  pod="$(mongo_pod)"
+  runtime="$(
+    kubectl exec -n "$OCI_K8S_NAMESPACE" "$pod" -- \
+      mongosh --quiet --eval '
+        const result=db.adminCommand({getParameter:1,featureCompatibilityVersion:1});
+        if (result.ok !== 1) throw new Error("FCV read failed");
+        print(JSON.stringify({
+          version:db.version(),
+          majorMinor:db.version().split(".").slice(0,2).join("."),
+          fcv:result.featureCompatibilityVersion.version
+        }));
+      '
+  )"
+  jq -e '
+    type == "object" and
+    (.version | type == "string") and
+    (.majorMinor | type == "string") and
+    (.fcv | type == "string")
+  ' <<<"$runtime" >/dev/null ||
+    oci_die "Mongo runtime version or FCV is unreadable"
+  printf '%s' "$runtime"
+}
+
+runtime_signature() {
+  jq -r '.majorMinor + "|" + .fcv' <<<"$1"
+}
+
+wait_for_mongo() {
+  local pod
+  kubectl rollout status "statefulset/$MONGO_STATEFULSET" \
+    -n "$OCI_K8S_NAMESPACE" --timeout=10m >/dev/null
+  pod="$(mongo_pod)"
+  for _ in $(seq 1 "$MONGO_UPGRADE_WAIT_ATTEMPTS"); do
+    if kubectl exec -n "$OCI_K8S_NAMESPACE" "$pod" -- \
+        mongosh --quiet --eval 'db.adminCommand({ping:1}).ok' 2>/dev/null |
+        grep -qx 1; then
+      return 0
+    fi
+    sleep "$MONGO_UPGRADE_SLEEP_SECONDS"
+  done
+  oci_die "Mongo did not become ready during staged version alignment"
+}
+
+deployment_replicas() {
+  local namespace="$1"
+  local deployment="$2"
+  kubectl get deployment "$deployment" -n "$namespace" -o json |
+    jq -r '[.spec.replicas // 0, .status.readyReplicas // 0] | @tsv'
+}
+
+pod_count() {
+  local namespace="$1"
+  local selector="$2"
+  kubectl get pods -n "$namespace" -l "$selector" -o json |
+    jq -r '.items | length'
+}
+
+workloads_are_active() {
+  local service replicas
+  replicas="$(deployment_replicas ingress-nginx ingress-nginx-controller)" ||
+    return 1
+  [[ "$replicas" == $'1\t1' ]] || return 1
+  for service in "${APP_SERVICES[@]}"; do
+    replicas="$(deployment_replicas "$OCI_K8S_NAMESPACE" "gaming-${service}-depl")" ||
+      return 1
+    [[ "$replicas" == $'1\t1' ]] || return 1
+  done
+}
+
+freeze_writers() {
+  local service identity replicas count all_zero
+  kubectl scale deployment ingress-nginx-controller -n ingress-nginx \
+    --replicas=0 >/dev/null
+  for service in "${APP_SERVICES[@]}"; do
+    identity="$(
+      kubectl get deployment "gaming-${service}-depl" \
+        -n "$OCI_K8S_NAMESPACE" --ignore-not-found -o name
+    )" || oci_die "unable to inspect OCI writer deployment: $service"
+    if [[ -n "$identity" ]]; then
+      kubectl scale deployment "gaming-${service}-depl" \
+        -n "$OCI_K8S_NAMESPACE" --replicas=0 >/dev/null
+    fi
+  done
+
+  for _ in $(seq 1 "$MONGO_UPGRADE_WAIT_ATTEMPTS"); do
+    all_zero=true
+    replicas="$(deployment_replicas ingress-nginx ingress-nginx-controller)" ||
+      oci_die "unable to verify frozen OCI ingress deployment"
+    [[ "$replicas" == $'0\t0' ]] || all_zero=false
+    count="$(pod_count ingress-nginx 'app.kubernetes.io/component=controller')" ||
+      oci_die "unable to verify frozen OCI ingress pods"
+    [[ "$count" == "0" ]] || all_zero=false
+    for service in "${APP_SERVICES[@]}"; do
+      identity="$(
+        kubectl get deployment "gaming-${service}-depl" \
+          -n "$OCI_K8S_NAMESPACE" --ignore-not-found -o name
+      )" || oci_die "unable to verify frozen OCI writer deployment: $service"
+      if [[ -n "$identity" ]]; then
+        replicas="$(
+          deployment_replicas "$OCI_K8S_NAMESPACE" "gaming-${service}-depl"
+        )" || oci_die "unable to read frozen OCI writer replicas: $service"
+        [[ "$replicas" == $'0\t0' ]] || all_zero=false
+      fi
+      count="$(pod_count "$OCI_K8S_NAMESPACE" "app=gaming-${service}")" ||
+        oci_die "unable to verify frozen OCI writer pods: $service"
+      [[ "$count" == "0" ]] || all_zero=false
+    done
+    [[ "$all_zero" == "true" ]] && return 0
+    sleep "$MONGO_UPGRADE_SLEEP_SECONDS"
+  done
+  oci_die "OCI writers did not stop before Mongo version alignment"
+}
+
+verify_fresh_storage_is_empty() {
+  local pvc_identity pvc_phase empty=false
+  pvc_identity="$(
+    kubectl get pvc gaming-auth-mongo-data -n "$OCI_K8S_NAMESPACE" \
+      --ignore-not-found -o name
+  )" || oci_die "unable to inspect Mongo PVC before fresh installation"
+  [[ "$pvc_identity" == "persistentvolumeclaim/gaming-auth-mongo-data" ]] ||
+    oci_die "Mongo StatefulSet is absent and its exact PVC is unavailable"
+  pvc_phase="$(
+    kubectl get pvc gaming-auth-mongo-data -n "$OCI_K8S_NAMESPACE" \
+      -o jsonpath='{.status.phase}'
+  )" || oci_die "unable to read Mongo PVC phase before fresh installation"
+  [[ "$pvc_phase" == "Bound" ]] ||
+    oci_die "Mongo StatefulSet is absent and its PVC is not Bound"
+
+  kubectl delete pod "$MONGO_INSPECTOR_POD" -n "$OCI_K8S_NAMESPACE" \
+    --ignore-not-found --wait=true >/dev/null
+  inspector_pod="$MONGO_INSPECTOR_POD"
+  kubectl apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${MONGO_INSPECTOR_POD}
+  namespace: ${OCI_K8S_NAMESPACE}
+spec:
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  containers:
+    - name: storage-inspector
+      image: ${MONGO_SOURCE_IMAGE}
+      command: ["/bin/sh", "-c", "sleep 600"]
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      volumeMounts:
+        - name: mongo-data
+          mountPath: /data/db
+          readOnly: true
+  volumes:
+    - name: mongo-data
+      persistentVolumeClaim:
+        claimName: gaming-auth-mongo-data
+        readOnly: true
+YAML
+  kubectl wait pod "$MONGO_INSPECTOR_POD" -n "$OCI_K8S_NAMESPACE" \
+    --for=condition=Ready --timeout=2m >/dev/null
+  if kubectl exec -n "$OCI_K8S_NAMESPACE" "$MONGO_INSPECTOR_POD" -- \
+      /bin/sh -c \
+      'entries="$(find /data/db -mindepth 1 -maxdepth 1 ! -name lost+found -print -quit)" ||
+        exit 41
+       test -z "$entries"'; then
+    empty=true
+  fi
+  kubectl delete pod "$MONGO_INSPECTOR_POD" -n "$OCI_K8S_NAMESPACE" \
+    --wait=true >/dev/null
+  inspector_pod=""
+  [[ "$empty" == "true" ]] ||
+    oci_die "Mongo StatefulSet is absent but retained storage is not empty"
+}
+
+set_fcv() {
+  local requested="$1"
+  local pod result
+  [[ "$requested" == "8.0" || "$requested" == "8.2" ]] ||
+    oci_die "unsupported Mongo FCV transition"
+  pod="$(mongo_pod)"
+  result="$(
+    kubectl exec -n "$OCI_K8S_NAMESPACE" "$pod" -- \
+      mongosh --quiet --eval "
+        const result=db.adminCommand({
+          setFeatureCompatibilityVersion:'${requested}',
+          confirm:true
+        });
+        print(JSON.stringify(result));
+      "
+  )"
+  jq -e '.ok == 1' <<<"$result" >/dev/null ||
+    oci_die "Mongo rejected FCV ${requested}"
+}
+
+validate_runtime_for_image() {
+  local image="$1"
+  local runtime="$2"
+  local version signature
+  version="$(jq -r '.version' <<<"$runtime")"
+  signature="$(runtime_signature "$runtime")"
+  case "$image" in
+    "$MONGO_SOURCE_IMAGE")
+      [[ "$version" == "$MONGO_SOURCE_VERSION" && "$signature" == "7.0|7.0" ]] ||
+        oci_die "reviewed Mongo 7.0 source image has an unexpected runtime or FCV"
+      ;;
+    "$MONGO_TRANSITION_IMAGE")
+      [[ "$version" == "$MONGO_TRANSITION_VERSION" &&
+        ( "$signature" == "8.0|7.0" || "$signature" == "8.0|8.0" ) ]] ||
+        oci_die "reviewed Mongo 8.0 transition image has an unexpected runtime or FCV"
+      ;;
+    "$MONGO_REVIEWED_TARGET_IMAGE")
+      [[ "$version" == "$MONGO_TARGET_VERSION" &&
+        ( "$signature" == "8.2|8.0" || "$signature" == "8.2|8.2" ) ]] ||
+        oci_die "reviewed Mongo 8.2 target image has an unexpected runtime or FCV"
+      ;;
+    *)
+      oci_die "live Mongo image is outside the reviewed staged upgrade path"
+      ;;
+  esac
+}
+
+prepare_upgrade() {
+  local statefulset_identity current_image runtime signature
+  statefulset_identity="$(
+    kubectl get statefulset "$MONGO_STATEFULSET" -n "$OCI_K8S_NAMESPACE" \
+      --ignore-not-found -o name
+  )" || oci_die "unable to inspect the live Mongo StatefulSet"
+  if [[ -z "$statefulset_identity" ]]; then
+    verify_fresh_storage_is_empty
+    write_upgrade_state true
+    freeze_writers
+    oci_log "oci_mongo_upgrade_prepare=PASS state=fresh-install-frozen"
+    return
+  fi
+  [[ "$statefulset_identity" == "statefulset.apps/$MONGO_STATEFULSET" ]] ||
+    oci_die "live Mongo StatefulSet identity is unexpected"
+
+  current_image="$(
+    kubectl get statefulset "$MONGO_STATEFULSET" -n "$OCI_K8S_NAMESPACE" \
+      -o jsonpath='{.spec.template.spec.containers[0].image}'
+  )"
+  case "$current_image" in
+    "$MONGO_SOURCE_IMAGE"|"$MONGO_TRANSITION_IMAGE"|"$MONGO_REVIEWED_TARGET_IMAGE") ;;
+    *) oci_die "live Mongo image is outside the reviewed staged upgrade path" ;;
+  esac
+  wait_for_mongo
+  runtime="$(mongo_runtime)"
+  validate_runtime_for_image "$current_image" "$runtime"
+  signature="$(runtime_signature "$runtime")"
+
+  if [[ "$current_image" == "$MONGO_REVIEWED_TARGET_IMAGE" &&
+        "$signature" == "8.2|8.2" ]] && workloads_are_active; then
+    write_upgrade_state false
+    oci_log "oci_mongo_upgrade_prepare=PASS state=already-aligned"
+    return
+  fi
+
+  write_upgrade_state true
+  freeze_writers
+
+  if [[ "$current_image" == "$MONGO_SOURCE_IMAGE" ]]; then
+    kubectl set image "statefulset/$MONGO_STATEFULSET" \
+      "$MONGO_CONTAINER=$MONGO_TRANSITION_IMAGE" \
+      -n "$OCI_K8S_NAMESPACE" >/dev/null
+    wait_for_mongo
+    runtime="$(mongo_runtime)"
+    [[ "$(jq -r '.version' <<<"$runtime")" == "$MONGO_TRANSITION_VERSION" &&
+      "$(runtime_signature "$runtime")" == "8.0|7.0" ]] ||
+      oci_die "Mongo did not enter the reviewed 8.0 binary transition state"
+    set_fcv 8.0
+    runtime="$(mongo_runtime)"
+    [[ "$(runtime_signature "$runtime")" == "8.0|8.0" ]] ||
+      oci_die "Mongo FCV did not reach 8.0 before the 8.2 rollout"
+  elif [[ "$current_image" == "$MONGO_TRANSITION_IMAGE" &&
+          "$signature" == "8.0|7.0" ]]; then
+    set_fcv 8.0
+    runtime="$(mongo_runtime)"
+    [[ "$(runtime_signature "$runtime")" == "8.0|8.0" ]] ||
+      oci_die "Mongo FCV did not reach 8.0 before the 8.2 rollout"
+  fi
+
+  oci_log "oci_mongo_upgrade_prepare=PASS state=ready-for-8.2"
+}
+
+finalize_upgrade() {
+  local current_image runtime signature image_id target_digest
+  current_image="$(
+    kubectl get statefulset "$MONGO_STATEFULSET" -n "$OCI_K8S_NAMESPACE" \
+      -o jsonpath='{.spec.template.spec.containers[0].image}'
+  )"
+  [[ "$current_image" == "$MONGO_REVIEWED_TARGET_IMAGE" ]] ||
+    oci_die "Mongo StatefulSet did not apply the reviewed 8.2.12 image"
+  wait_for_mongo
+  runtime="$(mongo_runtime)"
+  validate_runtime_for_image "$current_image" "$runtime"
+  signature="$(runtime_signature "$runtime")"
+  if [[ "$signature" == "8.2|8.0" ]]; then
+    set_fcv 8.2
+    runtime="$(mongo_runtime)"
+  fi
+  [[ "$(jq -r '.version' <<<"$runtime")" == "$MONGO_TARGET_VERSION" &&
+    "$(runtime_signature "$runtime")" == "8.2|8.2" ]] ||
+    oci_die "Mongo runtime did not converge to exact version 8.2.12 and FCV 8.2"
+
+  image_id="$(
+    kubectl get pod "$(mongo_pod)" -n "$OCI_K8S_NAMESPACE" \
+      -o jsonpath='{.status.containerStatuses[0].imageID}'
+  )"
+  target_digest="${MONGO_REVIEWED_TARGET_IMAGE##*@}"
+  [[ "$image_id" == *"@$target_digest" ||
+    "$image_id" == *"@$MONGO_TARGET_ARM64_MANIFEST" ]] ||
+    oci_die "running Mongo image digest differs from the reviewed 8.2.12 index"
+  oci_log "oci_mongo_upgrade_finalize=PASS version=8.2.12 fcv=8.2"
+}
+
+resume_ingress() {
+  local maintenance
+  maintenance="$(read_upgrade_state)"
+  if [[ "$maintenance" == "true" ]]; then
+    kubectl scale deployment ingress-nginx-controller -n ingress-nginx \
+      --replicas=1 >/dev/null
+    kubectl rollout status deployment/ingress-nginx-controller \
+      -n ingress-nginx --timeout=10m >/dev/null
+  fi
+  oci_log "oci_mongo_upgrade_resume=PASS"
+}
+
+case "$MODE" in
+  prepare) prepare_upgrade ;;
+  finalize) finalize_upgrade ;;
+  resume) resume_ingress ;;
+esac

--- a/infra/oci/scripts/verify-images.sh
+++ b/infra/oci/scripts/verify-images.sh
@@ -112,7 +112,7 @@ if [[ "$BOOT_IMAGES" == "1" ]]; then
   docker network create "$network" >/dev/null
   docker run -d --name "$mongo" --network "$network" \
     --network-alias mongo \
-    docker.io/library/mongo@sha256:3d715950d83061ff2fbc910d12d3703212538cacf6b3003e3736fa5c7f51a2e1 >/dev/null
+    docker.io/library/mongo@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3 >/dev/null
   docker run -d --name "$rabbit" --network "$network" \
     --network-alias rabbitmq \
     docker.io/library/rabbitmq@sha256:6033d0c2f4e9eb49dda9623067a96d317bc7b550513bd18532fbd3cd9a941c1b >/dev/null
@@ -133,6 +133,14 @@ if [[ "$BOOT_IMAGES" == "1" ]]; then
     oci_die "Mongo verification dependency did not become ready"
   [[ "$rabbit_ready" == "1" ]] ||
     oci_die "RabbitMQ verification dependency did not become ready"
+  mongo_runtime="$(
+    docker exec "$mongo" mongosh --quiet --eval '
+      const result=db.adminCommand({getParameter:1,featureCompatibilityVersion:1});
+      print(db.version()+"|"+result.featureCompatibilityVersion.version);
+    '
+  )"
+  [[ "$mongo_runtime" == "8.2.12|8.2" ]] ||
+    oci_die "Mongo verification dependency differs from exact version 8.2.12 and FCV 8.2"
 
   while IFS=$'\t' read -r service _repository image_ref _digest _platform_digest; do
     container="betstan-oci-${service}-${work_id}"

--- a/infra/oci/tests/fixtures/health/healthy.json
+++ b/infra/oci/tests/fixtures/health/healthy.json
@@ -87,6 +87,9 @@
     "pvc_count": 1,
     "pvc_bound": true,
     "pvc_gib": 50,
+    "version": "8.2.12",
+    "major_minor": "8.2",
+    "fcv": "8.2",
     "logical_databases": [
       "gaming_auth",
       "gaming_bet",

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -41,6 +41,8 @@ for lesson in \
     "OCI deletion and registry layer reclamation are asynchronous" \
     "target-loopback tunnel" \
     "No retained backup or old-OCI rollback exists" \
+    "Mongo \`fsyncLock\` is process-local" \
+    "Pre-commit public checks must be read-only" \
     "Never return a blind \`NO_GO\`"; do
     grep -Fq "$lesson" "$lessons" ||
       fail "OCI lessons omit required recovery guidance: $lesson"
@@ -60,6 +62,9 @@ grep -Fq "A run waiting for environment approval is active, not hung" \
 grep -Fq "After \`cutover-committed\`, never retry from Azure" \
     "$ROOT_DIR/.github/agents/betstan-migration-recovery.agent.md" ||
     fail "migration recovery agent can roll back a committed cutover"
+grep -Fq "controller-level HTTP mutation fence" \
+    "$ROOT_DIR/.github/agents/betstan-migration-recovery.agent.md" ||
+    fail "migration recovery agent does not preserve the restart-safe HTTP fence"
 grep -Fq "https://betstan.xyz" \
     "$ROOT_DIR/.github/agents/betstan-domain-ingress.agent.md" ||
     fail "domain ingress agent lacks the canonical host"
@@ -74,6 +79,7 @@ for retirement_contract in \
     'terminal_phase DEPLOYED_HEALTHY' \
     'destructive_boundary_crossed true' \
     'logical_source_target_parity true' \
+    'http_mutation_fence_removed true' \
     'azure_cluster_stopped_deallocated true' \
     'validate_initial_inventory "$INITIAL_INVENTORY_FILE"' \
     'az aks delete' \
@@ -303,6 +309,9 @@ grep -Fq 'certificate was not issued by Let' \
 grep -Fq 'certificate expires within seven days' \
   "$OCI_DIR/agents/smoke-liveness-stan.sh" ||
   fail "OCI public smoke does not verify served certificate expiry"
+grep -Fq 'mutating request bypassed the HTTP maintenance fence' \
+  "$OCI_DIR/agents/smoke-liveness-stan.sh" ||
+  fail "OCI public smoke cannot prove the cutover HTTP mutation fence"
 
 OCI_RUNTIME_MODE=k3s \
 OCI_K3S_NODE_NAME=betstan-k3s \
@@ -379,10 +388,53 @@ for ingress_values in \
   grep -Fq 'return 308 https://betstan.xyz$request_uri;' "$ingress_values" ||
     fail "ingress-nginx does not preserve the www request URI in its HTTPS redirect"
 done
-grep -Fq '"gaming-auth-mongo": "sha256:3d715950d83061ff2fbc910d12d3703212538cacf6b3003e3736fa5c7f51a2e1"' \
+mongo_target_digest=sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3
+for mongo_target_file in \
+  "$OCI_DIR/k8s/base/kustomization.yaml" \
+  "$OCI_DIR/scripts/verify-images.sh" \
+  "$OCI_DIR/agents/health-check-stan.sh"; do
+  grep -Fq "$mongo_target_digest" "$mongo_target_file" ||
+    fail "Mongo target identity differs from the requested immutable index: $mongo_target_file"
+done
+mongo_upgrade="$OCI_DIR/scripts/upgrade-mongo.sh"
+grep -Fq 'MONGO_TRANSITION_VERSION=8.0.29' "$mongo_upgrade" ||
+  fail "Mongo upgrade omits the reviewed 8.0 transition release"
+grep -Fq 'MONGO_TARGET_VERSION=8.2.12' "$mongo_upgrade" ||
+  fail "Mongo upgrade omits the exact Azure-compatible target release"
+grep -Fq 'MONGO_TARGET_ARM64_MANIFEST=sha256:21ca0269db1ebbd1c59f5cbc04928d7e3f6ab6186d7ceafc8fa489c0486525b4' \
+  "$mongo_upgrade" ||
+  fail "Mongo upgrade omits the exact ARM64 target manifest"
+grep -Fq 'sha256:21ca0269db1ebbd1c59f5cbc04928d7e3f6ab6186d7ceafc8fa489c0486525b4' \
   "$OCI_DIR/agents/health-check-stan.sh" ||
-  fail "Mongo health identity differs from the requested immutable index"
-grep -Fq '"gaming-rabbitmq": "sha256:6033d0c2f4e9eb49dda9623067a96d317bc7b550513bd18532fbd3cd9a941c1b"' \
+  fail "Mongo health omits the exact ARM64 target manifest"
+grep -Fq "setFeatureCompatibilityVersion:'\${requested}'" "$mongo_upgrade" ||
+  fail "Mongo upgrade does not advance FCV explicitly"
+grep -Fq '"$SCRIPT_DIR/upgrade-mongo.sh" prepare' "$OCI_DIR/scripts/deploy.sh" ||
+  fail "OCI deployment does not prepare the staged Mongo upgrade"
+grep -Fq '"$SCRIPT_DIR/upgrade-mongo.sh" finalize' "$OCI_DIR/scripts/deploy.sh" ||
+  fail "OCI deployment does not finalize the staged Mongo upgrade"
+grep -Fq '"$SCRIPT_DIR/upgrade-mongo.sh" resume' "$OCI_DIR/scripts/deploy.sh" ||
+  fail "OCI deployment does not reopen ingress after staged Mongo maintenance"
+grep -Fq 'readOnly: true' "$mongo_upgrade" ||
+  fail "Mongo fresh-storage inspection is not read-only"
+grep -Fq "trap 'cleanup 143' TERM" "$mongo_upgrade" ||
+  fail "Mongo upgrade can report a terminated command as successful"
+grep -Fq 'exit 41' "$mongo_upgrade" ||
+  fail "Mongo fresh-storage inspection does not fail closed on enumeration errors"
+python3 - "$OCI_DIR/scripts/deploy.sh" <<'PY'
+import sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+prepare = text.index('"$SCRIPT_DIR/upgrade-mongo.sh" prepare')
+apply_target = text.index("apply_documents 'StatefulSet:^gaming-auth-mongo-depl$'", prepare)
+finalize = text.index('"$SCRIPT_DIR/upgrade-mongo.sh" finalize', apply_target)
+provenance = text.index('} > "$OUTPUT_DIR/provenance.txt"', finalize)
+resume = text.index('"$SCRIPT_DIR/upgrade-mongo.sh" resume', provenance)
+completed = text.index('oci_log "oci_deploy=PASS', resume)
+if not prepare < apply_target < finalize < provenance < resume < completed:
+    raise SystemExit("Mongo maintenance/deploy ordering differs")
+PY
+grep -Fq 'sha256:6033d0c2f4e9eb49dda9623067a96d317bc7b550513bd18532fbd3cd9a941c1b' \
   "$OCI_DIR/agents/health-check-stan.sh" ||
   fail "RabbitMQ health identity differs from the requested immutable index"
 grep -Fq 'shape-flex-min: "10"' "$OCI_DIR/helm/ingress-nginx-values.yaml"
@@ -529,10 +581,8 @@ for workflow in "$deploy_workflow" "$migrate_workflow"; do
   public_job_line="$(grep -n -m1 '^  public-validate:' "$workflow" | cut -d: -f1)"
   next_job_line="$(awk -v start="$public_job_line" '
     NR > start && /^  [A-Za-z0-9_-]+:/ {print NR; exit}
-  ' "$workflow")"
+  ' "$workflow"  )"
   [[ -n "$next_job_line" ]] || next_job_line=$(( $(wc -l <"$workflow") + 1 ))
-  dependency_line="$(grep -n -m1 'name: Install browser validation dependencies' \
-    "$workflow" | cut -d: -f1)"
   public_secrets="$(
     sed -n "${public_job_line},$((next_job_line - 1))p" "$workflow" |
       grep -c 'secrets\.' || true
@@ -543,12 +593,9 @@ for workflow in "$deploy_workflow" "$migrate_workflow"; do
         'OCI_CLI_|OCI_CI_PRIVATE_KEY|AZURE_CONFIG|azure/login|aks-set-context|configure-kubectl-oke' ||
       true
   )"
-  [[ -n "$public_job_line" && -n "$dependency_line" &&
-      "$dependency_line" -gt "$public_job_line" &&
-      "$dependency_line" -lt "$next_job_line" &&
-      "$public_secrets" == "0" &&
+  [[ -n "$public_job_line" && "$public_secrets" == "0" &&
       "$public_cloud_credentials" == "0" ]] ||
-    fail "browser dependencies share a job with cloud credentials: $(basename "$workflow")"
+    fail "public validation shares a job with cloud credentials: $(basename "$workflow")"
   grep -Fq 'persist-credentials: false' "$workflow" ||
     fail "public validation checkout persists a GitHub credential: $(basename "$workflow")"
   grep -Fq 'OCI_CLUSTER_CHECKS_ALREADY_PASSED: "1"' "$workflow" ||
@@ -558,6 +605,46 @@ for workflow in "$deploy_workflow" "$migrate_workflow"; do
   grep -Fq 'OCI_E2E_ALREADY_PASSED: "1"' "$workflow" ||
     fail "protected validation still executes browser code: $(basename "$workflow")"
 done
+deploy_public_job_line="$(
+  grep -n -m1 '^  public-validate:' "$deploy_workflow" | cut -d: -f1
+)"
+deploy_dependency_line="$(
+  grep -n -m1 'name: Install browser validation dependencies' \
+    "$deploy_workflow" | cut -d: -f1
+)"
+[[ "$deploy_dependency_line" -gt "$deploy_public_job_line" ]] ||
+  fail "deployment browser validation is not in its credential-free public job"
+migration_public_job_line="$(
+  grep -n -m1 '^  public-validate:' "$migrate_workflow" | cut -d: -f1
+)"
+migration_finalize_job_line="$(
+  grep -n -m1 '^  finalize:' "$migrate_workflow" | cut -d: -f1
+)"
+migration_post_job_line="$(
+  grep -n -m1 '^  post-commit-validate:' "$migrate_workflow" | cut -d: -f1
+)"
+migration_dependency_line="$(
+  grep -n -m1 'name: Install browser validation dependencies' \
+    "$migrate_workflow" | cut -d: -f1
+)"
+[[ -n "$migration_post_job_line" &&
+    "$migration_public_job_line" -lt "$migration_finalize_job_line" &&
+    "$migration_finalize_job_line" -lt "$migration_post_job_line" &&
+    "$migration_dependency_line" -gt "$migration_post_job_line" ]] ||
+  fail "migration browser validation is not isolated after finalization"
+migration_post_secrets="$(
+  sed -n "${migration_post_job_line},\$p" "$migrate_workflow" |
+    grep -c 'secrets\.' || true
+)"
+migration_post_cloud_credentials="$(
+  sed -n "${migration_post_job_line},\$p" "$migrate_workflow" |
+    grep -Ec \
+      'OCI_CLI_|OCI_CI_PRIVATE_KEY|AZURE_CONFIG|azure/login|aks-set-context|configure-kubectl-oke' ||
+    true
+)"
+[[ "$migration_post_secrets" == "0" &&
+    "$migration_post_cloud_credentials" == "0" ]] ||
+  fail "post-commit browser validation receives cloud credentials"
 grep -Fq 'name: oci-infrastructure' "$infra_workflow"
 grep -Fq 'PROVISION OCI ZERO COST' "$infra_workflow"
 grep -Fq 'name: oci-production' "$deploy_workflow"
@@ -728,6 +815,7 @@ fi
 "$OCI_DIR/tests/test-capacity-contract.sh"
 "$OCI_DIR/tests/test-k3s-runtime-contract.sh"
 "$OCI_DIR/tests/test-migration-recovery-contract.sh"
+"$OCI_DIR/tests/test-mongo-upgrade.sh"
 
 git -C "$ROOT_DIR" diff --exit-code -- .github/workflows/production-build.yml >/dev/null ||
   fail "production-build.yml was modified"

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -33,6 +33,7 @@ run_failure() {
   local expected_boundary="$2"
   local expected_recovery="$3"
   local expected_oci_state="$4"
+  local expected_http_fence="$5"
   local output="$WORK_DIR/${point//\//-}.env"
   if OCI_RUNTIME_MODE=oke \
       MIGRATION_SIMULATION=1 \
@@ -49,6 +50,8 @@ run_failure() {
     fail "recovery state differs for $point"
   grep -Fxq "oci_state=$expected_oci_state" "$output" ||
     fail "OCI closure/baseline state differs for $point"
+  grep -Fxq "http_write_fence=$expected_http_fence" "$output" ||
+    fail "HTTP write-fence state differs for $point"
   grep -Fxq "azure_apps=frozen" "$output" ||
     fail "Azure writers were not kept frozen for $point"
   grep -Fxq "azure_stopped=true" "$output" ||
@@ -58,9 +61,10 @@ run_failure() {
 for point in \
   azure-start azure-provisioning azure-freeze source-queue-drain \
   runner-capacity archive-capture corrupt-archive disposable-validation \
-  cancellation hang target-queue-drain oci-freeze; do
-  run_failure "$point" false false baseline
+  cancellation hang target-queue-drain oci-freeze http-write-fence-install; do
+  run_failure "$point" false false baseline false
 done
+run_failure http-write-fence-installed-crash false false closed true
 
 databases=(
   gaming_auth gaming_bet gaming_backoffice gaming_event
@@ -70,21 +74,23 @@ for database in "${databases[@]}"; do
   for point in \
     "before-drop-$database" "after-drop-$database" \
     "before-restore-$database" "after-restore-$database"; do
-    run_failure "$point" true true closed
+    run_failure "$point" true true closed true
   done
 done
 
 for point in \
   rabbitmq-recreate restart-auth restart-client mongo-write-lock \
-  rabbitmq-write-lock protected-health public-health; do
-  run_failure "$point" true true closed
+  rabbitmq-write-lock http-write-fence-runtime \
+  mongo-restart-during-public-health protected-health public-health; do
+  run_failure "$point" true true closed true
 done
-run_failure post-boundary-cancellation true true closed
-run_failure post-boundary-hang true true closed
-run_failure cutover-committed true false committed-locked
-run_failure mongo-write-unlocked true false committed-mongo-writable
-run_failure rabbitmq-write-unlocked true false committed-writable
-run_failure retry-after-cutover true false forward-only
+run_failure post-boundary-cancellation true true closed true
+run_failure post-boundary-hang true true closed true
+run_failure cutover-committed true false committed-locked true
+run_failure mongo-write-unlocked true false committed-mongo-writable true
+run_failure rabbitmq-write-unlocked true false committed-writable true
+run_failure http-write-fence-removed true false committed-writable false
+run_failure retry-after-cutover true false forward-only true
 
 success_output="$WORK_DIR/success.env"
 OCI_RUNTIME_MODE=oke \
@@ -97,6 +103,8 @@ grep -Fxq 'exact_database_count=8' "$success_output" ||
   fail "successful replacement did not require eight exact databases"
 grep -Fxq 'oci_state=healthy' "$success_output" ||
   fail "successful replacement did not reach exact health"
+grep -Fxq 'http_write_fence=false' "$success_output" ||
+  fail "successful replacement retained the HTTP write fence"
 grep -Fxq 'azure_stopped=true' "$success_output" ||
   fail "successful replacement did not retain Azure stop evidence"
 
@@ -201,7 +209,11 @@ python3 "$STATE_HELPER" create \
   --set azure-baseline-sha256=azure-hash \
   --set oci-baseline=oci-baseline \
   --set oci-baseline-sha256=oci-hash \
+  --set http-write-fence=true \
   >"$WORK_DIR/mirror-base.json"
+python3 "$STATE_HELPER" summary "$WORK_DIR/mirror-base.json" |
+  grep -Fxq 'http-write-fence=true' ||
+  fail "sanitized migration summary omitted the HTTP write fence"
 python3 "$STATE_HELPER" mutate "$WORK_DIR/mirror-base.json" \
   --expect sequence=4 \
   --set sequence=5 \
@@ -299,7 +311,13 @@ for literal in \
   'az aks stop' \
   'Always stop and deallocate exact Azure source with evidence' \
   'OCI_PUBLIC_CHECKS_ALREADY_PASSED: "1"' \
-  'OCI_E2E_ALREADY_PASSED: "1"'; do
+  'OCI_E2E_ALREADY_PASSED: "1"' \
+  'Run read-only public OCI validation with mutation fence' \
+  'OCI_EXPECT_HTTP_MUTATION_FENCE: "1"' \
+  'post-commit-validate:' \
+  "needs.finalize.result == 'success'" \
+  'Validate public write path after committed fence removal' \
+  'http_mutation_fence_removed=true'; do
   grep -Fq "$literal" "$MIGRATION_WORKFLOW" ||
     fail "migration workflow is missing: $literal"
 done
@@ -323,6 +341,42 @@ grep -Fq '[ "$provisioning" = "Failed" ]' "$MIGRATION_WORKFLOW" ||
   fail "migration can run Bastion cleanup before an OCI CLI is installed"
 ! grep -Eq 'az aks (create|update|delete)|az aks nodepool' "$MIGRATION_WORKFLOW" ||
   fail "migration workflow can create, resize, or delete Azure"
+python3 - "$MIGRATION_WORKFLOW" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text()
+public_job = text.index("  public-validate:")
+finalize_job = text.index("  finalize:", public_job)
+read_only = text.index(
+    "Run read-only public OCI validation with mutation fence", public_job)
+fence_expectation = text.index(
+    'OCI_EXPECT_HTTP_MUTATION_FENCE: "1"', read_only)
+browser_install = text.index(
+    "Install browser validation dependencies", finalize_job)
+transition = text.index(
+    "Finalize success or enforce post-boundary closure", finalize_job)
+azure_stop = text.index(
+    "Always stop and deallocate exact Azure source with evidence", transition)
+post_commit_job = text.index("  post-commit-validate:", azure_stop)
+post_commit = text.index(
+    "Validate public write path after committed fence removal", post_commit_job)
+if not (public_job < read_only < fence_expectation < finalize_job <
+        transition < azure_stop < post_commit_job < browser_install <
+        post_commit):
+    raise SystemExit("read-only/public-write validation ordering differs")
+if "playwright" in text[public_job:finalize_job].lower():
+    raise SystemExit("pre-commit public validation can execute mutating browser checks")
+if "playwright" in text[finalize_job:post_commit_job].lower():
+    raise SystemExit("credentialed finalization can execute package browser code")
+post_commit_block = text[post_commit:]
+for output in ("public_url", "redirect_url", "diagnostic_url"):
+    expected = f"${{{{ needs.migrate.outputs.{output} }}}}"
+    if expected not in post_commit_block:
+        raise SystemExit(f"post-commit validation lacks migrated {output}")
+if "steps.provenance.outputs." in post_commit_block:
+    raise SystemExit("post-commit validation uses job-local unset URL outputs")
+PY
 
 for literal in \
   'workflows: ["oci-migrate"]' \
@@ -396,6 +450,19 @@ for literal in \
   'owner_run_is_conclusively_inactive' \
   'exactly eight Mongo PVCs' \
   'deployment_mongo_uri' \
+  'MONGO_REVIEWED_INDEX_DIGEST=sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3' \
+  'MONGO_REVIEWED_AMD64_MANIFEST=sha256:41afd6e1183f57e4e4d03ab733070671fca8553da2b36f15d6e3fc9760494d17' \
+  'MONGO_REVIEWED_ARM64_MANIFEST=sha256:21ca0269db1ebbd1c59f5cbc04928d7e3f6ab6186d7ceafc8fa489c0486525b4' \
+  'source-mongo-identities.json' \
+  'source-mongo-identities=' \
+  'target-mongo-container-id=' \
+  'target-mongo-restart-count=' \
+  'restore_source_mongo_manifest_from_state true' \
+  'verify_source_mongo_identity' \
+  'verify_target_mongo_identity' \
+  'verify_target_mongo_identity false' \
+  'freeze_azure_after_commit' \
+  'verify_cutover_write_locks' \
   'mongodump --quiet --archive --gzip' \
   'age --encrypt' \
   'docker run -d --name "$disposable_container"' \
@@ -405,6 +472,18 @@ for literal in \
   'logical-parity=true' \
   'lock_target_writes' \
   'lock_rabbitmq_writes' \
+  'INGRESS_CONTROLLER_CONFIGMAP="ingress-nginx-controller"' \
+  'if (\$request_method !~ ^(GET|HEAD|OPTIONS)\$)' \
+  'http-write-fence=false' \
+  'http_write_fence_config_status' \
+  'http_write_fence_runtime_status' \
+  "jq -r '.items[].metadata.name'" \
+  'ingress controller replicas disagree on the HTTP write fence' \
+  'install_http_write_fence' \
+  'wait_http_write_fence_runtime true' \
+  'state_optional_value http-write-fence' \
+  'remove_http_write_fence' \
+  'migration_failure_hook http-write-fence-removed' \
   'cutover-committed' \
   'cutover-committed | cutover-forward-recovery' \
   'last_committed_phase="$phase"' \
@@ -417,6 +496,12 @@ for literal in \
   grep -Fq "$literal" "$MIGRATION" ||
     fail "migration state machine is missing: $literal"
 done
+[[ "$(grep -Fc 'verify_source_mongo_identity "$pod"' "$MIGRATION")" -ge 3 ]] ||
+  fail "migration does not revalidate each source around capture"
+[[ "$(grep -Fc 'verify_target_mongo_identity' "$MIGRATION")" -ge 6 ]] ||
+  fail "migration does not revalidate the target around replacement"
+[[ "$(grep -Fc 'verify_cutover_write_locks' "$MIGRATION")" -ge 3 ]] ||
+  fail "migration does not revalidate both write locks immediately before commit"
 python3 - "$MIGRATION" <<'PY'
 from pathlib import Path
 import sys
@@ -425,9 +510,15 @@ text = Path(sys.argv[1]).read_text()
 replace = text.index("      verify_target_exact\n", text.index("case \"$MODE\" in"))
 mongo_lock = text.index("      lock_target_writes\n", replace)
 restart = text.index("      recreate_rabbitmq_and_restart\n", mongo_lock)
+main_freeze = text.rindex("      freeze_oci\n", 0, replace)
+fence_install = text.index("      install_http_write_fence\n", main_freeze)
+retry_unlock = text.index("      unlock_target_writes_for_retry\n", fence_install)
 finalize = text.index("    finalize-success)", restart)
+finalize_phase = text.index('finalize_phase="$(state_value phase)"', finalize)
 target_pod = text.index("target_mongo_pod=\"$(kube_capture", finalize)
-lock_check = text.index("$(target_write_lock_status)", target_pod)
+lock_check = text.index("          verify_cutover_write_locks\n", target_pod)
+final_exact = text.index("          verify_final_exact_state\n", lock_check)
+lock_recheck = text.index("          verify_cutover_write_locks\n", final_exact)
 commit = text.index("state_advance cutover-committed", finalize)
 mongo_unlock = text.index("      unlock_target_writes\n", commit)
 mongo_unlock_failure = text.index(
@@ -435,10 +526,20 @@ mongo_unlock_failure = text.index(
 rabbit_unlock = text.index("      unlock_rabbitmq_writes\n", mongo_unlock)
 rabbit_unlock_failure = text.index(
     "migration_failure_hook rabbitmq-write-unlocked", rabbit_unlock)
-completed = text.index("state_advance completed", rabbit_unlock)
-if not (replace < mongo_lock < restart < finalize < target_pod < lock_check <
-        commit < mongo_unlock < mongo_unlock_failure < rabbit_unlock <
-        rabbit_unlock_failure < completed):
+http_fence_remove = text.index("      remove_http_write_fence\n", rabbit_unlock)
+http_fence_failure = text.index(
+    "migration_failure_hook http-write-fence-removed", http_fence_remove)
+completed = text.index("state_advance completed", http_fence_failure)
+committed_case = text.index(
+    "        cutover-committed | cutover-forward-recovery)", lock_recheck)
+forward_identity = text.index(
+    "          verify_target_mongo_identity false", committed_case)
+if not (main_freeze < fence_install < retry_unlock < replace < mongo_lock <
+        restart < finalize < finalize_phase <
+        target_pod < lock_check < final_exact < lock_recheck < commit <
+        committed_case < forward_identity < mongo_unlock <
+        mongo_unlock_failure < rabbit_unlock < rabbit_unlock_failure <
+        http_fence_remove < http_fence_failure < completed):
     raise SystemExit("write-lock/cutover ordering differs")
 
 cleanup = text.index("cleanup() {")

--- a/infra/oci/tests/test-mongo-upgrade.sh
+++ b/infra/oci/tests/test-mongo-upgrade.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+UPGRADE="$ROOT_DIR/infra/oci/scripts/upgrade-mongo.sh"
+WORK_DIR="$ROOT_DIR/infra/oci/tests/.mongo-upgrade-work"
+STATE="$WORK_DIR/state.json"
+LOG="$WORK_DIR/kubectl.log"
+UPGRADE_STATE="$WORK_DIR/upgrade.env"
+SOURCE_IMAGE="docker.io/library/mongo@sha256:3d715950d83061ff2fbc910d12d3703212538cacf6b3003e3736fa5c7f51a2e1"
+TRANSITION_IMAGE="docker.io/library/mongo@sha256:de267922bc1153d923f5c9dc429f21c11faf18299080c1ce04d6d6007097fb06"
+TARGET_IMAGE="docker.io/library/mongo@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3"
+
+fail() {
+  echo "Mongo upgrade contract failure: $*" >&2
+  exit 1
+}
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR/bin"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+cat > "$WORK_DIR/bin/kubectl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state="${KUBECTL_STATE:?}"
+log="${KUBECTL_LOG:?}"
+printf '%q ' "$@" >> "$log"
+printf '\n' >> "$log"
+
+update_state() {
+  local filter="$1"
+  local tmp="${state}.$$"
+  jq "$filter" "$state" > "$tmp"
+  mv "$tmp" "$state"
+}
+
+namespace=""
+for ((index=1; index <= $#; index++)); do
+  if [[ "${!index}" == "-n" ]]; then
+    next=$((index + 1))
+    namespace="${!next}"
+  fi
+done
+
+case "${1:-}" in
+  get)
+    case "${2:-}" in
+      statefulset)
+        if [[ "$(jq -r .exists "$state")" != "true" ]]; then
+          [[ "$*" == *--ignore-not-found* ]] && exit 0
+          exit 1
+        fi
+        if [[ "$*" == *'-o name'* ]]; then
+          printf 'statefulset.apps/gaming-auth-mongo-depl\n'
+        elif [[ "$*" == *jsonpath* ]]; then
+          jq -r .image "$state"
+        else
+          printf '{}\n'
+        fi
+        ;;
+      pods)
+        if [[ "$*" == *'-o json'* ]]; then
+          if [[ "$namespace" == "ingress-nginx" ]]; then
+            replicas="$(jq -r .ingress "$state")"
+          else
+            replicas="$(jq -r .apps "$state")"
+          fi
+          jq -cn --argjson count "$replicas" \
+            '{items:[range(0;$count) | {}]}'
+        else
+          printf 'gaming-auth-mongo-depl-0'
+        fi
+        ;;
+      pod)
+        digest="$(
+          jq -r '.image_id_digest // (.image | split("@")[1])' "$state"
+        )"
+        printf 'docker.io/library/mongo@%s' "$digest"
+        ;;
+      pvc)
+        if [[ "$*" == *'-o name'* ]]; then
+          printf 'persistentvolumeclaim/gaming-auth-mongo-data\n'
+        elif [[ "$*" == *jsonpath* ]]; then
+          printf 'Bound'
+        else
+          printf '{}\n'
+        fi
+        ;;
+      deployment)
+        name="${3:-}"
+        if [[ "$name" == "ingress-nginx-controller" ]]; then
+          replicas="$(jq -r .ingress "$state")"
+        else
+          [[ "$(jq -r .apps_exist "$state")" == "true" ]] || exit 1
+          replicas="$(jq -r .apps "$state")"
+        fi
+        if [[ "$*" == *'-o name'* ]]; then
+          printf 'deployment.apps/%s\n' "$name"
+        elif [[ "$*" == *'-o json'* ]]; then
+          jq -cn --argjson replicas "$replicas" \
+            '{spec:{replicas:$replicas},status:{readyReplicas:$replicas}}'
+        else
+          printf '{}\n'
+        fi
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  rollout)
+    [[ "${KUBECTL_FAIL_ROLLOUT:-0}" != "1" ]]
+    ;;
+  apply)
+    cat >/dev/null
+    ;;
+  delete|wait)
+    ;;
+  scale)
+    replicas=""
+    for argument in "$@"; do
+      case "$argument" in
+        --replicas=*) replicas="${argument#*=}" ;;
+      esac
+    done
+    [[ "$replicas" =~ ^[01]$ ]] || exit 1
+    if [[ "$namespace" == "ingress-nginx" ]]; then
+      update_state ".ingress=$replicas"
+    else
+      update_state ".apps=$replicas"
+    fi
+    ;;
+  set)
+    assignment="${4:-}"
+    image="${assignment#*=}"
+    case "$image" in
+      *de267922bc1153d923f5c9dc429f21c11faf18299080c1ce04d6d6007097fb06)
+        update_state \
+          ".image=\"$image\" | .version=\"8.0.29\" | .major=\"8.0\""
+        ;;
+      *e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3)
+        update_state \
+          ".image=\"$image\" | .version=\"8.2.12\" | .major=\"8.2\""
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  exec)
+    if [[ "$*" == *betstan-mongo-storage-inspector* ]]; then
+      [[ "$(jq -r .storage_empty "$state")" == "true" ]]
+    elif [[ "$*" == *setFeatureCompatibilityVersion* ]]; then
+      if [[ "$*" == *"'8.0'"* ]]; then
+        update_state '.fcv="8.0"'
+      elif [[ "$*" == *"'8.2'"* ]]; then
+        update_state '.fcv="8.2"'
+      else
+        exit 1
+      fi
+      printf '{"ok":1}\n'
+    elif [[ "$*" == *'ping:1'* ]]; then
+      printf '1\n'
+    else
+      jq -c '{version,majorMinor:.major,fcv}' "$state"
+    fi
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$WORK_DIR/bin/kubectl"
+
+write_state() {
+  local image="$1"
+  local version="$2"
+  local major="$3"
+  local fcv="$4"
+  local ingress="${5:-1}"
+  local apps="${6:-1}"
+  jq -cn \
+    --arg image "$image" \
+    --arg version "$version" \
+    --arg major "$major" \
+    --arg fcv "$fcv" \
+    --argjson ingress "$ingress" \
+    --argjson apps "$apps" \
+    '{
+      exists:true,
+      apps_exist:true,
+      image:$image,
+      version:$version,
+      major:$major,
+      fcv:$fcv,
+      ingress:$ingress,
+      apps:$apps
+      ,storage_empty:true
+    }' > "$STATE"
+  : > "$LOG"
+  rm -f "$UPGRADE_STATE"
+}
+
+run_upgrade() {
+  env \
+    PATH="$WORK_DIR/bin:$PATH" \
+    KUBECTL_STATE="$STATE" \
+    KUBECTL_LOG="$LOG" \
+    OCI_K8S_NAMESPACE=betstan-oci \
+    MONGO_TARGET_IMAGE="$TARGET_IMAGE" \
+    MONGO_UPGRADE_STATE_FILE="$UPGRADE_STATE" \
+    MONGO_UPGRADE_WAIT_ATTEMPTS=2 \
+    MONGO_UPGRADE_SLEEP_SECONDS=0 \
+    "$UPGRADE" "$1"
+}
+
+write_state "$SOURCE_IMAGE" 7.0.21 7.0 7.0
+run_upgrade prepare >/dev/null
+jq -e \
+  --arg image "$TRANSITION_IMAGE" '
+    .image == $image and .version == "8.0.29" and
+    .major == "8.0" and .fcv == "8.0" and
+    .ingress == 0 and .apps == 0
+  ' "$STATE" >/dev/null ||
+  fail "7.0 prepare did not stage 8.0/FCV 8.0 with writers frozen"
+grep -Fq 'maintenance=true' "$UPGRADE_STATE" ||
+  fail "7.0 prepare did not persist maintenance state"
+python3 - "$LOG" <<'PY'
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+image = next(i for i, line in enumerate(lines) if "set image" in line)
+fcv = next(i for i, line in enumerate(lines) if "setFeatureCompatibilityVersion" in line)
+if image >= fcv:
+    raise SystemExit("Mongo 8.0 FCV changed before the 8.0 binary rollout")
+PY
+
+jq \
+  --arg image "$TARGET_IMAGE" '
+    .image=$image | .version="8.2.12" | .major="8.2"
+  ' "$STATE" > "$STATE.tmp"
+mv "$STATE.tmp" "$STATE"
+run_upgrade finalize >/dev/null
+jq -e '.version == "8.2.12" and .major == "8.2" and .fcv == "8.2"' \
+  "$STATE" >/dev/null ||
+  fail "8.2 finalize did not set exact target runtime and FCV"
+run_upgrade resume >/dev/null
+[[ "$(jq -r .ingress "$STATE")" == "1" ]] ||
+  fail "maintenance ingress was not resumed"
+
+write_state "$TRANSITION_IMAGE" 8.0.29 8.0 7.0 0 0
+run_upgrade prepare >/dev/null
+jq -e '.fcv == "8.0" and .ingress == 0 and .apps == 0' "$STATE" >/dev/null ||
+  fail "interrupted 8.0 transition did not resume safely"
+
+write_state "$TARGET_IMAGE" 8.2.12 8.2 8.0 0 0
+run_upgrade prepare >/dev/null
+run_upgrade finalize >/dev/null
+[[ "$(jq -r .fcv "$STATE")" == "8.2" ]] ||
+  fail "interrupted 8.2 FCV transition did not resume safely"
+
+write_state "$TARGET_IMAGE" 8.2.12 8.2 8.2
+run_upgrade prepare >/dev/null
+grep -Fq 'maintenance=false' "$UPGRADE_STATE" ||
+  fail "aligned Mongo unexpectedly entered maintenance"
+if grep -Eq '^scale |^set image ' "$LOG"; then
+  fail "aligned Mongo was mutated during prepare"
+fi
+jq '.image_id_digest="sha256:21ca0269db1ebbd1c59f5cbc04928d7e3f6ab6186d7ceafc8fa489c0486525b4"' \
+  "$STATE" > "$STATE.tmp"
+mv "$STATE.tmp" "$STATE"
+run_upgrade finalize >/dev/null
+run_upgrade resume >/dev/null
+
+write_state "$TARGET_IMAGE" 8.2.12 8.2 8.2
+jq '.exists=false | .storage_empty=true' "$STATE" > "$STATE.tmp"
+mv "$STATE.tmp" "$STATE"
+run_upgrade prepare >/dev/null
+grep -Fq 'maintenance=true' "$UPGRADE_STATE" ||
+  fail "fresh Mongo installation did not preserve maintenance fencing"
+jq -e '.ingress == 0 and .apps == 0' "$STATE" >/dev/null ||
+  fail "fresh Mongo installation did not freeze existing writers"
+
+write_state "$TARGET_IMAGE" 8.2.12 8.2 8.2
+jq '.exists=false | .storage_empty=false' "$STATE" > "$STATE.tmp"
+mv "$STATE.tmp" "$STATE"
+if run_upgrade prepare >"$WORK_DIR/nonempty-storage.out" 2>&1; then
+  fail "non-empty retained storage bypassed the staged upgrade"
+fi
+
+rm -f "$UPGRADE_STATE"
+if run_upgrade resume >"$WORK_DIR/missing-state.out" 2>&1; then
+  fail "Mongo ingress resume accepted a missing upgrade state"
+fi
+
+write_state "$SOURCE_IMAGE" 7.0.20 7.0 7.0
+if run_upgrade prepare >"$WORK_DIR/invalid-runtime.out" 2>&1; then
+  fail "unexpected Mongo source version was accepted"
+fi
+if grep -Eq '^scale |^set image ' "$LOG"; then
+  fail "unexpected Mongo source version mutated live workloads"
+fi
+
+write_state "$SOURCE_IMAGE" 7.0.21 7.0 7.0
+if env \
+    PATH="$WORK_DIR/bin:$PATH" \
+    KUBECTL_STATE="$STATE" \
+    KUBECTL_LOG="$LOG" \
+    OCI_K8S_NAMESPACE=betstan-oci \
+    MONGO_TARGET_IMAGE="${TARGET_IMAGE%?}0" \
+    MONGO_UPGRADE_STATE_FILE="$UPGRADE_STATE" \
+    "$UPGRADE" prepare >"$WORK_DIR/wrong-target.out" 2>&1; then
+  fail "unreviewed Mongo target image was accepted"
+fi
+
+echo "oci_mongo_upgrade_contract=PASS"


### PR DESCRIPTION
## Production-capable changes
- staged OCI MongoDB 7.0 -> 8.0 -> 8.2 deployment alignment
- exact Azure-to-OCI migration identity and fence hardening
- protected read-only pre-commit and credential-free post-commit validation
- Azure retirement provenance now requires HTTP fence removal

Promotes exact `dev` SHA `f8ad78b283288ebd22b1efb880c29e676118d73a`. OCI deployment and migration remain separately protected manual operations; this PR does not dispatch either.