### PR TITLE
Promote OCI migration journal hardening

### DIFF
--- a/.github/agents/betstan-migration-recovery.agent.md
+++ b/.github/agents/betstan-migration-recovery.agent.md
@@ -28,6 +28,12 @@ read-only and prefer the checked-in recovery workflow and scripts.
 - Take over a stale lock only when GitHub proves the owner run is inactive,
   both cluster journals agree, live fingerprints and phase match, and the
   fencing generation increments atomically.
+- Keep the journal's original source SHA immutable. A newer release may become
+  the active source SHA only when it is a Git descendant of the prior active
+  SHA, the retained phase is exactly a fully unlocked pre-destructive failure,
+  the live OCI replica baseline still matches, Azure remains fully frozen with
+  no queue backlog, and Mongo, RabbitMQ, and the HTTP fence are all
+  writable/unfenced before the atomic takeover.
 - Never substitute current `master` for the journal SHA during recovery.
 
 ## No-backup replacement boundary

--- a/.github/workflows/oci-migrate.yml
+++ b/.github/workflows/oci-migrate.yml
@@ -1519,7 +1519,7 @@ jobs:
           }
 
           migration_id="$(get_phase_field migration-id)"
-          source_sha="$(get_phase_field original-source-sha)"
+          source_sha="$(get_phase_field active-source-sha)"
           run_id="$(get_phase_field owner-run-id)"
           run_attempt="$(get_phase_field owner-run-attempt)"
           journal_generation="$(get_phase_field fencing-token)"

--- a/.github/workflows/oci-migration-recovery.yml
+++ b/.github/workflows/oci-migration-recovery.yml
@@ -124,6 +124,39 @@ jobs:
           git fetch --quiet origin master:refs/remotes/origin/master
           [ "$(git rev-parse HEAD)" = "$EXPECTED_SOURCE_SHA" ]
           git merge-base --is-ancestor "$EXPECTED_SOURCE_SHA" origin/master
+          workflow_id="$(
+            ./infra/oci/scripts/bounded-command.py \
+              --timeout-seconds 45 --attempts 2 \
+              --classification github-workflow-read -- \
+              gh api "repos/$REPOSITORY/actions/workflows/oci-migrate.yml" \
+              --jq '.id'
+          )"
+          owner_run_json="$(
+            ./infra/oci/scripts/bounded-command.py \
+              --timeout-seconds 45 --attempts 2 \
+              --classification github-run-read -- \
+              gh api \
+                "repos/$REPOSITORY/actions/runs/$EXPECTED_OWNER_RUN_ID/attempts/1"
+          )"
+          observed_workflow="$(jq -r '.workflow_id // empty' <<<"$owner_run_json")"
+          path="$(jq -r '.path // empty' <<<"$owner_run_json")"
+          owner_event="$(jq -r '.event // empty' <<<"$owner_run_json")"
+          owner_head_sha="$(jq -r '.head_sha // empty' <<<"$owner_run_json")"
+          owner_branch="$(jq -r '.head_branch // empty' <<<"$owner_run_json")"
+          owner_repository="$(
+            jq -r '.head_repository.full_name // empty' <<<"$owner_run_json"
+          )"
+          owner_status="$(jq -r '.status // empty' <<<"$owner_run_json")"
+          owner_conclusion="$(jq -r '.conclusion // empty' <<<"$owner_run_json")"
+          owner_attempt="$(jq -r '.run_attempt // empty' <<<"$owner_run_json")"
+          [ "$observed_workflow" = "$workflow_id" ]
+          [ "$path" = ".github/workflows/oci-migrate.yml" ]
+          [ "$owner_event" = "workflow_dispatch" ]
+          [ "$owner_head_sha" = "$EXPECTED_SOURCE_SHA" ]
+          [ "$owner_branch" = "master" ]
+          [ "$owner_repository" = "$REPOSITORY" ]
+          [ "$owner_attempt" = "1" ]
+          [ "$owner_attempt" = "$EXPECTED_OWNER_RUN_ATTEMPT" ]
           case "$GITHUB_EVENT_NAME" in
             schedule)
               [ "$RECOVERY_ENABLED" = "true" ]
