### PR TITLE
Promote batched RabbitMQ routing fence

### DIFF
--- a/.github/agents/betstan-migration-recovery.agent.md
+++ b/.github/agents/betstan-migration-recovery.agent.md
@@ -61,10 +61,12 @@ read-only and prefer the checked-in recovery workflow and scripts.
   Start passive consumers first and gamemaster last, require exact empty
   topology within 45 seconds, then remove the exact 17 application bindings as
   the routing fence. Never deny RabbitMQ write permission: declaration and
-  timer channel errors crash consumers. Bound every binding deletion to the
-  remaining pre-timer deadline. After commit, quiesce gamemaster, unlock Mongo,
-  restart passive consumers before gamemaster to restore exact bindings, verify
-  convergence, and only then remove the HTTP fence.
+  timer channel errors crash consumers. Remove the exact 17 application
+  bindings by sending their rows to one bounded in-pod deletion loop;
+  per-binding Bastion round trips can exhaust the pre-timer deadline. After
+  commit, quiesce gamemaster, unlock Mongo, restart passive consumers before
+  gamemaster to restore exact bindings, verify convergence, and only then
+  remove the HTTP fence.
   Pre-commit public checks are read-only. Record
   `cutover-committed` only after final parity under all three fences, then
   unlock idempotently and remove the HTTP fence last.

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -97,9 +97,11 @@ conversation summaries are not authority.
   permission: the resulting channel error crashes gamemaster and removes
   consumers. Instead remove the exact 17 non-default exchange-to-queue
   bindings, verify queues and consumers stay stable with zero backlog, and
-  bound each deletion to the remaining pre-timer deadline. After commit,
-  quiesce gamemaster before unlocking Mongo, then restore bindings by restarting
-  passive consumers before gamemaster.
+  execute the exact deletions as one bounded in-pod batch. A separate
+  Bastion/kubectl round trip for each binding can exhaust the pre-timer deadline
+  even after fast topology convergence. After commit, quiesce gamemaster before
+  unlocking Mongo, then restore bindings by restarting passive consumers before
+  gamemaster.
 - Pre-commit public checks must be read-only and prove the HTTP mutation fence.
   Run the mutating browser journey only after commit and fence removal; never
   let a validation write invalidate the certified source/target signatures.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -195,13 +195,14 @@ fixtures.
    and the autonomous gamemaster last, then requires the exact empty topology
    to converge within 45 seconds. It fences messaging before gamemaster's first
    60-second polling tick by removing the exact 17 application exchange
-   bindings while retaining queues, consumers, and writable declaration
-   permissions. An ACL write denial is not used because it closes application
-   channels and destabilizes consumers. Application readiness alone does not
-   certify asynchronous broker registration. Finalization rechecks parity
-   under all fences, records `cutover-committed`, quiesces the autonomous
-   gamemaster, unlocks Mongo, restores the exact bindings by restarting passive
-   consumers before gamemaster, and only then enables external writes.
+   bindings in one bounded in-pod batch while retaining queues, consumers, and
+   writable declaration permissions. An ACL write denial is not used because
+   it closes application channels and destabilizes consumers. Application
+   readiness alone does not certify asynchronous broker registration.
+   Finalization rechecks parity under all fences, records `cutover-committed`,
+   quiesces the autonomous gamemaster, unlocks Mongo, restores the exact
+   bindings by restarting passive consumers before gamemaster, and only then
+   enables external writes.
    A pre-destructive failure restores OCI workload baselines. Any later
    pre-commit failure keeps OCI closed and marks `recovery-required`; a later
    full retry clears partial application databases and starts again from

