### PR TITLE
Wait for RabbitMQ consumer convergence

### DIFF
--- a/.github/agents/betstan-migration-recovery.agent.md
+++ b/.github/agents/betstan-migration-recovery.agent.md
@@ -57,8 +57,10 @@ read-only and prefer the checked-in recovery workflow and scripts.
   lock. If a Mongo restart cleared a process-local lock while the journal still
   says locked, reconcile the field only after the raw command proves the live
   process is unlocked. RabbitMQ must remain writable only while consumers
-  declare and bind the empty topology, then be publish-locked before ingress
-  starts.
+  declare and bind the empty topology. Workload readiness does not prove
+  asynchronous broker registration: require a bounded convergence loop for
+  the exact 17 queues, zero backlog, and nonzero consumers on every queue,
+  then publish-lock RabbitMQ before ingress starts.
   Pre-commit public checks are read-only. Record
   `cutover-committed` only after final parity under all three fences, then
   unlock idempotently and remove the HTTP fence last.

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -88,6 +88,12 @@ conversation summaries are not authority.
   before starting the remaining workloads. Do not move the RabbitMQ publish
   lock ahead of consumer topology initialization: queue binding requires write
   permission even though external publishing is still blocked by zero ingress.
+- A successful application rollout does not prove that asynchronous RabbitMQ
+  queue declaration, binding, and consumer registration have converged. After
+  sequential startup, poll the exact 17 queue names, zero backlog, and nonzero
+  consumer count per queue within a bounded deadline. Keep ingress closed and
+  RabbitMQ writable during that wait, emit sanitized mismatch diagnostics on
+  exhaustion, and publish-lock RabbitMQ only after the exact topology passes.
 - Pre-commit public checks must be read-only and prove the HTTP mutation fence.
   Run the mutating browser journey only after commit and fence removal; never
   let a validation write invalidate the certified source/target signatures.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -192,8 +192,11 @@ fixtures.
    application remain stopped so its required index initialization can finish,
    then immediately locks Mongo and recertifies exact parity under that lock.
    It recreates the 17-queue RabbitMQ topology, restarts consumers
-   sequentially, and locks RabbitMQ publishes before ingress opens under the
-   HTTP mutation fence. Finalization rechecks parity under all locks, records
+   sequentially, waits within a bounded loop for the exact queue names, zero
+   backlog, and at least one consumer per queue, and only then locks RabbitMQ
+   publishes before ingress opens under the HTTP mutation fence. Application
+   readiness alone does not certify that asynchronous broker registration has
+   converged. Finalization rechecks parity under all locks, records
    `cutover-committed`, and only then enables writes.
    A pre-destructive failure restores OCI workload baselines. Any later
    pre-commit failure keeps OCI closed and marks `recovery-required`; a later

--- a/infra/oci/scripts/migrate-from-azure.sh
+++ b/infra/oci/scripts/migrate-from-azure.sh
@@ -37,6 +37,8 @@ STREAM_TIMEOUT_SECONDS="${MIGRATION_STREAM_TIMEOUT_SECONDS:-900}"
 MONGO_VALIDATION_TIMEOUT_SECONDS="${MIGRATION_MONGO_VALIDATION_TIMEOUT_SECONDS:-600}"
 QUEUE_DRAIN_ATTEMPTS="${QUEUE_DRAIN_ATTEMPTS:-30}"
 QUEUE_DRAIN_SLEEP_SECONDS="${QUEUE_DRAIN_SLEEP_SECONDS:-10}"
+QUEUE_CONVERGENCE_ATTEMPTS="${QUEUE_CONVERGENCE_ATTEMPTS:-30}"
+QUEUE_CONVERGENCE_SLEEP_SECONDS="${QUEUE_CONVERGENCE_SLEEP_SECONDS:-10}"
 RUNNER_CAPACITY_MULTIPLIER="${RUNNER_CAPACITY_MULTIPLIER:-2}"
 RUNNER_CAPACITY_RESERVE_BYTES="${RUNNER_CAPACITY_RESERVE_BYTES:-2147483648}"
 SIGNATURE_SCRIPT="$SCRIPT_DIR/mongo-canonical-signature.js"
