### PR TITLE
Fix OCI Mongo cutover recovery

### DIFF
--- a/.github/agents/betstan-migration-recovery.agent.md
+++ b/.github/agents/betstan-migration-recovery.agent.md
@@ -30,10 +30,12 @@ read-only and prefer the checked-in recovery workflow and scripts.
   fencing generation increments atomically.
 - Keep the journal's original source SHA immutable. A newer release may become
   the active source SHA only when it is a Git descendant of the prior active
-  SHA, the retained phase is exactly a fully unlocked pre-destructive failure,
-  the live OCI replica baseline still matches, Azure remains fully frozen with
-  no queue backlog, and Mongo, RabbitMQ, and the HTTP fence are all
-  writable/unfenced before the atomic takeover.
+  SHA. A fully unlocked pre-destructive failure additionally requires the live
+  OCI replica baseline to match and Mongo, RabbitMQ, and HTTP to be unfenced.
+  A destructive `recovery-required` retry instead requires the active old
+  lock, retained HTTP fence and active replica baseline, plus zero live OCI
+  ingress, application, and RabbitMQ replicas. Both paths require frozen Azure
+  with no queue backlog before the atomic owner and fencing takeover.
 - Never substitute current `master` for the journal SHA during recovery.
 
 ## No-backup replacement boundary

--- a/.github/workflows/oci-migrate.yml
+++ b/.github/workflows/oci-migrate.yml
@@ -25,8 +25,18 @@ on:
         required: true
         default: false
         type: boolean
+      recover_closed_oci:
+        description: Reuse an image-equivalent ancestor deployment while OCI is fail-closed
+        required: true
+        default: false
+        type: boolean
+      recovery_deploy_source_sha:
+        description: Exact deployed ancestor SHA for a fail-closed recovery retry
+        required: false
+        default: ""
+        type: string
       confirmation:
-        description: Type REPLACE OCI DATA FROM AZURE
+        description: Type REPLACE OCI DATA FROM AZURE or RECOVER CLOSED OCI DATA FROM AZURE
         required: true
         type: string
 
@@ -55,6 +65,9 @@ jobs:
       DEPLOY_RUN_ID: ${{ inputs.deploy_run_id }}
       INFRASTRUCTURE_RUN_ID: ${{ inputs.infrastructure_run_id }}
       REPLACE_OCI_DATA: ${{ inputs.replace_oci_data }}
+      RECOVER_CLOSED_OCI: ${{ inputs.recover_closed_oci }}
+      RECOVERY_DEPLOY_SOURCE_INPUT: ${{ inputs.recovery_deploy_source_sha }}
+      DEPLOY_SOURCE_SHA: ${{ inputs.recovery_deploy_source_sha || inputs.approved_sha }}
       CONFIRMATION: ${{ inputs.confirmation }}
       OCI_RUNTIME_MODE: ${{ vars.OCI_RUNTIME_MODE }}
       OCI_CLI_VERSION: "3.90.0"
@@ -127,20 +140,39 @@ jobs:
           [ "$GITHUB_REF_NAME" = "master" ]
           [ "$GITHUB_RUN_ATTEMPT" = "1" ]
           [ "$REPLACE_OCI_DATA" = "true" ]
