### PR TITLE
fix(oci): run Mongo signatures in file mode

### DIFF
--- a/infra/azure/agents/consolidate-production-mongo-stan.sh
+++ b/infra/azure/agents/consolidate-production-mongo-stan.sh
@@ -106,8 +106,8 @@ database_signature() {
   {
     printf 'const DB_NAME = "%s";\n' "$database"
     cat "$SIGNATURE_SCRIPT"
-  } | kubectl exec -i -n "$NAMESPACE" "$pod" -- mongosh --quiet |
-    tail -n 1
+  } | kubectl exec -i -n "$NAMESPACE" "$pod" -- \
+    mongosh --quiet --file /dev/stdin
 }
 
 database_exists() {

--- a/infra/azure/agents/test-shared-mongo-consolidation-stan.sh
+++ b/infra/azure/agents/test-shared-mongo-consolidation-stan.sh
@@ -7,7 +7,7 @@ LOCK_SCRIPT="$ROOT_DIR/infra/azure/agents/shared-mongo-operation-lock-stan.sh"
 ROLLBACK_READINESS="$ROOT_DIR/infra/azure/agents/rollback-readiness-stan.sh"
 SIGNATURE_SCRIPT="$ROOT_DIR/infra/azure/agents/mongo-database-signature-stan.js"
 MIGRATION_AGENT="$ROOT_DIR/.github/agents/betstan-mongo-migration.agent.md"
-MONGO_TEST_IMAGE="${MONGO_TEST_IMAGE:-mongo:7}"
+MONGO_TEST_IMAGE="${MONGO_TEST_IMAGE:-docker.io/library/mongo@sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3}"
 SKIP_DOCKER="${SKIP_DOCKER:-0}"
 
 fail() {
@@ -197,10 +197,21 @@ wait_for_mongo() {
 container_signature() {
   local container="$1"
   local database="$2"
-  {
-    printf 'const DB_NAME = "%s";\n' "$database"
-    cat "$SIGNATURE_SCRIPT"
-  } | docker exec -i "$container" mongosh --quiet | tail -n 1
+  local signature
+  signature="$(
+    {
+      printf 'const DB_NAME = "%s";\n' "$database"
+      cat "$SIGNATURE_SCRIPT"
+    } | docker exec -i "$container" mongosh --quiet --file /dev/stdin
+  )"
+  jq -e --arg database "$database" '
+    .database == $database and
+    (.collections | type) == "array" and
+    (.dataHash | type) == "string" and
+    (.collectionHashes | type) == "object"
+  ' <<<"$signature" >/dev/null ||
+    fail "canonical signature is not valid JSON for $database"
+  printf '%s\n' "$signature"
 }
 
 wait_for_mongo "$source_container"

--- a/infra/oci/scripts/migrate-from-azure.sh
+++ b/infra/oci/scripts/migrate-from-azure.sh
@@ -1671,9 +1671,10 @@ mongo_signature_kube() {
     printf 'const DB_NAME = "%s";\n' "$database"
     cat "$SIGNATURE_SCRIPT"
   } >"$script_file"
+  # Mongosh 2.5 treats bare stdin as a REPL; file mode emits only the script result.
   kube_raw "$provider" mongo-signature "$MONGO_VALIDATION_TIMEOUT_SECONDS" 2 \
     exec -i -n "$(provider_namespace "$provider")" "$pod" -- \
-    mongosh --quiet <"$script_file" >"$output"
+    mongosh --quiet --file /dev/stdin <"$script_file" >"$output"
   [[ -s "$output" ]] || migration_die "empty canonical signature for $database"
   migration_raw signature-json 30 1 jq -e . "$output" >/dev/null ||
     migration_die "invalid canonical signature for $database"
@@ -1689,7 +1690,7 @@ mongo_signature_docker() {
     cat "$SIGNATURE_SCRIPT"
   } >"$script_file"
   migration_raw disposable-signature "$MONGO_VALIDATION_TIMEOUT_SECONDS" 2 \
-    docker exec -i "$disposable_container" mongosh --quiet \
+    docker exec -i "$disposable_container" mongosh --quiet --file /dev/stdin \
     <"$script_file" >"$output"
   [[ -s "$output" ]] || migration_die "empty disposable signature for $database"
   migration_raw signature-json 30 1 jq -e . "$output" >/dev/null ||

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -27,6 +27,8 @@ done
 PYTHONPYCACHEPREFIX="$WORK_DIR/pycache" \
   python3 -m py_compile "$STATE_HELPER" "$BOUNDED"
 node --check "$OCI_DIR/scripts/mongo-canonical-signature.js"
+[[ "$(grep -Fc 'mongosh --quiet --file /dev/stdin' "$MIGRATION")" == "2" ]] ||
+  fail "canonical signatures are not executed in non-REPL mongosh file mode"
 
 run_failure() {
   local point="$1"


### PR DESCRIPTION
Fixes the live pre-destructive migration failure where MongoDB 8.2 `mongosh` treated bare stdin as an interactive REPL and corrupted canonical signature output. Uses explicit `--file /dev/stdin`, updates the coupled consolidation path, and tests against the exact reviewed Mongo 8.2.12 image.\n\nCommit: `b45ac4cf88061a59cb141c2529d1869aecd8b4dc`\n\nValidation: full OCI contract, migration recovery contract, exact Mongo 8.2 eight-database parity test, shell syntax, error-level ShellCheck, and independent code review.