### PR TITLE
Promote OCI auth cutover startup recovery

### DIFF
--- a/.github/agents/betstan-migration-recovery.agent.md
+++ b/.github/agents/betstan-migration-recovery.agent.md
@@ -50,7 +50,16 @@ read-only and prefer the checked-in recovery workflow and scripts.
   protected validation. Because Mongo's `fsyncLock` is cleared by a container
   restart, also require the mirrored, controller-level HTTP mutation fence
   before ingress reopens and verify the directive in the running NGINX
-  configuration. Pre-commit public checks are read-only. Record
+  configuration. If an application must reconcile an already-restored index
+  before it can become Ready, start only that exact application while Mongo is
+  unlocked and ingress, RabbitMQ, and every other application remain at zero;
+  lock Mongo immediately after readiness and recertify exact parity under the
+  lock. If a Mongo restart cleared a process-local lock while the journal still
+  says locked, reconcile the field only after the raw command proves the live
+  process is unlocked. RabbitMQ must remain writable only while consumers
+  declare and bind the empty topology, then be publish-locked before ingress
+  starts.
+  Pre-commit public checks are read-only. Record
   `cutover-committed` only after final parity under all three fences, then
   unlock idempotently and remove the HTTP fence last.
 - After `cutover-committed`, never retry from Azure. OCI may have accepted new

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -70,13 +70,24 @@ conversation summaries are not authority.
   ingress-nginx ConfigMap fence that rejects mutating HTTP methods, verify it
   in the running NGINX configuration, and mirror its state in both journals.
   Keep it across every pre-commit failure and remove it only after
-  `cutover-committed` and both internal write locks are released.
+  `cutover-committed` and both internal write locks are released. During a
+  full retry, a raw unlocked probe may safely reconcile a stale journal lock
+  field left behind by a Mongo process restart; never infer that state from
+  pod readiness alone.
 - In MongoDB 8.2, mongosh `db.currentOp()` can omit the top-level `fsyncLock`
   field even while the raw `currentOp` database command reports it as true.
   The raw command omits the field while unlocked, so treat absence as false
   but reject command errors or malformed present values. Normalize BSON `Long`
   lock counts to JavaScript numbers before serializing them for shell
   validation.
+- An application that awaits index reconciliation before opening its health
+  port cannot start under Mongo `fsyncLock`, even when the identical index
+  already exists. Keep ingress, RabbitMQ, and every other application at zero,
+  start only that exact application while Mongo is unlocked, immediately lock
+  Mongo after readiness, and recertify all canonical signatures under the lock
+  before starting the remaining workloads. Do not move the RabbitMQ publish
+  lock ahead of consumer topology initialization: queue binding requires write
+  permission even though external publishing is still blocked by zero ingress.
 - Pre-commit public checks must be read-only and prove the HTTP mutation fence.
   Run the mutating browser journey only after commit and fence removal; never
   let a validation write invalidate the certified source/target signatures.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -188,9 +188,12 @@ fixtures.
    transfer archives only on ephemeral runner storage, validates them in an
    isolated disposable Mongo, then drops and exactly replaces the eight
    allowlisted OCI databases. It verifies canonical data and metadata
-   signatures, recreates the 17-queue RabbitMQ topology, restarts consumers
-   sequentially, then locks Mongo and RabbitMQ publishes while protected and
-   public health run. Finalization rechecks parity under both locks, records
+   signatures, starts only auth while ingress, RabbitMQ, and every other
+   application remain stopped so its required index initialization can finish,
+   then immediately locks Mongo and recertifies exact parity under that lock.
+   It recreates the 17-queue RabbitMQ topology, restarts consumers
+   sequentially, and locks RabbitMQ publishes before ingress opens under the
+   HTTP mutation fence. Finalization rechecks parity under all locks, records
    `cutover-committed`, and only then enables writes.
    A pre-destructive failure restores OCI workload baselines. Any later
    pre-commit failure keeps OCI closed and marks `recovery-required`; a later