-          [ "$CONFIRMATION" = "REPLACE OCI DATA FROM AZURE" ]
           [ "$AZURE_CLUSTER_NAME" = "betstan-aks" ]
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$DEPLOY_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$BUILD_RUN_ID" =~ ^[1-9][0-9]*$ ]]
           [[ "$DEPLOY_RUN_ID" =~ ^[1-9][0-9]*$ ]]
           [[ "$INFRASTRUCTURE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
           git fetch --quiet origin master:refs/remotes/origin/master
           [ "$SOURCE_SHA" = "$GITHUB_SHA" ]
           [ "$SOURCE_SHA" = "$(git rev-parse origin/master)" ]
+          case "$RECOVER_CLOSED_OCI" in
+            false)
+              [ "$CONFIRMATION" = "REPLACE OCI DATA FROM AZURE" ]
+              [ "$DEPLOY_SOURCE_SHA" = "$SOURCE_SHA" ]
+              [ -z "$RECOVERY_DEPLOY_SOURCE_INPUT" ]
+              ;;
+            true)
+              [ "$CONFIRMATION" = "RECOVER CLOSED OCI DATA FROM AZURE" ]
+              [ "$DEPLOY_SOURCE_SHA" != "$SOURCE_SHA" ]
+              git cat-file -e "${DEPLOY_SOURCE_SHA}^{commit}"
+              git merge-base --is-ancestor "$DEPLOY_SOURCE_SHA" "$SOURCE_SHA"
+              ./infra/oci/scripts/compare-image-inputs.sh \
+                "$DEPLOY_SOURCE_SHA" "$SOURCE_SHA"
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
 
           validate_run() {
             local workflow_file="$1"
             local run_id="$2"
             local expected_event="$3"
+            local expected_sha="$4"
             local workflow_id
             workflow_id="$(
               ./infra/oci/scripts/bounded-command.py \
@@ -158,16 +190,19 @@ jobs:
             [ "$observed_workflow" = "$workflow_id" ]
             [ "$path" = ".github/workflows/$workflow_file" ]
             [ "$event" = "$expected_event" ]
-            [ "$head_sha" = "$SOURCE_SHA" ]
+            [ "$head_sha" = "$expected_sha" ]
             [ "$head_branch" = "master" ]
             [ "$repository" = "$REPOSITORY" ]
             [ "$status" = "completed" ]
             [ "$conclusion" = "success" ]
             [ "$attempt" = "1" ]
           }
-          validate_run oci-production-build.yml "$BUILD_RUN_ID" workflow_run
-          validate_run oci-infrastructure.yml "$INFRASTRUCTURE_RUN_ID" workflow_dispatch
-          validate_run oci-production-deploy.yml "$DEPLOY_RUN_ID" workflow_dispatch
+          validate_run \
+            oci-production-build.yml "$BUILD_RUN_ID" workflow_run "$SOURCE_SHA"
+          validate_run \
+            oci-infrastructure.yml "$INFRASTRUCTURE_RUN_ID" workflow_dispatch "$SOURCE_SHA"
+          validate_run \
+            oci-production-deploy.yml "$DEPLOY_RUN_ID" workflow_dispatch "$DEPLOY_SOURCE_SHA"
 
       - name: Download exact build provenance
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -211,7 +246,7 @@ jobs:
           VERIFY_REMOTE=0 BOOT_IMAGES=0 \
             ./infra/oci/scripts/verify-images.sh
 
-          grep -Fx "source_sha=$SOURCE_SHA" artifacts/deploy/provenance.txt
+          grep -Fx "source_sha=$DEPLOY_SOURCE_SHA" artifacts/deploy/provenance.txt
           grep -Fx "deployment_run_id=$DEPLOY_RUN_ID" artifacts/deploy/provenance.txt
           grep -Fx "deployment_run_attempt=1" artifacts/deploy/provenance.txt
           cmp -s artifacts/oci-migration/build-images.tsv artifacts/deploy/images.tsv
@@ -254,6 +289,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           printf '%s\n' \
             "source_sha=$SOURCE_SHA" \
+            "deploy_source_sha=$DEPLOY_SOURCE_SHA" \
+            "recover_closed_oci=$RECOVER_CLOSED_OCI" \
             "build_run_id=$BUILD_RUN_ID" \
             "build_run_attempt=1" \
             "infrastructure_run_id=$INFRASTRUCTURE_RUN_ID" \
@@ -875,6 +912,9 @@ jobs:
     env:
       SOURCE_SHA: ${{ inputs.approved_sha }}
       DEPLOY_RUN_ID: ${{ inputs.deploy_run_id }}
+      RECOVER_CLOSED_OCI: ${{ inputs.recover_closed_oci }}
+      RECOVERY_DEPLOY_SOURCE_INPUT: ${{ inputs.recovery_deploy_source_sha }}
+      DEPLOY_SOURCE_SHA: ${{ inputs.recovery_deploy_source_sha || inputs.approved_sha }}
       INFRASTRUCTURE_RUN_ID: ${{ inputs.infrastructure_run_id }}
       REPLACE_OCI_DATA: ${{ inputs.replace_oci_data }}
       PUBLIC_VALIDATION_RESULT: ${{ needs.public-validate.result }}