@@ -139,31 +172,9 @@ jobs:
               ;;
             workflow_run)
               [[ "$UPSTREAM_RUN_ID" =~ ^[1-9][0-9]*$ ]]
-              workflow_id="$(
-                ./infra/oci/scripts/bounded-command.py \
-                  --timeout-seconds 45 --attempts 2 \
-                  --classification github-workflow-read -- \
-                  gh api "repos/$REPOSITORY/actions/workflows/oci-migrate.yml" \
-                  --jq '.id'
-              )"
-              read -r observed_workflow path event head_sha branch repository status conclusion attempt <<<"$(
-                ./infra/oci/scripts/bounded-command.py \
-                  --timeout-seconds 45 --attempts 2 \
-                  --classification github-run-read -- \
-                  gh api "repos/$REPOSITORY/actions/runs/$UPSTREAM_RUN_ID/attempts/1" \
-                  --jq '[.workflow_id,.path,.event,.head_sha,.head_branch,.head_repository.full_name,.status,.conclusion,.run_attempt] | @tsv'
-              )"
-              [ "$observed_workflow" = "$workflow_id" ]
-              [ "$path" = ".github/workflows/oci-migrate.yml" ]
-              [ "$event" = "workflow_dispatch" ]
-              [ "$head_sha" = "$EXPECTED_SOURCE_SHA" ]
-              [ "$branch" = "master" ]
-              [ "$repository" = "$REPOSITORY" ]
-              [ "$status" = "completed" ]
-              [ "$conclusion" != "success" ]
-              [ "$attempt" = "1" ]
+              [ "$owner_status" = "completed" ]
+              [ "$owner_conclusion" != "success" ]
               [ "$UPSTREAM_RUN_ID" = "$EXPECTED_OWNER_RUN_ID" ]
-              [ "$attempt" = "$EXPECTED_OWNER_RUN_ATTEMPT" ]
               ;;
             *)
               exit 1
@@ -183,6 +194,7 @@ jobs:
           HOME: ${{ runner.temp }}/azure-recovery
         run: |
           set -euo pipefail
+          mkdir -p artifacts/azure-migration-recovery
           [ "$AZURE_CLUSTER_NAME" = "betstan-aks" ]
           cluster_json="$(
             ./infra/oci/scripts/bounded-command.py \

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -73,6 +73,14 @@ conversation summaries are not authority.
 - A stale heartbeat does not authorize blind lock deletion. Verify the owner
   run is conclusively inactive, both cluster locks and fingerprints agree, and
   the fencing generation is advanced atomically.
+- Preserve the journal's original source SHA as immutable lineage. A
+  descendant hotfix can replace only the active source SHA, and only from the
+  exact unlocked `failed-before-destructive-boundary` phase with unchanged
+  OCI replicas, fully frozen Azure applications/ingress, no Azure queue
+  backlog, and no live Mongo, RabbitMQ, or HTTP write fence.
+- Checkout removes untracked directories created by earlier workflow steps.
+  Recreate sanitized recovery artifact directories after checkout before
+  writing evidence.
 - A recovery watchdog may freeze applications and stop/deallocate Azure. It
   must never start Azure, reopen OCI, delete data, or tear down resources.
 

--- a/infra/oci/scripts/migrate-from-azure.sh
+++ b/infra/oci/scripts/migrate-from-azure.sh
@@ -396,6 +396,17 @@ state_optional_value() {
     --arg key "$1" '.data[$key] // empty' "$(state_file azure journal)"
 }
 