--- a/infra/oci/scripts/migrate-from-azure.sh
+++ b/infra/oci/scripts/migrate-from-azure.sh
@@ -1911,7 +1911,7 @@ normalize_rabbitmq_permissions() {
 
 lock_rabbitmq_writes() {
   local autonomous_start_epoch="$1"
-  local pod actual expected source destination properties_key elapsed remaining
+  local pod actual expected elapsed remaining
   migration_is_positive_int "$autonomous_start_epoch" ||
     migration_die "RabbitMQ autonomous producer start epoch is invalid"
   [[ "$(rabbitmq_write_permission "$autonomous_start_epoch")" == ".*" ]] ||
@@ -1929,22 +1929,26 @@ lock_rabbitmq_writes() {
   elapsed="$(( $(migration_epoch) - autonomous_start_epoch ))"
   (( elapsed < QUEUE_CONVERGENCE_DEADLINE_SECONDS )) ||
     migration_die "RabbitMQ routing fence missed the autonomous producer deadline"
-  while IFS=$'\t' read -r source destination properties_key; do
-    [[ -n "$source" && -n "$destination" && -n "$properties_key" ]] ||
-      migration_die "OCI RabbitMQ application binding row is incomplete"
-    elapsed="$(( $(migration_epoch) - autonomous_start_epoch ))"
-    remaining="$(( QUEUE_CONVERGENCE_DEADLINE_SECONDS - elapsed ))"
-    (( remaining > 0 )) ||
-      migration_die "RabbitMQ routing fence exhausted the autonomous producer deadline"
-    migration_raw rabbitmq-binding-fence "$remaining" 1 \
-      kubectl --kubeconfig "$(provider_kubeconfig oci)" \
-      exec -n "$OCI_K8S_NAMESPACE" "$pod" -- \
-      rabbitmqadmin -q delete binding \
-        source="$source" \
-        destination_type=queue \
-        destination="$destination" \
-        properties_key="$properties_key"
-  done <<<"$actual"
+  remaining="$(autonomous_deadline_remaining "$autonomous_start_epoch")"
+  migration_raw rabbitmq-binding-fence "$remaining" 1 \
+    kubectl --kubeconfig "$(provider_kubeconfig oci)" \
+    exec -i -n "$OCI_K8S_NAMESPACE" "$pod" -- \
+    sh -ceu '
+      tab="$(printf "\t")"
+      count=0
+      while IFS="$tab" read -r source destination properties_key; do
+        [ -n "$source" ] &&
+          [ -n "$destination" ] &&
+          [ "$properties_key" = "~" ]
+        rabbitmqadmin -q delete binding \
+          source="$source" \
+          destination_type=queue \
+          destination="$destination" \
+          properties_key="$properties_key"
+        count=$((count + 1))
+      done
+      [ "$count" -eq 17 ]
+    ' <<<"$actual"
   elapsed="$(( $(migration_epoch) - autonomous_start_epoch ))"
   (( elapsed < QUEUE_CONVERGENCE_DEADLINE_SECONDS )) ||
     migration_die "RabbitMQ routing fence completed after the autonomous producer deadline"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -69,6 +69,9 @@ grep -Fq "controller-level HTTP mutation fence" \
 grep -Fq "remove the exact 17 application bindings" \
     "$ROOT_DIR/.github/agents/betstan-migration-recovery.agent.md" ||
     fail "migration recovery agent does not require the RabbitMQ routing fence"
+grep -Fq "one bounded in-pod deletion loop" \
+    "$ROOT_DIR/.github/agents/betstan-migration-recovery.agent.md" ||
+    fail "migration recovery agent permits per-binding Bastion round trips"
 grep -Fq "https://betstan.xyz" \
     "$ROOT_DIR/.github/agents/betstan-domain-ingress.agent.md" ||
     fail "domain ingress agent lacks the canonical host"

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -719,8 +719,10 @@ for required in (
     "rabbitmqadmin -q delete binding",
     'rabbitmq_routing_fence_status "$autonomous_start_epoch"',
     "elapsed < QUEUE_CONVERGENCE_DEADLINE_SECONDS",
-    'remaining="$(( QUEUE_CONVERGENCE_DEADLINE_SECONDS - elapsed ))"',
+    'remaining="$(autonomous_deadline_remaining',
     'migration_raw rabbitmq-binding-fence "$remaining" 1',
+    'exec -i -n "$OCI_K8S_NAMESPACE" "$pod"',
+    '[ "$count" -eq 17 ]',
 ):
     if required not in lock:
         raise SystemExit(f"RabbitMQ routing fence is missing: {required}")


### PR DESCRIPTION
Promotes the generation 7 follow-up from dev. The exact binding set, deadline, count, and post-fence verification are unchanged; only the 17 Bastion round trips are collapsed into one bounded in-pod operation.