@@ -182,6 +184,7 @@ simulate() {
   for point in \
     auth-startup-before-mongo-lock mongo-write-lock \
     rabbitmq-recreate restart-auth restart-client \
+    rabbitmq-consumer-convergence \
     rabbitmq-write-lock http-write-fence-runtime \
     mongo-restart-during-public-health protected-health public-health; do
     if [[ "$fail_at" == "$point" ]]; then
@@ -1544,6 +1547,49 @@ drain_queues() {
   migration_die "$provider RabbitMQ did not drain before the bounded deadline"
 }
 
+wait_rabbitmq_consumer_convergence() {
+  local provider="$1"
+  local attempt rows count names expected backlog bad
+  local missing extra zero_consumers
+  expected="$(LC_ALL=C sort "$OCI_RABBITMQ_BASELINE_FILE")"
+  for attempt in $(seq 1 "$QUEUE_CONVERGENCE_ATTEMPTS"); do
+    rows="$(rabbit_queue_rows "$provider")"
+    count="$(awk 'NF {count++} END {print count+0}' <<<"$rows")"
+    names="$(awk '{print $1}' <<<"$rows" | LC_ALL=C sort)"
+    backlog="$(awk '{sum += $2 + $3} END {print sum+0}' <<<"$rows")"
+    bad="$(awk '$4 < 1 {bad++} END {print bad+0}' <<<"$rows")"
+    if [[ "$count" == "17" && "$names" == "$expected" &&
+      "$backlog" == "0" && "$bad" == "0" ]]; then
+      oci_log \
+        "rabbitmq_consumer_convergence=PASS provider=$provider attempt=$attempt"
+      return 0
+    fi
+    oci_log \
+      "rabbitmq_consumer_convergence=WAIT provider=$provider attempt=$attempt queue_count=$count backlog=$backlog zero_consumer_count=$bad"
+    if (( attempt < QUEUE_CONVERGENCE_ATTEMPTS )); then
+      migration_sleep "$QUEUE_CONVERGENCE_SLEEP_SECONDS"
+    fi
+  done
+
+  missing="$(
+    comm -23 \
+      <(printf '%s\n' "$expected") \
+      <(if [[ -n "$names" ]]; then printf '%s\n' "$names"; fi) |
+      paste -sd, -
+  )"
+  extra="$(
+    comm -13 \
+      <(printf '%s\n' "$expected") \
+      <(if [[ -n "$names" ]]; then printf '%s\n' "$names"; fi) |
+      paste -sd, -
+  )"
+  zero_consumers="$(
+    awk '$4 < 1 {printf "%s%s", separator, $1; separator=","}' <<<"$rows"
+  )"
+  migration_die \
+    "$provider RabbitMQ consumer topology did not converge: queue-count=$count backlog=$backlog missing=${missing:-none} extra=${extra:-none} zero-consumers=${zero_consumers:-none}"
+}
+
 applications_are_zero() {
   local provider="$1"
   local namespace service replicas
@@ -2553,7 +2599,7 @@ start_auth_before_mongo_lock() {
 }
 
 recreate_rabbitmq_and_restart() {
-  local service replicas ingress rows count names expected backlog bad
+  local service replicas ingress
   state_assert_fence
   verify_target_mongo_identity
   scale_deployment oci "$OCI_K8S_NAMESPACE" gaming-rabbitmq-depl 0
@@ -2584,15 +2630,8 @@ recreate_rabbitmq_and_restart() {
     migration_failure_hook "restart-$service"
   done
 
-  rows="$(rabbit_queue_rows oci)"
-  count="$(awk 'NF {count++} END {print count+0}' <<<"$rows")"
-  names="$(awk '{print $1}' <<<"$rows" | LC_ALL=C sort)"
-  expected="$(LC_ALL=C sort "$OCI_RABBITMQ_BASELINE_FILE")"
-  backlog="$(awk '{sum += $2 + $3} END {print sum+0}' <<<"$rows")"
-  bad="$(awk '$4 < 1 {bad++} END {print bad+0}' <<<"$rows")"
-  [[ "$count" == "17" && "$names" == "$expected" &&
-    "$backlog" == "0" && "$bad" == "0" ]] ||
-    migration_die "OCI RabbitMQ is not exact after sequential consumer restart"
+  wait_rabbitmq_consumer_convergence oci
+  migration_failure_hook rabbitmq-consumer-convergence
   lock_rabbitmq_writes
 
   ingress="$(baseline_value "$oci_baseline" ingress)"
@@ -2779,6 +2818,10 @@ validate_inputs() {
     migration_die "queue drain attempts must be positive"
   migration_is_positive_int "$QUEUE_DRAIN_SLEEP_SECONDS" ||
     migration_die "queue drain sleep must be positive"
+  migration_is_positive_int "$QUEUE_CONVERGENCE_ATTEMPTS" ||
+    migration_die "queue convergence attempts must be positive"
+  migration_is_positive_int "$QUEUE_CONVERGENCE_SLEEP_SECONDS" ||
+    migration_die "queue convergence sleep must be positive"
   migration_is_positive_int "$RUNNER_CAPACITY_MULTIPLIER" ||
     migration_die "runner capacity multiplier must be positive"
   migration_is_positive_int "$RUNNER_CAPACITY_RESERVE_BYTES" ||

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -42,6 +42,7 @@ for lesson in \
     "target-loopback tunnel" \
     "No retained backup or old-OCI rollback exists" \
     "Mongo \`fsyncLock\` is process-local" \
+    "application rollout does not prove that asynchronous RabbitMQ" \
     "Pre-commit public checks must be read-only" \
     "Never return a blind \`NO_GO\`"; do
     grep -Fq "$lesson" "$lessons" ||
@@ -65,6 +66,9 @@ grep -Fq "After \`cutover-committed\`, never retry from Azure" \
 grep -Fq "controller-level HTTP mutation fence" \
     "$ROOT_DIR/.github/agents/betstan-migration-recovery.agent.md" ||
     fail "migration recovery agent does not preserve the restart-safe HTTP fence"
+grep -Fq "bounded convergence loop for" \
+    "$ROOT_DIR/.github/agents/betstan-migration-recovery.agent.md" ||
+    fail "migration recovery agent does not require bounded RabbitMQ convergence"
 grep -Fq "https://betstan.xyz" \
     "$ROOT_DIR/.github/agents/betstan-domain-ingress.agent.md" ||
     fail "domain ingress agent lacks the canonical host"

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -84,6 +84,7 @@ done
 for point in \
   auth-startup-before-mongo-lock mongo-write-lock \
   rabbitmq-recreate restart-auth restart-client \
+  rabbitmq-consumer-convergence \
   rabbitmq-write-lock http-write-fence-runtime \
   mongo-restart-during-public-health protected-health public-health; do
   run_failure "$point" true true closed true
@@ -560,6 +561,11 @@ for literal in \
   'const lockCount=Number(result.lockCount)' \
   'retry journal Mongo write-lock state is invalid' \
   'retry Mongo write-lock state did not reconcile' \
+  'wait_rabbitmq_consumer_convergence' \
+  'rabbitmq_consumer_convergence=WAIT' \
+  'rabbitmq_consumer_convergence=PASS' \
+  'RabbitMQ consumer topology did not converge' \
+  'rabbitmq-consumer-convergence' \
   'lock_rabbitmq_writes' \
   'INGRESS_CONTROLLER_CONFIGMAP="ingress-nginx-controller"' \
   'if (\$request_method !~ ^(GET|HEAD|OPTIONS)\$)' \
@@ -614,9 +620,40 @@ rabbit_state = migration.index(
 application_loop = migration.index(
     '  for service in "${BACKEND_SERVICES[@]}" client; do', rabbit_state
 )
-rabbit_lock = migration.index("  lock_rabbitmq_writes\n", application_loop)
-if not rabbit_restart < rabbit_unlock < rabbit_state < application_loop < rabbit_lock:
+rabbit_convergence = migration.index(
+    "  wait_rabbitmq_consumer_convergence oci\n", application_loop
+)
+rabbit_convergence_failure = migration.index(
+    "  migration_failure_hook rabbitmq-consumer-convergence\n",
+    rabbit_convergence,
+)
+rabbit_lock = migration.index(
+    "  lock_rabbitmq_writes\n", rabbit_convergence_failure
+)
+if not (
+    rabbit_restart < rabbit_unlock < rabbit_state < application_loop
+    < rabbit_convergence < rabbit_convergence_failure < rabbit_lock
+):
     raise SystemExit("RabbitMQ recovery does not normalize publish permissions")
+
+convergence_start = migration.index("wait_rabbitmq_consumer_convergence() {")
+convergence_end = migration.index("\n}\n", convergence_start)
+convergence = migration[convergence_start:convergence_end]
+for required in (
+    'seq 1 "$QUEUE_CONVERGENCE_ATTEMPTS"',
+    'migration_sleep "$QUEUE_CONVERGENCE_SLEEP_SECONDS"',
+    '"$count" == "17"',
+    '"$names" == "$expected"',
+    '"$backlog" == "0"',
+    '"$bad" == "0"',
+    "missing=",
+    "extra=",
+    "zero_consumers=",
+):
+    if required not in convergence:
+        raise SystemExit(
+            f"RabbitMQ convergence gate is missing: {required}"
+        )
 PY
 [[ "$(grep -Fc 'verify_source_mongo_identity "$pod"' "$MIGRATION")" -ge 3 ]] ||
   fail "migration does not revalidate each source around capture"


### PR DESCRIPTION
## Summary
- poll for the exact 17 RabbitMQ queues, zero backlog, and consumers after sequential startup
- keep ingress closed and RabbitMQ writable until bounded convergence succeeds
- fail closed with sanitized topology diagnostics when convergence times out
- encode the incident lesson in recovery contracts and operator guidance

## Validation
- `./infra/oci/tests/test-contract.sh`
- `shellcheck -S error infra/oci/scripts/migrate-from-azure.sh infra/oci/tests/test-migration-recovery-contract.sh infra/oci/tests/test-contract.sh`