+state_active_source_sha() {
+  local active_source
+  active_source="$(state_optional_value active-source-sha)"
+  if [[ -z "$active_source" ]]; then
+    active_source="$(state_value original-source-sha)"
+  fi
+  [[ "$active_source" =~ ^[0-9a-f]{40}$ ]] ||
+    migration_die "active migration source SHA is invalid"
+  printf '%s' "$active_source"
+}
+
 state_monotonic_epoch() {
   local previous="$1"
   local now
@@ -489,9 +500,12 @@ state_read_all() {
 }
 
 state_validate_contract() {
+  local active_source
+  active_source="$(state_active_source_sha)"
   [[ "$(state_value schema-version)" == "1" &&
     "$(state_lock_value schema-version)" == "1" &&
     "$(state_value owner-workflow)" == ".github/workflows/oci-migrate.yml" &&
+    "$active_source" =~ ^[0-9a-f]{40}$ &&
     "$(state_value journal-id)" == "$(state_lock_value journal-id)" &&
     "$(state_value migration-id)" == "$(state_lock_value migration-id)" &&
     "$(state_value owner-run-id)" == "$(state_lock_value owner-run-id)" &&
@@ -653,6 +667,7 @@ state_recover_partial_creation() {
 owner_run_is_conclusively_inactive() {
   local run_id="$1"
   local attempt="$2"
+  local expected_source_sha="${3:-}"
   local document status
   if [[ -n "${MIGRATION_OWNER_RUN_FIXTURE:-}" ]]; then
     document="$(cat "$MIGRATION_OWNER_RUN_FIXTURE")"
@@ -667,11 +682,13 @@ owner_run_is_conclusively_inactive() {
   migration_raw github-run-identity 30 1 jq -e \
     --argjson id "$run_id" \
     --argjson attempt "$attempt" \
+    --arg source_sha "$expected_source_sha" \
     --arg repository "$REPOSITORY" '
       .id == $id and
       .run_attempt == $attempt and
       .path == ".github/workflows/oci-migrate.yml" and
       .head_branch == "master" and
+      ($source_sha == "" or .head_sha == $source_sha) and
       (.head_repository.full_name == $repository or $repository == "")
     ' <<<"$document" >/dev/null ||
     migration_die "stale lock owner does not identify the exact migration workflow"
@@ -700,6 +717,7 @@ state_new_documents() {
     "schema-version=1"
     "journal-id=$journal_id"
     "original-source-sha=$SOURCE_SHA"
+    "active-source-sha=$SOURCE_SHA"
     "migration-id=$MIGRATION_ID"
     "owner-run-id=$OWNER_RUN_ID"
     "owner-run-attempt=$OWNER_RUN_ATTEMPT"
@@ -756,11 +774,13 @@ state_new_documents() {
 
 state_takeover() {
   local preserve_recovery="$1"
-  local old_migration old_run old_attempt old_fence old_sequence old_heartbeat
+  local old_migration old_run old_attempt old_source
+  local old_fence old_sequence old_heartbeat
   local journal_id now
   old_migration="$(state_value migration-id)"
   old_run="$(state_value owner-run-id)"
   old_attempt="$(state_value owner-run-attempt)"
+  old_source="$(state_active_source_sha)"
   old_fence="$(state_value fencing-token)"
   old_sequence="$(state_value sequence)"
   old_heartbeat="$(state_value heartbeat-epoch)"
@@ -771,13 +791,11 @@ state_takeover() {
   now="$(state_monotonic_epoch "$old_heartbeat")"
   fencing_token=$((old_fence + 1))
 
+  owner_run_is_conclusively_inactive \
+    "$old_run" "$old_attempt" "$old_source" ||
+    migration_die "migration lock owner is active; takeover is forbidden"
   case "$(state_lock_value state)" in
-    active)
-      if ! owner_run_is_conclusively_inactive "$old_run" "$old_attempt"; then
-        migration_die "migration lock owner is active; takeover is forbidden"
-      fi
-      ;;
-    released)
+    active | released)
       ;;
     *)
       migration_die "migration lock state is invalid"
@@ -798,6 +816,7 @@ state_takeover() {
       --expect "owner-run-attempt=$old_attempt" \
       --expect "fencing-token=$old_fence" \
       --expect "sequence=$old_sequence" \
+      --set "active-source-sha=$SOURCE_SHA" \
       --set "migration-id=$MIGRATION_ID" \
       --set "owner-run-id=$OWNER_RUN_ID" \
       --set "owner-run-attempt=$OWNER_RUN_ATTEMPT" \
@@ -830,6 +849,7 @@ state_takeover() {
         "migration-id=$MIGRATION_ID" \
         "owner-run-id=$OWNER_RUN_ID" \
         "owner-run-attempt=$OWNER_RUN_ATTEMPT" \
+        "active-source-sha=$SOURCE_SHA" \
         "fencing-token=$fencing_token" \
         "sequence=$((old_sequence + 1))" \
         "phase=lock-taken-over" || rollback_failed=1
@@ -857,8 +877,45 @@ state_takeover() {
   fi
 }
 
+validate_cross_release_takeover() {
+  local existing_source="$1"
+  local service
+  [[ "$existing_source" != "$SOURCE_SHA" ]] ||
+    return 0
+  [[ "$(state_value phase)" == "failed-before-destructive-boundary" &&
+    "$(state_value destructive-boundary)" == "false" &&
+    "$(state_value recovery-required)" == "false" &&
+    "$(state_optional_value mongo-write-lock)" == "false" &&
+    "$(state_optional_value rabbitmq-write-lock)" == "false" &&
+    "$(state_optional_value http-write-fence)" == "false" ]] ||
+    migration_die "cross-release retry requires a fully unlocked pre-destructive failure"
+  [[ "$oci_baseline" == "$(state_value oci-baseline)" ]] ||
+    migration_die "cross-release retry OCI replica baseline differs from the journal"
+  applications_are_zero azure ||
+    migration_die "cross-release retry Azure applications are not frozen"
+  wait_deployment_zero azure ingress-nginx ingress-nginx-controller \
+    app.kubernetes.io/component=controller
+  for service in "${APP_SERVICES[@]}"; do
+    wait_deployment_zero azure "$AZURE_NAMESPACE" "gaming-${service}-depl" \
+      "app=gaming-${service}"
+  done
+  verify_frozen_source_queues
+  [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] ||
+    migration_die "cross-release retry checkout differs from SOURCE_SHA"
+  git cat-file -e "${existing_source}^{commit}" 2>/dev/null ||
+    migration_die "prior active migration SHA is unavailable"
+  git merge-base --is-ancestor "$existing_source" "$SOURCE_SHA" ||
+    migration_die "cross-release retry is not a descendant of the active journal SHA"
+  [[ "$(target_write_lock_status)" == "false" &&
+    "$(rabbitmq_write_permission)" == ".*" &&
+    "$(http_write_fence_config_status)" == "false" &&
+    "$(http_write_fence_runtime_status)" == "false" ]] ||
+    migration_die "cross-release retry found a live OCI write lock or HTTP fence"
+}
+
 state_acquire() {
-  local presence now journal_id lock_state existing_sha existing_azure existing_oci
+  local presence now journal_id lock_state existing_source
+  local existing_azure existing_oci
   local existing_phase
   presence="$(state_read_all)"
   now="$(migration_epoch)"
@@ -882,11 +939,9 @@ state_acquire() {
             "OCI cutover is committed; retrying from Azure is permanently forbidden"
           ;;
       esac
-      existing_sha="$(state_value original-source-sha)"
+      existing_source="$(state_active_source_sha)"
       existing_azure="$(state_value azure-cluster-fingerprint)"
       existing_oci="$(state_value oci-cluster-fingerprint)"
-      [[ "$existing_sha" == "$SOURCE_SHA" ]] ||
-        migration_die "existing journal original SHA differs from this exact retry"
       [[ "$existing_azure" == "$AZURE_CLUSTER_FINGERPRINT" &&
         "$existing_oci" == "$OCI_CLUSTER_FINGERPRINT" ]] ||
         migration_die "live cluster fingerprints differ from the mirrored journal"
@@ -901,6 +956,7 @@ state_acquire() {
         migration_die "Azure baseline hash differs from the mirrored journal"
       [[ "$(state_value oci-baseline-sha256)" == "$expected_oci_baseline_hash" ]] ||
         migration_die "OCI baseline hash differs from the mirrored journal"
+      validate_cross_release_takeover "$existing_source"
       lock_state="$(state_lock_value state)"
       if [[ "$(state_value migration-id)" == "$MIGRATION_ID" &&
             "$(state_value owner-run-id)" == "$OWNER_RUN_ID" &&
@@ -930,6 +986,8 @@ state_acquire() {
   state_compare_kind journal
   state_compare_kind lock
   state_validate_contract
+  [[ "$(state_active_source_sha)" == "$SOURCE_SHA" ]] ||
+    migration_die "migration journal is not bound to this active source SHA"
   state_boundary="$(state_value destructive-boundary)"
   state_recovery="$(state_value recovery-required)"
   last_committed_phase="$(state_value phase)"
@@ -953,7 +1011,8 @@ state_load_owned() {
   state_validate_contract
   [[ "$(state_value migration-id)" == "$MIGRATION_ID" &&
     "$(state_value owner-run-id)" == "$OWNER_RUN_ID" &&
-    "$(state_value owner-run-attempt)" == "$OWNER_RUN_ATTEMPT" ]] ||
+    "$(state_value owner-run-attempt)" == "$OWNER_RUN_ATTEMPT" &&
+    "$(state_active_source_sha)" == "$SOURCE_SHA" ]] ||
     migration_die "migration state is fenced by another run"
   fencing_token="$(state_value fencing-token)"
   [[ "$(state_lock_value fencing-token)" == "$fencing_token" ]] ||
@@ -978,6 +1037,7 @@ state_assert_fence() {
   [[ "$(state_value migration-id)" == "$MIGRATION_ID" &&
     "$(state_value owner-run-id)" == "$OWNER_RUN_ID" &&
     "$(state_value owner-run-attempt)" == "$OWNER_RUN_ATTEMPT" &&
+    "$(state_active_source_sha)" == "$SOURCE_SHA" &&
     "$(state_value fencing-token)" == "$fencing_token" &&
     "$(state_lock_value migration-id)" == "$MIGRATION_ID" &&
     "$(state_lock_value owner-run-id)" == "$OWNER_RUN_ID" &&
@@ -2624,7 +2684,7 @@ validate_inputs() {
     -x "$MIGRATION_BOUNDED_COMMAND" ]] ||
     migration_die "migration helpers are unavailable"
   local command_name
-  for command_name in kubectl jq python3 gh cmp awk sort; do
+  for command_name in kubectl jq python3 gh git cmp awk sort; do
     migration_require_command "$command_name"
   done
   if [[ "$MODE" == "replace" ]]; then

--- a/infra/oci/scripts/migration-state.py
+++ b/infra/oci/scripts/migration-state.py
@@ -68,6 +68,11 @@ def reconcile(source: dict, target: dict, kind: str) -> dict:
                 "owner-run-attempt",
             )
         )
+        active_source_unchanged = source_data.get(
+            "active-source-sha", source_data.get("original-source-sha")
+        ) == target_data.get(
+            "active-source-sha", target_data.get("original-source-sha")
+        )
         heartbeat_only = (
             same_owner
             and source_fence == target_fence
@@ -89,6 +94,7 @@ def reconcile(source: dict, target: dict, kind: str) -> dict:
             and source_fence == target_fence
             and source_sequence == target_sequence + 1
             and source_heartbeat >= target_heartbeat
+            and active_source_unchanged
         )
         takeover = (
             not same_owner
@@ -229,6 +235,7 @@ def main() -> int:
         "schema-version",
         "journal-id",
         "original-source-sha",
+        "active-source-sha",
         "migration-id",
         "owner-run-id",
         "owner-run-attempt",

--- a/infra/oci/scripts/recover-azure-migration.sh
+++ b/infra/oci/scripts/recover-azure-migration.sh
@@ -194,7 +194,8 @@ validate_expected_completed_journal() {
   owner_workflow="$(migration_raw recovery-state 30 1 jq -r \
     '.data["owner-workflow"]' "$state_file")"
   source_sha="$(migration_raw recovery-state 30 1 jq -r \
-    '.data["original-source-sha"]' "$state_file")"
+    '.data["active-source-sha"] // .data["original-source-sha"]' \
+    "$state_file")"
   state_owner="$(migration_raw recovery-state 30 1 jq -r \
     '.data["owner-run-id"]' "$state_file")"
   state_attempt="$(migration_raw recovery-state 30 1 jq -r \
@@ -370,7 +371,8 @@ inspect_active_runs() {
   owner_workflow="$(migration_raw recovery-state 30 1 jq -r \
     '.data["owner-workflow"]' "$state_file")"
   state_source_sha="$(migration_raw recovery-state 30 1 jq -r \
-    '.data["original-source-sha"]' "$state_file")"
+    '.data["active-source-sha"] // .data["original-source-sha"]' \
+    "$state_file")"
   phase="$(migration_raw recovery-state 30 1 jq -r '.data.phase' "$state_file")"
   sequence="$(migration_raw recovery-state 30 1 jq -r '.data.sequence' "$state_file")"
   boundary="$(migration_raw recovery-state 30 1 jq -r \

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -196,6 +196,7 @@ python3 "$STATE_HELPER" create \
   --set schema-version=1 \
   --set journal-id=fixture-journal \
   --set original-source-sha=1111111111111111111111111111111111111111 \
+  --set active-source-sha=1111111111111111111111111111111111111111 \
   --set migration-id=100-1 \
   --set owner-run-id=100 \
   --set owner-run-attempt=1 \
@@ -216,6 +217,49 @@ python3 "$STATE_HELPER" create \
 python3 "$STATE_HELPER" summary "$WORK_DIR/mirror-base.json" |
   grep -Fxq 'http-write-fence=true' ||
   fail "sanitized migration summary omitted the HTTP write fence"
+python3 "$STATE_HELPER" summary "$WORK_DIR/mirror-base.json" |
+  grep -Fxq \
+    'active-source-sha=1111111111111111111111111111111111111111' ||
+  fail "sanitized migration summary omitted the active source SHA"
+python3 "$STATE_HELPER" mutate "$WORK_DIR/mirror-base.json" \
+  --expect active-source-sha=1111111111111111111111111111111111111111 \
+  --expect migration-id=100-1 \
+  --expect fencing-token=1 \
+  --expect sequence=4 \
+  --set active-source-sha=2222222222222222222222222222222222222222 \
+  --set migration-id=101-1 \
+  --set owner-run-id=101 \
+  --set fencing-token=2 \
+  --set sequence=5 \
+  --set phase=lock-taken-over \
+  --set heartbeat-epoch=11 \
+  >"$WORK_DIR/cross-release-takeover.json"
+python3 "$STATE_HELPER" reconcile --kind journal \
+  "$WORK_DIR/cross-release-takeover.json" "$WORK_DIR/mirror-base.json" \
+  >"$WORK_DIR/cross-release-reconciled.json"
+python3 "$STATE_HELPER" compare \
+  "$WORK_DIR/cross-release-takeover.json" \
+  "$WORK_DIR/cross-release-reconciled.json" ||
+  fail "descendant release takeover could not be mirrored safely"
+grep -Fq \
+  '"original-source-sha": "1111111111111111111111111111111111111111"' \
+  "$WORK_DIR/cross-release-reconciled.json" ||
+  fail "descendant release takeover changed immutable journal lineage"
+grep -Fq \
+  '"active-source-sha": "2222222222222222222222222222222222222222"' \
+  "$WORK_DIR/cross-release-reconciled.json" ||
+  fail "descendant release takeover did not bind the active source SHA"
+python3 "$STATE_HELPER" mutate "$WORK_DIR/mirror-base.json" \
+  --set active-source-sha=2222222222222222222222222222222222222222 \
+  --set sequence=5 \
+  --set phase=source-captured \
+  --set heartbeat-epoch=11 \
+  >"$WORK_DIR/same-owner-lineage-drift.json"
+if python3 "$STATE_HELPER" reconcile --kind journal \
+    "$WORK_DIR/same-owner-lineage-drift.json" "$WORK_DIR/mirror-base.json" \
+    >/dev/null 2>&1; then
+  fail "same migration owner changed active source lineage"
+fi
 python3 "$STATE_HELPER" mutate "$WORK_DIR/mirror-base.json" \
   --expect sequence=4 \
   --set sequence=5 \
@@ -295,6 +339,7 @@ for literal in \
   'schema=betstan.oci-migration-success.v1' \
   'terminal_status=DEPLOYED_HEALTHY' \
   '[ "$migration_id" = "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" ]' \
+  'source_sha="$(get_phase_field active-source-sha)"' \
   '[ "$source_sha" = "$SOURCE_SHA" ]' \
   'journal_heartbeat_epoch=' \
   'fencing_generation=' \
@@ -401,12 +446,19 @@ for literal in \
   'EXPECTED_OWNER_RUN_ATTEMPT:' \
   'EXPECTED_MIGRATION_ID:' \
   'EXPECTED_FENCING_GENERATION:' \
-  '[ "$head_sha" = "$EXPECTED_SOURCE_SHA" ]' \
+  'owner_run_json="$(' \
+  '[ "$owner_head_sha" = "$EXPECTED_SOURCE_SHA" ]' \
+  'owner_conclusion="$(jq -r' \
+  '.conclusion // empty' \
+  '"repos/$REPOSITORY/actions/runs/$EXPECTED_OWNER_RUN_ID/attempts/1"' \
+  'mkdir -p artifacts/azure-migration-recovery' \
   'cancel-in-progress: true' \
   'az aks stop'; do
   grep -Fq "$literal" "$RECOVERY_WORKFLOW" ||
     fail "recovery workflow is missing: $literal"
 done
+! grep -Fq '@tsv' "$RECOVERY_WORKFLOW" ||
+  fail "recovery workflow can shift nullable owner-run fields"
 ! grep -Eq \
   'OCI_MIGRATION_AZURE_CREDENTIALS|OCI_CI_PRIVATE_KEY_PEM|OCI_K3S_SSH_PRIVATE_KEY|OCI_MIGRATION_AGE_IDENTITY' \
   "$RECOVERY_WORKFLOW" ||
@@ -424,6 +476,7 @@ for literal in \
   '"$state_migration" == "$EXPECTED_MIGRATION_ID"' \
   '"$state_fence" == "$EXPECTED_FENCING_GENERATION"' \
   '"$state_source_sha" == "$EXPECTED_SOURCE_SHA"' \
+  '.data["active-source-sha"] // .data["original-source-sha"]' \
   'different-active-migration'; do
   grep -Fq "$literal" "$RECOVERY" ||
     fail "recovery script is not bound to exact migration evidence: $literal"
@@ -450,6 +503,13 @@ for literal in \
   'state_reconcile_existing' \
   'state_recover_partial_creation' \
   'owner_run_is_conclusively_inactive' \
+  'active-source-sha=$SOURCE_SHA' \
+  'cross-release retry requires a fully unlocked pre-destructive failure' \
+  'cross-release retry OCI replica baseline differs from the journal' \
+  'cross-release retry Azure applications are not frozen' \
+  'verify_frozen_source_queues' \
+  'git merge-base --is-ancestor "$existing_source" "$SOURCE_SHA"' \
+  'cross-release retry found a live OCI write lock or HTTP fence' \
   'exactly eight Mongo PVCs' \
   'deployment_mongo_uri' \
   'MONGO_REVIEWED_INDEX_DIGEST=sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3' \
@@ -562,5 +622,14 @@ if not fail_closed_case < fail_closed_committed < fail_closed_close:
 PY
 ! grep -Eiq 'watchdog|restore_azure|Object Storage|snapshot' "$MIGRATION" ||
   fail "migration can reopen Azure or retain a prohibited recovery copy"
+grep -Fq "journal's original source SHA immutable" \
+  "$ROOT_DIR/.github/agents/betstan-migration-recovery.agent.md" ||
+  fail "migration recovery agent omits immutable cross-release lineage"
+grep -Fq "descendant hotfix can replace only the active source SHA" \
+  "$OCI_DIR/LESSONS_LEARNED.md" ||
+  fail "OCI lessons omit the descendant hotfix takeover boundary"
+grep -Fq "Recreate sanitized recovery artifact directories after checkout" \
+  "$OCI_DIR/LESSONS_LEARNED.md" ||
+  fail "OCI lessons omit checkout-safe recovery evidence"
 
 echo "migration_recovery_contract=PASS"


### PR DESCRIPTION
## Summary
Promote the reviewed migration journal lineage and recovery hardening from `dev` to production `master`.

## Release safety
- immutable original migration lineage is preserved
- descendant takeover is limited to a verified pre-destructive failed journal
- recovery is bound to the exact owner run SHA
- Azure and OCI live-state gates fail closed before takeover