### PR TITLE
Retry asynchronous OCI Bastion readiness

### DIFF
--- a/.github/agents/betstan-oci-operator.agent.md
+++ b/.github/agents/betstan-oci-operator.agent.md
@@ -72,6 +72,9 @@ substitute another region, shape, bandwidth, storage class, or paid runtime.
   SSH to `127.0.0.1:6443`. Direct Bastion-to-6443 and Managed SSH are not the
   supported A1 path. Always delete the session, restore the non-routable
   Bastion client CIDR, stop the exact tunnel PIDs, and remove temporary keys.
+  Treat session `ACTIVE` and SSH endpoint readiness as separate asynchronous
+  states; retry only the tunnel against the same session with bounded backoff
+  and persisted PID cleanup.
 - Never expose SSH, port 6443, kubelet, Mongo, RabbitMQ, or application
   NodePorts directly to the internet.
 - Deploy only exact digest provenance, sequentially: Mongo, RabbitMQ,

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -29,6 +29,10 @@ conversation summaries are not authority.
 - Direct Bastion forwarding to k3s port 6443 is blocked by the OCI Ubuntu host
   firewall. Use one Bastion session to target SSH and a target-loopback tunnel
   to `127.0.0.1:6443`.
+- An OCI Bastion session can report `ACTIVE` before its SSH endpoint accepts a
+  durable tunnel. Retry the tunnel against that same exact session with a
+  bounded backoff, clearing and persisting each failed PID; do not create
+  duplicate sessions or weaken cleanup.
 
 ## Canonical production routing
 

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -166,7 +166,9 @@ fixtures.
    port-forwarding session to target SSH, then tunnels the k3s API through
    the target loopback interface. This avoids both Managed SSH, which OCI
    Bastion does not support for Ubuntu on Ampere A1, and the OCI Ubuntu host
-   firewall that rejects direct non-SSH input.
+   firewall that rejects direct non-SSH input. Because session `ACTIVE` can
+   precede endpoint readiness, the operator retries only the tunnel against
+   that same session with bounded backoff and exact PID cleanup.
    `scripts/finalize-k3s.sh` then mounts the Mongo volume, installs
    ingress-nginx and cert-manager, and reconciles the fixed 10/10 Mbps OCI
    load balancer.