@@ -925,9 +965,26 @@ jobs:
           [ "$GITHUB_RUN_ATTEMPT" = "1" ]
           [ "$REPLACE_OCI_DATA" = "true" ]
           [ "$AZURE_CLUSTER_NAME" = "betstan-aks" ]
+          [[ "$DEPLOY_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
           git fetch --quiet origin master:refs/remotes/origin/master
           [ "$SOURCE_SHA" = "$(git rev-parse HEAD)" ]
           [ "$SOURCE_SHA" = "$(git rev-parse origin/master)" ]
+          case "$RECOVER_CLOSED_OCI" in
+            false)
+              [ "$DEPLOY_SOURCE_SHA" = "$SOURCE_SHA" ]
+              [ -z "$RECOVERY_DEPLOY_SOURCE_INPUT" ]
+              ;;
+            true)
+              [ "$DEPLOY_SOURCE_SHA" != "$SOURCE_SHA" ]
+              git cat-file -e "${DEPLOY_SOURCE_SHA}^{commit}"
+              git merge-base --is-ancestor "$DEPLOY_SOURCE_SHA" "$SOURCE_SHA"
+              ./infra/oci/scripts/compare-image-inputs.sh \
+                "$DEPLOY_SOURCE_SHA" "$SOURCE_SHA"
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
 
       - name: Download exact deployment provenance for finalization
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -951,7 +1008,7 @@ jobs:
         id: provenance
         run: |
           set -euo pipefail
-          grep -Fx "source_sha=$SOURCE_SHA" artifacts/deploy/provenance.txt
+          grep -Fx "source_sha=$DEPLOY_SOURCE_SHA" artifacts/deploy/provenance.txt
           grep -Fx "deployment_run_id=$DEPLOY_RUN_ID" artifacts/deploy/provenance.txt
           grep -Fx "deployment_run_attempt=1" artifacts/deploy/provenance.txt
           # shellcheck disable=SC1091
@@ -1426,6 +1483,8 @@ jobs:
       name: oci-migration
     env:
       SOURCE_SHA: ${{ inputs.approved_sha }}
+      DEPLOY_SOURCE_SHA: ${{ inputs.recovery_deploy_source_sha || inputs.approved_sha }}
+      RECOVER_CLOSED_OCI: ${{ inputs.recover_closed_oci }}
       AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256: ${{ vars.AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256 }}
     steps:
       - name: Checkout exact committed migration without credentials
@@ -1540,6 +1599,9 @@ jobs:
 
           [[ "$migration_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$DEPLOY_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$RECOVER_CLOSED_OCI" == "true" ||
+            "$RECOVER_CLOSED_OCI" == "false" ]]
           [ "$migration_id" = "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" ]
           [ "$source_sha" = "$SOURCE_SHA" ]
           [ "$run_id" = "$GITHUB_RUN_ID" ]
@@ -1572,6 +1634,8 @@ jobs:
             "schema=betstan.oci-migration-success.v1" \
             "migration_id=$migration_id" \
             "source_sha=$source_sha" \
+            "runtime_deploy_source_sha=$DEPLOY_SOURCE_SHA" \
+            "closed_recovery_retry=$RECOVER_CLOSED_OCI" \
             "github_run_id=$run_id" \
             "github_run_attempt=$run_attempt" \
             "terminal_phase=DEPLOYED_HEALTHY" \

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -67,6 +67,12 @@ conversation summaries are not authority.
   in the running NGINX configuration, and mirror its state in both journals.
   Keep it across every pre-commit failure and remove it only after
   `cutover-committed` and both internal write locks are released.
+- In MongoDB 8.2, mongosh `db.currentOp()` can omit the top-level `fsyncLock`
+  field even while the raw `currentOp` database command reports it as true.
+  The raw command omits the field while unlocked, so treat absence as false
+  but reject command errors or malformed present values. Normalize BSON `Long`
+  lock counts to JavaScript numbers before serializing them for shell
+  validation.
 - Pre-commit public checks must be read-only and prove the HTTP mutation fence.
   Run the mutating browser journey only after commit and fence removal; never
   let a validation write invalidate the certified source/target signatures.