--- a/infra/oci/scripts/migrate-from-azure.sh
+++ b/infra/oci/scripts/migrate-from-azure.sh
@@ -180,7 +180,8 @@ simulate() {
     done
   done
   for point in \
-    rabbitmq-recreate restart-auth restart-client mongo-write-lock \
+    auth-startup-before-mongo-lock mongo-write-lock \
+    rabbitmq-recreate restart-auth restart-client \
     rabbitmq-write-lock http-write-fence-runtime \
     mongo-restart-during-public-health protected-health public-health; do
     if [[ "$fail_at" == "$point" ]]; then
@@ -1629,16 +1630,29 @@ unlock_target_writes() {
 }
 
 unlock_target_writes_for_retry() {
+  local lock_status journal_lock
   target_mongo_pod="$(kube_capture oci target-pod 30 2 \
     get pods -n "$OCI_K8S_NAMESPACE" -l app=gaming-auth-mongo \
     -o jsonpath='{.items[0].metadata.name}')"
   [[ -n "$target_mongo_pod" ]] ||
     migration_die "OCI Mongo pod is unavailable for retry preparation"
-  if [[ "$(target_write_lock_status)" == "true" ]]; then
+  lock_status="$(target_write_lock_status)"
+  journal_lock="$(state_optional_value mongo-write-lock)"
+  [[ "$journal_lock" == "true" || "$journal_lock" == "false" ]] ||
+    migration_die "retry journal Mongo write-lock state is invalid"
+  if [[ "$lock_status" == "true" ]]; then
     unlock_target_writes
+  fi
+  if [[ "$lock_status" == "true" || "$journal_lock" == "true" ]]; then
     state_advance retry-write-lock-released true true \
       "mongo-write-lock=false"
   fi
+  state_read_all >/dev/null
+  state_compare_kind journal
+  state_validate_contract
+  [[ "$(target_write_lock_status)" == "false" &&
+    "$(state_optional_value mongo-write-lock)" == "false" ]] ||
+    migration_die "retry Mongo write-lock state did not reconcile"
 }
 
 rabbitmq_write_permission() {
@@ -2411,10 +2425,14 @@ restore_target_databases() {
 }
 
 verify_target_exact() {
+  local phase="${1:-target-exactly-validated}"
   local inventory mapping _service database _sts _pod _pvc expected actual
   local signature_hash source_aggregate target_aggregate
   local signature_args=()
   local target_manifest="$WORK_DIR/target-signature-manifest.tsv"
+  [[ "$phase" == "target-exactly-validated" ||
+    "$phase" == "target-exactly-validated-after-auth-startup" ]] ||
+    migration_die "target exact-validation phase is invalid"
   : >"$target_manifest"
   verify_target_mongo_identity
   inventory="$(mongo_non_system_databases oci "$target_mongo_pod")"
@@ -2439,7 +2457,7 @@ verify_target_exact() {
     "$target_aggregate" == "$source_aggregate" ]] ||
     migration_die "aggregate source/target signature parity failed"
   verify_target_mongo_identity
-  state_advance target-exactly-validated true true \
+  state_advance "$phase" true true \
     "database-count=8" \
     "logical-parity=true" \
     "target-signature-manifest-sha256=$target_aggregate" \
@@ -2483,6 +2501,55 @@ close_oci() {
   wait_deployment_zero oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl \
     app=gaming-rabbitmq
   oci_frozen=1
+}
+
+start_auth_before_mongo_lock() {
+  local service replicas auth_state
+  state_assert_fence
+  verify_target_mongo_identity
+  [[ "$(state_optional_value mongo-write-lock)" == "false" &&
+    "$(target_write_lock_status)" == "false" ]] ||
+    migration_die "auth index initialization requires an unlocked OCI Mongo"
+  [[ "$(state_optional_value http-write-fence)" == "true" &&
+    "$(http_write_fence_config_status)" == "true" ]] ||
+    migration_die "auth index initialization requires the retained HTTP fence"
+  wait_deployment_zero oci ingress-nginx ingress-nginx-controller \
+    app.kubernetes.io/component=controller
+  wait_deployment_zero oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl \
+    app=gaming-rabbitmq
+  for service in "${APP_SERVICES[@]}"; do
+    wait_deployment_zero oci "$OCI_K8S_NAMESPACE" \
+      "gaming-${service}-depl" "app=gaming-${service}"
+  done
+
+  replicas="$(baseline_value "$oci_baseline" auth)"
+  [[ "$replicas" == "1" ]] ||
+    migration_die "OCI auth baseline must be exactly one replica"
+  scale_deployment oci "$OCI_K8S_NAMESPACE" gaming-auth-depl "$replicas"
+  kube_run oci auth-pre-lock-rollout 600 1 \
+    rollout status deployment/gaming-auth-depl \
+    -n "$OCI_K8S_NAMESPACE" --timeout=9m
+  auth_state="$(kube_capture oci auth-pre-lock-read 30 2 \
+    get deployment gaming-auth-depl -n "$OCI_K8S_NAMESPACE" \
+    -o jsonpath='{.spec.replicas}|{.status.availableReplicas}|{.status.readyReplicas}')"
+  [[ "$auth_state" == "1|1|1" &&
+    "$(target_write_lock_status)" == "false" &&
+    "$(http_write_fence_config_status)" == "true" ]] ||
+    migration_die "auth did not initialize safely before the Mongo write lock"
+  wait_deployment_zero oci ingress-nginx ingress-nginx-controller \
+    app.kubernetes.io/component=controller
+  wait_deployment_zero oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl \
+    app=gaming-rabbitmq
+  for service in "${APP_SERVICES[@]}"; do
+    [[ "$service" == "auth" ]] && continue
+    wait_deployment_zero oci "$OCI_K8S_NAMESPACE" \
+      "gaming-${service}-depl" "app=gaming-${service}"
+  done
+  state_assert_fence
+  verify_target_mongo_identity
+  state_advance auth-started-before-mongo-lock true true \
+    "mongo-write-lock=false" "http-write-fence=true"
+  migration_failure_hook auth-startup-before-mongo-lock
 }
 
 recreate_rabbitmq_and_restart() {
@@ -2796,7 +2863,9 @@ main() {
       restore_target_databases
       verify_target_exact
       verify_target_mongo_identity
+      start_auth_before_mongo_lock
       lock_target_writes
+      verify_target_exact target-exactly-validated-after-auth-startup
       recreate_rabbitmq_and_restart
       state_write_summary
       rm -rf "$WORK_DIR"

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -9,6 +9,7 @@ STATE_HELPER="$OCI_DIR/scripts/migration-state.py"
 BOUNDED="$OCI_DIR/scripts/bounded-command.py"
 MIGRATION_WORKFLOW="$ROOT_DIR/.github/workflows/oci-migrate.yml"
 RECOVERY_WORKFLOW="$ROOT_DIR/.github/workflows/oci-migration-recovery.yml"
+AUTH_ENTRYPOINT="$ROOT_DIR/auth/src/index.ts"
 WORK_DIR="$OCI_DIR/tests/.migration-recovery-work"
 
 fail() {
@@ -81,7 +82,8 @@ for database in "${databases[@]}"; do
 done
 
 for point in \
-  rabbitmq-recreate restart-auth restart-client mongo-write-lock \
+  auth-startup-before-mongo-lock mongo-write-lock \
+  rabbitmq-recreate restart-auth restart-client \
   rabbitmq-write-lock http-write-fence-runtime \
   mongo-restart-during-public-health protected-health public-health; do
   run_failure "$point" true true closed true
@@ -546,11 +548,18 @@ for literal in \
   'signature-$database' \
   'target-signature-manifest-sha256' \
   'logical-parity=true' \
+  'start_auth_before_mongo_lock' \
+  'auth-started-before-mongo-lock' \
+  'target-exactly-validated-after-auth-startup' \
+  'auth index initialization requires an unlocked OCI Mongo' \
+  'auth index initialization requires the retained HTTP fence' \
   'lock_target_writes' \
   'runCommand({currentOp:1,$all:true})' \
   '(result.fsyncLock !== undefined &&' \
   'print(result.fsyncLock === true)' \
   'const lockCount=Number(result.lockCount)' \
+  'retry journal Mongo write-lock state is invalid' \
+  'retry Mongo write-lock state did not reconcile' \
   'lock_rabbitmq_writes' \
   'INGRESS_CONTROLLER_CONFIGMAP="ingress-nginx-controller"' \
   'if (\$request_method !~ ^(GET|HEAD|OPTIONS)\$)' \
@@ -602,7 +611,11 @@ rabbit_unlock = migration.index("  unlock_rabbitmq_writes\n", rabbit_restart)
 rabbit_state = migration.index(
     "  state_advance rabbitmq-recreated true true", rabbit_unlock
 )
-if not rabbit_restart < rabbit_unlock < rabbit_state:
+application_loop = migration.index(
+    '  for service in "${BACKEND_SERVICES[@]}" client; do', rabbit_state
+)
+rabbit_lock = migration.index("  lock_rabbitmq_writes\n", application_loop)
+if not rabbit_restart < rabbit_unlock < rabbit_state < application_loop < rabbit_lock:
     raise SystemExit("RabbitMQ recovery does not normalize publish permissions")
 PY
 [[ "$(grep -Fc 'verify_source_mongo_identity "$pod"' "$MIGRATION")" -ge 3 ]] ||
@@ -611,14 +624,20 @@ PY
   fail "migration does not revalidate the target around replacement"
 [[ "$(grep -Fc 'verify_cutover_write_locks' "$MIGRATION")" -ge 3 ]] ||
   fail "migration does not revalidate both write locks immediately before commit"
-python3 - "$MIGRATION" <<'PY'
+python3 - "$MIGRATION" "$AUTH_ENTRYPOINT" <<'PY'
 from pathlib import Path
 import sys
 
 text = Path(sys.argv[1]).read_text()
+auth_entrypoint = Path(sys.argv[2]).read_text()
 replace = text.index("      verify_target_exact\n", text.index("case \"$MODE\" in"))
-mongo_lock = text.index("      lock_target_writes\n", replace)
-restart = text.index("      recreate_rabbitmq_and_restart\n", mongo_lock)
+auth_start = text.index("      start_auth_before_mongo_lock\n", replace)
+mongo_lock = text.index("      lock_target_writes\n", auth_start)
+post_auth_exact = text.index(
+    "      verify_target_exact target-exactly-validated-after-auth-startup\n",
+    mongo_lock,
+)
+restart = text.index("      recreate_rabbitmq_and_restart\n", post_auth_exact)
 main_freeze = text.rindex("      freeze_oci\n", 0, replace)
 fence_install = text.index("      install_http_write_fence\n", main_freeze)
 retry_unlock = text.index("      unlock_target_writes_for_retry\n", fence_install)
@@ -643,13 +662,68 @@ committed_case = text.index(
     "        cutover-committed | cutover-forward-recovery)", lock_recheck)
 forward_identity = text.index(
     "          verify_target_mongo_identity false", committed_case)
-if not (main_freeze < fence_install < retry_unlock < replace < mongo_lock <
-        restart < finalize < finalize_phase <
+if not (main_freeze < fence_install < retry_unlock < replace < auth_start <
+        mongo_lock < post_auth_exact < restart < finalize < finalize_phase <
         target_pod < lock_check < final_exact < lock_recheck < commit <
         committed_case < forward_identity < mongo_unlock <
         mongo_unlock_failure < rabbit_unlock < rabbit_unlock_failure <
         http_fence_remove < http_fence_failure < completed):
     raise SystemExit("write-lock/cutover ordering differs")
+
+auth_function_start = text.index("start_auth_before_mongo_lock() {")
+auth_function_end = text.index("\n}\n", auth_function_start)
+auth_function = text[auth_function_start:auth_function_end]
+for required in (
+    '$(target_write_lock_status)" == "false"',
+    '$(http_write_fence_config_status)" == "true"',
+    "wait_deployment_zero oci ingress-nginx",
+    "gaming-rabbitmq-depl",
+    '"gaming-${service}-depl"',
+    'baseline_value "$oci_baseline" auth',
+    "rollout status deployment/gaming-auth-depl",
+    '[[ "$service" == "auth" ]] && continue',
+    "migration_failure_hook auth-startup-before-mongo-lock",
+):
+    if required not in auth_function:
+        raise SystemExit(f"pre-lock auth startup is missing: {required}")
+if not (
+    auth_entrypoint.index("await User.init()")
+    < auth_entrypoint.index("app.listen(3000")
+):
+    raise SystemExit("auth no longer requires index initialization before readiness")
+
+retry_unlock_start = text.index("unlock_target_writes_for_retry() {")
+retry_unlock_end = text.index("\n}\n", retry_unlock_start)
+retry_unlock_function = text[retry_unlock_start:retry_unlock_end]
+runtime_read = retry_unlock_function.index(
+    'lock_status="$(target_write_lock_status)"'
+)
+journal_read = retry_unlock_function.index(
+    'journal_lock="$(state_optional_value mongo-write-lock)"'
+)
+runtime_unlock = retry_unlock_function.index(
+    'if [[ "$lock_status" == "true" ]]; then'
+)
+journal_reconcile = retry_unlock_function.index(
+    'if [[ "$lock_status" == "true" || "$journal_lock" == "true" ]]'
+)
+state_release = retry_unlock_function.index(
+    "state_advance retry-write-lock-released", journal_reconcile
+)
+state_refresh = retry_unlock_function.index(
+    "state_read_all >/dev/null", state_release
+)
+state_compare = retry_unlock_function.index(
+    "state_compare_kind journal", state_refresh
+)
+final_assertion = retry_unlock_function.index(
+    "retry Mongo write-lock state did not reconcile", state_compare
+)
+if not (
+    runtime_read < journal_read < runtime_unlock < journal_reconcile
+    < state_release < state_refresh < state_compare < final_assertion
+):
+    raise SystemExit("retry does not reconcile a process-cleared Mongo write lock")
 
 cleanup = text.index("cleanup() {")
 cleanup_case = text.index('case "$current_phase" in', cleanup)


### PR DESCRIPTION
## Summary
Promote the deployment-only OCI migration fix that initializes auth before taking the Mongo fsync lock, then recertifies exact data parity under the lock before starting the remaining workloads.

## Release safety
- no application source, image input, API, service-boundary, or architecture changes
- OCI remains fail-closed until the complete replacement and certification succeed
- all eight Azure databases remain the authoritative recovery source
- stale runtime/journal Mongo lock state is reconciled before a full retry
- regression contracts enforce the startup, lock, parity, RabbitMQ, and ingress ordering