--- a/infra/oci/scripts/configure-k3s-access.sh
+++ b/infra/oci/scripts/configure-k3s-access.sh
@@ -174,8 +174,8 @@ stop_tunnel() {
   [[ -n "$tunnel_pid" ]] || return 0
   if kill -0 "$tunnel_pid" 2>/dev/null; then
     kill "$tunnel_pid"
-    wait "$tunnel_pid" 2>/dev/null || true
   fi
+  wait "$tunnel_pid" 2>/dev/null || true
 }
 
 cleanup_access() {
@@ -417,22 +417,25 @@ ssh_session_id="$(
 bastion_endpoint="$(session_endpoint "$ssh_session_id" 22)"
 write_session_state
 
-ssh \
-  -i "$bastion_private_key" \
-  -N \
-  -L "127.0.0.1:${OCI_K3S_LOCAL_SSH_PORT}:${instance_private_ip}:22" \
-  -o BatchMode=yes \
-  -o ExitOnForwardFailure=yes \
-  -o IdentitiesOnly=yes \
-  -o ServerAliveInterval=30 \
-  -o ServerAliveCountMax=3 \
-  -o StrictHostKeyChecking=accept-new \
-  -o UserKnownHostsFile="$bastion_known_hosts" \
-  -p 22 \
-  "${ssh_session_id}@${bastion_endpoint}" \
-  >"$WORK_DIR/bastion-ssh-tunnel.log" 2>&1 &
-ssh_tunnel_pid=$!
-write_session_state
+start_bastion_ssh_tunnel() {
+  : >"$WORK_DIR/bastion-ssh-tunnel.log"
+  ssh \
+    -i "$bastion_private_key" \
+    -N \
+    -L "127.0.0.1:${OCI_K3S_LOCAL_SSH_PORT}:${instance_private_ip}:22" \
+    -o BatchMode=yes \
+    -o ExitOnForwardFailure=yes \
+    -o IdentitiesOnly=yes \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
+    -o StrictHostKeyChecking=accept-new \
+    -o UserKnownHostsFile="$bastion_known_hosts" \
+    -p 22 \
+    "${ssh_session_id}@${bastion_endpoint}" \
+    >"$WORK_DIR/bastion-ssh-tunnel.log" 2>&1 &
+  ssh_tunnel_pid=$!
+  write_session_state
+}
 
 target_ssh_options=(
   -i "$target_private_key"
@@ -448,18 +451,37 @@ target_ssh_options=(
   -o UserKnownHostsFile="$target_known_hosts"
 )
 ssh_ready=0
-for _ in $(seq 1 30); do
-  kill -0 "$ssh_tunnel_pid" 2>/dev/null ||
-    oci_die "target SSH Bastion tunnel process exited"
-  if ssh \
-      "${target_ssh_options[@]}" \
-      "${OCI_K3S_OS_USER}@127.0.0.1" \
-      'sudo test -s /etc/rancher/k3s/k3s.yaml' \
-      >/dev/null 2>&1; then
-    ssh_ready=1
+target_ssh_attempt=0
+for tunnel_attempt in $(seq 1 6); do
+  tunnel_failed=0
+  start_bastion_ssh_tunnel
+  while (( target_ssh_attempt < 30 )); do
+    if ! kill -0 "$ssh_tunnel_pid" 2>/dev/null; then
+      tunnel_failed=1
+      break
+    fi
+    target_ssh_attempt=$((target_ssh_attempt + 1))
+    if ssh \
+        "${target_ssh_options[@]}" \
+        "${OCI_K3S_OS_USER}@127.0.0.1" \
+        'sudo test -s /etc/rancher/k3s/k3s.yaml' \
+        >/dev/null 2>&1; then
+      ssh_ready=1
+      break 2
+    fi
+    sleep 10
+  done
+  stop_tunnel "$ssh_tunnel_pid"
+  ssh_tunnel_pid=""
+  write_session_state
+  if [[ "$tunnel_failed" == "1" &&
+    "$tunnel_attempt" -lt 6 &&
+    "$target_ssh_attempt" -lt 30 ]]; then
+    oci_log "bastion_ssh_tunnel_retry=$tunnel_attempt reason=endpoint-not-ready"
+    sleep 15
+  else
     break
   fi
-  sleep 10
 done
 [[ "$ssh_ready" == "1" ]] ||
   oci_die "target SSH did not become usable through OCI Bastion"

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -437,6 +437,24 @@ grep -Fq -- \
 grep -Fq 'kubectl --request-timeout=10s get --raw=/readyz' \
   "$OCI_DIR/scripts/configure-k3s-access.sh" ||
   fail "k3s API readiness does not have a bounded request timeout"
+grep -Fq 'for tunnel_attempt in $(seq 1 6)' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access does not retry an ACTIVE session whose SSH endpoint is not ready"
+grep -Fq 'while (( target_ssh_attempt < 30 ))' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access shortened the bounded target SSH readiness window"
+grep -Fq 'tunnel_failed=1' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access cannot distinguish endpoint failure from target startup"
+grep -Fq 'bastion_ssh_tunnel_retry=$tunnel_attempt reason=endpoint-not-ready' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access does not classify Bastion endpoint propagation retries"
+grep -Fq 'stop_tunnel "$ssh_tunnel_pid"' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access does not stop a failed tunnel before retrying"
+grep -Fq 'ssh_tunnel_pid=""' \
+  "$OCI_DIR/scripts/configure-k3s-access.sh" ||
+  fail "k3s access does not clear a failed tunnel PID before persisting retry state"
 ! grep -Eq 'iptables|netfilter|ufw' "$OCI_DIR/scripts/configure-k3s-access.sh" ||
   fail "k3s access mutates the target host firewall"
 ! grep -Eq 'ControlMaster|ControlPersist' \


### PR DESCRIPTION
OCI Bastion can report a port-forwarding session `ACTIVE` before its SSH endpoint accepts a durable tunnel. Retry only the tunnel against the same exact session with bounded backoff, while stopping, waiting, clearing, and persisting every failed PID.

This fixes the pre-data failure in migration run `32201378101`; Azure was stopped and OCI remained fail-closed.

Validation: full OCI offline suite, ShellCheck, live normal access, and a forced live port-collision recovery.