@@ -74,10 +80,17 @@ conversation summaries are not authority.
   run is conclusively inactive, both cluster locks and fingerprints agree, and
   the fencing generation is advanced atomically.
 - Preserve the journal's original source SHA as immutable lineage. A
-  descendant hotfix can replace only the active source SHA, and only from the
-  exact unlocked `failed-before-destructive-boundary` phase with unchanged
-  OCI replicas, fully frozen Azure applications/ingress, no Azure queue
-  backlog, and no live Mongo, RabbitMQ, or HTTP write fence.
+  descendant hotfix can replace only the active source SHA. For an unlocked
+  `failed-before-destructive-boundary` phase, require unchanged OCI replicas,
+  fully frozen Azure applications/ingress, no Azure queue backlog, and no live
+  Mongo, RabbitMQ, or HTTP write fence. For `recovery-required`, require the
+  destructive and recovery flags, active journal lock, frozen Azure, closed
+  OCI ingress/applications/RabbitMQ, retained HTTP fence, and the original
+  active replica baseline before atomically advancing the owner and fencing
+  generation.
+- Recovery bindings belong to the `azure-migration-recovery` GitHub
+  environment. Repository variables with the same names do not override stale
+  environment values.
 - Checkout removes untracked directories created by earlier workflow steps.
   Recreate sanitized recovery artifact directories after checkout before
   writing evidence.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -120,7 +120,9 @@ An armed schedule also requires
 window so protected and public validation are not mistaken for a hung run.
 The expected SHA, run, attempt, migration ID, and fencing generation must be
 set immediately after dispatch and before approving `oci-migration`; recovery
-checks those values against both the workflow run and Azure journal.
+checks those values against both the workflow run and Azure journal. Set and
+clear these variables in the `azure-migration-recovery` environment; an
+environment value overrides a repository value with the same name.
 
 The capacity-acquirer identity needs only `VOLUME_INSPECT`, `VOLUME_UPDATE`,
 and `VOLUME_DELETE` in the deployment compartment for boot-volume
@@ -191,7 +193,11 @@ fixtures.
    A pre-destructive failure restores OCI workload baselines. Any later
    pre-commit failure keeps OCI closed and marks `recovery-required`; a later
    full retry clears partial application databases and starts again from
-   frozen Azure. A post-commit interruption is retried only forward through
+   frozen Azure. A descendant deployment-only hotfix may reuse the exact
+   image-equivalent deployed ancestor provenance only for that closed retry;
+   the journal must independently prove the old owner is inactive, Azure is
+   frozen, and OCI ingress, applications, and RabbitMQ remain at zero. A
+   post-commit interruption is retried only forward through
    idempotent write unlock and completion; retry from Azure is permanently
    forbidden because OCI may already have accepted writes. No path reopens
    Azure writers, retains a data artifact, or rolls back to the previous OCI

--- a/infra/oci/scripts/migrate-from-azure.sh
+++ b/infra/oci/scripts/migrate-from-azure.sh
@@ -322,7 +322,7 @@ kube_capture() {
   migration_raw "$classification" "$timeout_seconds" "$attempts" \
     kubectl --kubeconfig "$(provider_kubeconfig "$provider")" "$@"
   local status=$?
-  migration_maybe_heartbeat 1
+  migration_maybe_heartbeat
   return "$status"
 }
 
@@ -879,18 +879,15 @@ state_takeover() {
 
 validate_cross_release_takeover() {
   local existing_source="$1"
-  local service
+  local phase lock_status service stored_oci_baseline
   [[ "$existing_source" != "$SOURCE_SHA" ]] ||
     return 0
-  [[ "$(state_value phase)" == "failed-before-destructive-boundary" &&
-    "$(state_value destructive-boundary)" == "false" &&
-    "$(state_value recovery-required)" == "false" &&
-    "$(state_optional_value mongo-write-lock)" == "false" &&
-    "$(state_optional_value rabbitmq-write-lock)" == "false" &&
-    "$(state_optional_value http-write-fence)" == "false" ]] ||
-    migration_die "cross-release retry requires a fully unlocked pre-destructive failure"
-  [[ "$oci_baseline" == "$(state_value oci-baseline)" ]] ||
-    migration_die "cross-release retry OCI replica baseline differs from the journal"
+  [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] ||
+    migration_die "cross-release retry checkout differs from SOURCE_SHA"
+  git cat-file -e "${existing_source}^{commit}" 2>/dev/null ||
+    migration_die "prior active migration SHA is unavailable"
+  git merge-base --is-ancestor "$existing_source" "$SOURCE_SHA" ||
+    migration_die "cross-release retry is not a descendant of the active journal SHA"
   applications_are_zero azure ||
     migration_die "cross-release retry Azure applications are not frozen"
   wait_deployment_zero azure ingress-nginx ingress-nginx-controller \
@@ -900,17 +897,54 @@ validate_cross_release_takeover() {
       "app=gaming-${service}"
   done
   verify_frozen_source_queues
-  [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] ||
-    migration_die "cross-release retry checkout differs from SOURCE_SHA"
-  git cat-file -e "${existing_source}^{commit}" 2>/dev/null ||
-    migration_die "prior active migration SHA is unavailable"
-  git merge-base --is-ancestor "$existing_source" "$SOURCE_SHA" ||
-    migration_die "cross-release retry is not a descendant of the active journal SHA"
-  [[ "$(target_write_lock_status)" == "false" &&
-    "$(rabbitmq_write_permission)" == ".*" &&
-    "$(http_write_fence_config_status)" == "false" &&
-    "$(http_write_fence_runtime_status)" == "false" ]] ||
-    migration_die "cross-release retry found a live OCI write lock or HTTP fence"
+
+  phase="$(state_value phase)"
+  case "$phase" in
+    failed-before-destructive-boundary)
+      [[ "$(state_value destructive-boundary)" == "false" &&
+        "$(state_value recovery-required)" == "false" &&
+        "$(state_optional_value mongo-write-lock)" == "false" &&
+        "$(state_optional_value rabbitmq-write-lock)" == "false" &&
+        "$(state_optional_value http-write-fence)" == "false" ]] ||
+        migration_die "cross-release retry requires a fully unlocked pre-destructive failure"
+      [[ "$oci_baseline" == "$(state_value oci-baseline)" ]] ||
+        migration_die "cross-release retry OCI replica baseline differs from the journal"
+      [[ "$(target_write_lock_status)" == "false" &&
+        "$(rabbitmq_write_permission)" == ".*" &&
+        "$(http_write_fence_config_status)" == "false" &&
+        "$(http_write_fence_runtime_status)" == "false" ]] ||
+        migration_die "cross-release retry found a live OCI write lock or HTTP fence"
+      ;;
+    recovery-required)
+      [[ "$(state_value destructive-boundary)" == "true" &&
+        "$(state_value recovery-required)" == "true" &&
+        "$(state_lock_value state)" == "active" &&
+        "$(state_optional_value http-write-fence)" == "true" ]] ||
+        migration_die "cross-release recovery retry requires an active closed post-boundary journal"
+      applications_are_zero oci ||
+        migration_die "cross-release recovery retry OCI applications are not closed"
+      wait_deployment_zero oci ingress-nginx ingress-nginx-controller \
+        app.kubernetes.io/component=controller
+      wait_deployment_zero oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl \
+        app=gaming-rabbitmq
+      [[ "$(http_write_fence_config_status)" == "true" ]] ||
+        migration_die "cross-release recovery retry lost the OCI HTTP write fence"
+      lock_status="$(target_write_lock_status)"
+      [[ "$lock_status" == "true" || "$lock_status" == "false" ]] ||
+        migration_die "cross-release recovery retry cannot determine the OCI Mongo lock"
+      stored_oci_baseline="$(state_value oci-baseline)"
+      [[ "$(baseline_value "$stored_oci_baseline" ingress)" =~ ^[1-9][0-9]*$ &&
+        "$(baseline_value "$stored_oci_baseline" rabbitmq)" == "1" ]] ||
+        migration_die "cross-release recovery retry has an inactive OCI baseline"
+      for service in "${APP_SERVICES[@]}"; do
+        [[ "$(baseline_value "$stored_oci_baseline" "$service")" =~ ^[1-9][0-9]*$ ]] ||
+          migration_die "cross-release recovery retry has an inactive $service baseline"
+      done
+      ;;
+    *)
+      migration_die "cross-release retry phase is not safely recoverable"
+      ;;
+  esac
 }
 
 state_acquire() {
@@ -1550,7 +1584,13 @@ mongo_eval() {
 
 target_write_lock_status() {
   mongo_eval oci "$target_mongo_pod" '
-    print(db.getSiblingDB("admin").currentOp().fsyncLock === true);
+    const result=db.getSiblingDB("admin").runCommand({currentOp:1,$all:true});
+    if (Number(result.ok) !== 1 ||
+        (result.fsyncLock !== undefined &&
+         typeof result.fsyncLock !== "boolean")) {
+      throw new Error("Mongo fsync lock status is unavailable");
+    }
+    print(result.fsyncLock === true);
   '
 }
 
@@ -1559,7 +1599,9 @@ lock_target_writes() {
   [[ "$(target_write_lock_status)" == "false" ]] ||
     migration_die "OCI Mongo write lock was already active unexpectedly"
   result="$(mongo_eval oci "$target_mongo_pod" '
-    print(JSON.stringify(db.getSiblingDB("admin").runCommand({fsync:1,lock:true})));
+    const result=db.getSiblingDB("admin").runCommand({fsync:1,lock:true});
+    const lockCount=Number(result.lockCount);
+    print(JSON.stringify({ok:Number(result.ok),lockCount}));
   ')"
   migration_raw mongo-write-lock 30 1 jq -e \
     '.ok == 1 and .lockCount >= 1' <<<"$result" >/dev/null ||
@@ -1575,7 +1617,9 @@ unlock_target_writes() {
     return 0
   fi
   result="$(mongo_eval oci "$target_mongo_pod" '
-    print(JSON.stringify(db.getSiblingDB("admin").runCommand({fsyncUnlock:1})));
+    const result=db.getSiblingDB("admin").runCommand({fsyncUnlock:1});
+    const lockCount=Number(result.lockCount);
+    print(JSON.stringify({ok:Number(result.ok),lockCount}));
   ')"
   migration_raw mongo-write-unlock 30 1 jq -e \
     '.ok == 1 and .lockCount == 0' <<<"$result" >/dev/null ||
@@ -2455,6 +2499,7 @@ recreate_rabbitmq_and_restart() {
   kube_run oci rabbitmq-rollout 600 1 \
     rollout status deployment/gaming-rabbitmq-depl \
     -n "$OCI_K8S_NAMESPACE" --timeout=9m
+  unlock_rabbitmq_writes
   state_advance rabbitmq-recreated true true "rabbitmq-write-lock=false"
   migration_failure_hook rabbitmq-recreate
 

--- a/infra/oci/scripts/migration-common.sh
+++ b/infra/oci/scripts/migration-common.sh
@@ -78,7 +78,7 @@ migration_run() {
     "external_command=START classification=$classification timeout_seconds=$timeout_seconds attempts=$attempts"
   migration_raw "$classification" "$timeout_seconds" "$attempts" "$@"
   local status=$?
-  migration_maybe_heartbeat 1
+  migration_maybe_heartbeat
   if [[ "$status" -ne 0 ]]; then
     migration_log \
       "external_command=FAIL classification=$classification status=$status"

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -327,6 +327,16 @@ fi
 for literal in \
   'replace_oci_data:' \
   'inputs.replace_oci_data == true' \
+  'recover_closed_oci:' \
+  'recovery_deploy_source_sha:' \
+  'RECOVER CLOSED OCI DATA FROM AZURE' \
+  'DEPLOY_SOURCE_SHA:' \
+  'compare-image-inputs.sh' \
+  'validate_run \' \
+  'oci-production-deploy.yml "$DEPLOY_RUN_ID" workflow_dispatch "$DEPLOY_SOURCE_SHA"' \
+  'grep -Fx "source_sha=$DEPLOY_SOURCE_SHA" artifacts/deploy/provenance.txt' \
+  'runtime_deploy_source_sha=$DEPLOY_SOURCE_SHA' \
+  'closed_recovery_retry=$RECOVER_CLOSED_OCI' \
   'build_run_id:' \
   'redirect_url: ${{ steps.provenance.outputs.redirect_url }}' \
   'diagnostic_url: ${{ steps.provenance.outputs.diagnostic_url }}' \
@@ -510,6 +520,10 @@ for literal in \
   'verify_frozen_source_queues' \
   'git merge-base --is-ancestor "$existing_source" "$SOURCE_SHA"' \
   'cross-release retry found a live OCI write lock or HTTP fence' \
+  'cross-release recovery retry requires an active closed post-boundary journal' \
+  'cross-release recovery retry OCI applications are not closed' \
+  'cross-release recovery retry lost the OCI HTTP write fence' \
+  'cross-release recovery retry has an inactive OCI baseline' \
   'exactly eight Mongo PVCs' \
   'deployment_mongo_uri' \
   'MONGO_REVIEWED_INDEX_DIGEST=sha256:e0ce8c35124d4a9f9785532d1f268f39e9728ffa1cb38f46fa482436424c4bd3' \
@@ -533,6 +547,10 @@ for literal in \
   'target-signature-manifest-sha256' \
   'logical-parity=true' \
   'lock_target_writes' \
+  'runCommand({currentOp:1,$all:true})' \
+  '(result.fsyncLock !== undefined &&' \
+  'print(result.fsyncLock === true)' \
+  'const lockCount=Number(result.lockCount)' \
   'lock_rabbitmq_writes' \
   'INGRESS_CONTROLLER_CONFIGMAP="ingress-nginx-controller"' \
   'if (\$request_method !~ ^(GET|HEAD|OPTIONS)\$)' \
@@ -558,6 +576,35 @@ for literal in \
   grep -Fq "$literal" "$MIGRATION" ||
     fail "migration state machine is missing: $literal"
 done
+! grep -Fq '.currentOp().fsyncLock' "$MIGRATION" ||
+  fail "migration uses mongosh currentOp(), which omits MongoDB 8.2 fsyncLock"
+python3 - "$MIGRATION" "$OCI_DIR/scripts/migration-common.sh" <<'PY'
+from pathlib import Path
+import sys
+
+migration = Path(sys.argv[1]).read_text()
+common = Path(sys.argv[2]).read_text()
+kube_capture = migration[
+    migration.index("kube_capture() {"):migration.index("\n}\n", migration.index("kube_capture() {")) + 3
+]
+migration_run = common[
+    common.index("migration_run() {"):common.index("\n}\n", common.index("migration_run() {")) + 3
+]
+if "migration_maybe_heartbeat 1" in kube_capture:
+    raise SystemExit("captured Kubernetes reads force redundant mirrored heartbeats")
+if "migration_maybe_heartbeat 1" in migration_run:
+    raise SystemExit("short external commands force redundant mirrored heartbeats")
+
+rabbit_restart = migration.index(
+    'scale_deployment oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl 1'
+)
+rabbit_unlock = migration.index("  unlock_rabbitmq_writes\n", rabbit_restart)
+rabbit_state = migration.index(
+    "  state_advance rabbitmq-recreated true true", rabbit_unlock
+)
+if not rabbit_restart < rabbit_unlock < rabbit_state:
+    raise SystemExit("RabbitMQ recovery does not normalize publish permissions")
+PY
 [[ "$(grep -Fc 'verify_source_mongo_identity "$pod"' "$MIGRATION")" -ge 3 ]] ||
   fail "migration does not revalidate each source around capture"
 [[ "$(grep -Fc 'verify_target_mongo_identity' "$MIGRATION")" -ge 6 ]] ||


### PR DESCRIPTION
Fix the MongoDB 8.2 fsync lock probe that falsely failed the OCI cutover after restore.

This deployment-only hotfix also permits a strictly fenced descendant retry from the existing recovery-required journal while reusing only image-equivalent immutable deployment provenance, normalizes RabbitMQ permissions on retry, and reduces redundant mirrored heartbeat writes. OCI remains fail-closed until the full migration certifies parity and health.

Validation: full OCI offline contract suite, ShellCheck/actionlint, and a live MongoDB 8.2.12 lock/unlock probe.