### PR TITLE
Promote Azure retirement hardening

### DIFF
--- a/.github/agents/betstan-azure-retirement.agent.md
+++ b/.github/agents/betstan-azure-retirement.agent.md
@@ -39,10 +39,18 @@ delete Azure while migration or OCI validation is incomplete.
 
 Use exact resource IDs and `retire-production-stan.sh`. Run `plan`, bind the
 destructive confirmation to its exact inventory digest, then run `execute`.
-Delete the AKS cluster,
-wait for its managed resource group, then remove the primary BetStan resource
-group contents, historical snapshots, load balancer/IPs, disks, alerts,
-action group, and temporary migration/recovery identities and secrets.
+The migration success field allowlist must exactly match the producer,
+including `runtime_deploy_source_sha` and `closed_recovery_retry`, and validate
+their relationship rather than ignoring new provenance. Hash Azure resource
+IDs exactly as emitted; the migration fingerprint is case-preserving.
+
+Read AKS `eTag` with its Azure casing and preserve its exact value through the
+delete intent. If an Azure CLI extension transforms the `If-Match` value, use
+the reviewed literal ARM delete request; never replace optimistic concurrency with a wildcard.
+Delete the AKS cluster, wait for its managed resource group, then remove the
+primary BetStan resource group contents, historical snapshots, load
+balancer/IPs, disks, alerts, action group, and temporary migration/recovery
+identities and secrets.
 
 If deletion is asynchronous, record the same resource identity and resume
 observation; never recreate or broaden deletion by a name pattern. Verify the

--- a/infra/azure/agents/retire-production-stan.sh
+++ b/infra/azure/agents/retire-production-stan.sh
@@ -7,6 +7,7 @@ GH_REPOSITORY="${GH_REPOSITORY:-vasilyevstan/betstan}"
 AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-betstan-rg}"
 AZURE_CLUSTER_NAME="${AZURE_CLUSTER_NAME:-betstan-aks}"
 AZURE_EXPECTED_NODE_RESOURCE_GROUP="${AZURE_EXPECTED_NODE_RESOURCE_GROUP:-MC_betstan-rg_betstan-aks_eastus}"
+AZURE_AKS_API_VERSION=2025-10-01
 MIGRATION_RUN_ID="${MIGRATION_RUN_ID:-}"
 MIGRATION_RUN_ATTEMPT="${MIGRATION_RUN_ATTEMPT:-}"
 MIGRATION_ID="${MIGRATION_ID:-}"
@@ -465,6 +466,7 @@ artifact_run_binding
 azure_cluster_resource_id_sha256
 azure_cluster_stopped_deallocated
 azure_writers_frozen
+closed_recovery_retry
 database_count
 destructive_boundary_crossed
 fencing_generation
@@ -478,6 +480,7 @@ journal_sequence
 logical_source_target_parity
 migration_id
 oci_reopened_healthy
+runtime_deploy_source_sha
 schema
 source_sha
 source_signature_aggregate_sha256
@@ -493,6 +496,27 @@ actual_summary_keys="$(
 require_summary_value schema betstan.oci-migration-success.v1
 require_summary_value migration_id "$MIGRATION_ID"
 require_summary_value source_sha "$SOURCE_SHA"
+runtime_deploy_source_sha="$(
+  env_value "$SUMMARY_FILE" runtime_deploy_source_sha
+)"
+[[ "$runtime_deploy_source_sha" =~ ^[0-9a-f]{40}$ ]] ||
+  die "runtime deployment source SHA is invalid"
+closed_recovery_retry="$(
+  env_value "$SUMMARY_FILE" closed_recovery_retry
+)"
+case "$closed_recovery_retry" in
+  false)
+    [[ "$runtime_deploy_source_sha" == "$SOURCE_SHA" ]] ||
+      die "ordinary migration runtime deployment SHA differs"
+    ;;
+  true)
+    [[ "$runtime_deploy_source_sha" != "$SOURCE_SHA" ]] ||
+      die "closed-recovery runtime deployment SHA was not an ancestor"
+    ;;
+  *)
+    die "closed-recovery retry flag is invalid"
+    ;;
+esac
 require_summary_value github_run_id "$MIGRATION_RUN_ID"
 require_summary_value github_run_attempt "$MIGRATION_RUN_ATTEMPT"
 require_summary_value artifact_run_binding \
@@ -562,7 +586,7 @@ else
     --name "$AZURE_CLUSTER_NAME" -o json > "$cluster_json"
   cluster_id="$(jq -r .id "$cluster_json")"
   cluster_id_digest="$(
-    printf '%s' "$cluster_id" | tr '[:upper:]' '[:lower:]' | sha256_text
+    printf '%s' "$cluster_id" | sha256_text
   )"
   [[ "$cluster_id_digest" == "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256" ]] ||
     die "live AKS resource identity differs from the approved fingerprint"
@@ -572,7 +596,7 @@ else
   [[ "$live_power_state" == "Stopped" ||
     "$live_power_state" == "Deallocated" ]] ||
     die "AKS control plane is not stopped"
-  CLUSTER_ETAG="$(jq -r '.etag // empty' "$cluster_json")"
+  CLUSTER_ETAG="$(jq -r '.eTag // .etag // empty' "$cluster_json")"
   [[ -n "$CLUSTER_ETAG" ]] ||
     die "live AKS ETag is missing"
 
@@ -648,23 +672,20 @@ while true; do
         --name "$AZURE_CLUSTER_NAME" -o json > "$cluster_json"
       live_cluster_id="$(jq -r '.id // empty' "$cluster_json")"
       live_cluster_digest="$(
-        printf '%s' "$live_cluster_id" |
-          tr '[:upper:]' '[:lower:]' |
-          sha256_text
+        printf '%s' "$live_cluster_id" | sha256_text
       )"
       [[ "$live_cluster_digest" == "$AZURE_EXPECTED_CLUSTER_RESOURCE_ID_SHA256" ]] ||
         die "AKS identity changed after delete intent"
       provisioning_state="$(jq -r '.provisioningState // empty' "$cluster_json")"
-      live_etag="$(jq -r '.etag // empty' "$cluster_json")"
+      live_etag="$(jq -r '.eTag // .etag // empty' "$cluster_json")"
       if [[ "$provisioning_state" != "Deleting" ]]; then
         [[ "$live_etag" == "$CLUSTER_ETAG" ]] ||
           die "AKS ETag changed after delete intent"
-        az aks delete \
-          --subscription "$AZURE_SUBSCRIPTION_ID" \
-          --resource-group "$AZURE_RESOURCE_GROUP" \
-          --name "$AZURE_CLUSTER_NAME" \
-          --if-match "$CLUSTER_ETAG" \
-          --yes --no-wait
+        az rest \
+          --method delete \
+          --url "${live_cluster_id}?api-version=${AZURE_AKS_API_VERSION}" \
+          --headers "If-Match=${CLUSTER_ETAG}" \
+          --output none
       fi
       write_state aks-delete-submitted
       ;;

--- a/infra/azure/agents/test-retire-production-stan.sh
+++ b/infra/azure/agents/test-retire-production-stan.sh
@@ -146,7 +146,7 @@ case "${1:-} ${2:-}" in
       --arg id "$STUB_CLUSTER_ID" \
       --arg power "${STUB_AKS_POWER_STATE:-Stopped}" '{
       id:$id,
-      etag:"fixture-etag",
+      eTag:"fixture-etag",
       nodeResourceGroup:"MC_betstan-rg_betstan-aks_eastus",
       powerState:{code:$power},
       provisioningState:"Failed"
@@ -208,6 +208,24 @@ case "${1:-} ${2:-}" in
     printf '%s\n' aks-absent > "$STUB_DELETE_PHASE_FILE"
     [[ "${STUB_CRASH_POINT:-}" != "aks" ]] || exit 99
     ;;
+  "rest --method")
+    method=""
+    url=""
+    header=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --method) method="$2"; shift 2 ;;
+        --url) url="$2"; shift 2 ;;
+        --headers) header="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    [[ "$method" == "delete" ]]
+    [[ "$url" == "${STUB_CLUSTER_ID}?api-version=2025-10-01" ]]
+    [[ "$header" == "If-Match=fixture-etag" ]]
+    printf '%s\n' aks-absent > "$STUB_DELETE_PHASE_FILE"
+    [[ "${STUB_CRASH_POINT:-}" != "aks" ]] || exit 99
+    ;;
   *)
     printf 'unexpected az call: %s\n' "$*" >&2
     exit 1
@@ -259,10 +277,18 @@ elif [[ "${1:-} ${2:-}" == "run download" ]]; then
     target_signature="$(printf 'b%.0s' {1..64})"
   fence_removed=true
   [[ "${STUB_FENCE_RETAINED:-0}" != "1" ]] || fence_removed=false
+  runtime_deploy_source_sha="${STUB_RUNTIME_DEPLOY_SOURCE_SHA:-${STUB_SOURCE_SHA}}"
+  [[ "${STUB_BAD_RUNTIME_SHA:-0}" != "1" ]] ||
+    runtime_deploy_source_sha=invalid
+  closed_recovery_retry="${STUB_CLOSED_RECOVERY_RETRY:-false}"
+  [[ "${STUB_BAD_CLOSED_RECOVERY:-0}" != "1" ]] ||
+    closed_recovery_retry=invalid
   cat > "$directory/migration-summary.env" <<ENV
 schema=betstan.oci-migration-success.v1
 migration_id=migration-fixture
 source_sha=${STUB_SOURCE_SHA}
+runtime_deploy_source_sha=${runtime_deploy_source_sha}
+closed_recovery_retry=${closed_recovery_retry}
 github_run_id=123
 github_run_attempt=1
 terminal_phase=DEPLOYED_HEALTHY
@@ -360,6 +386,8 @@ operation="${1:-}"
 shift || true
 case "$operation" in
   s_client)
+    IFS= read -r command
+    [[ "$command" == "Q" ]]
     printf '%s\n' fixture-certificate
     ;;
   x509)
@@ -391,7 +419,6 @@ chmod +x "$BIN_DIR/openssl"
 
 cluster_digest="$(
   printf '%s' "$CLUSTER_ID" |
-    tr '[:upper:]' '[:lower:]' |
     shasum -a 256 |
     awk '{print $1}'
 )"
@@ -437,12 +464,16 @@ run_plan() {
 : > "$WORK_DIR/az.log"
 run_plan "$WORK_DIR/good" |
   grep -Eq '^azure_retirement=READY_TO_CONFIRM inventory_sha256=[0-9a-f]{64} resources=28$'
-! grep -Eq 'aks delete|group delete' "$WORK_DIR/az.log" ||
+! grep -Eq 'aks delete|rest --method delete|group delete' "$WORK_DIR/az.log" ||
   { echo "plan mode issued a destructive Azure command" >&2; exit 1; }
 
 run_plan "$WORK_DIR/deallocated" STUB_AKS_POWER_STATE=Deallocated |
   grep -Eq '^azure_retirement=READY_TO_CONFIRM inventory_sha256=[0-9a-f]{64} resources=28$'
 run_plan "$WORK_DIR/empty-vmss" STUB_EMPTY_VMSS=1 |
+  grep -Eq '^azure_retirement=READY_TO_CONFIRM inventory_sha256=[0-9a-f]{64} resources=28$'
+run_plan "$WORK_DIR/closed-recovery" \
+    STUB_CLOSED_RECOVERY_RETRY=true \
+    STUB_RUNTIME_DEPLOY_SOURCE_SHA=2222222222222222222222222222222222222222 |
   grep -Eq '^azure_retirement=READY_TO_CONFIRM inventory_sha256=[0-9a-f]{64} resources=28$'
 if run_plan "$WORK_DIR/running-control-plane" STUB_AKS_POWER_STATE=Running \
     >"$WORK_DIR/running-control-plane.out" 2>&1; then
@@ -453,7 +484,8 @@ grep -Fq 'NO_GO azure_retirement_reason=' "$WORK_DIR/running-control-plane.out"
 
 for failure_mode in \
   STUB_BAD_RUN STUB_BAD_PARITY STUB_UNKNOWN_RESOURCE STUB_RUNNING_VMSS \
-  STUB_WRONG_SUBSCRIPTION STUB_GROUP_API_FAIL STUB_FENCE_RETAINED; do
+  STUB_WRONG_SUBSCRIPTION STUB_GROUP_API_FAIL STUB_FENCE_RETAINED \
+  STUB_BAD_RUNTIME_SHA STUB_BAD_CLOSED_RECOVERY; do
   if run_plan "$WORK_DIR/${failure_mode}" "$failure_mode=1" \
       >"$WORK_DIR/${failure_mode}.out" 2>&1; then
     echo "retirement fixture unexpectedly passed: $failure_mode" >&2
@@ -461,6 +493,14 @@ for failure_mode in \
   fi
   grep -Fq 'NO_GO azure_retirement_reason=' "$WORK_DIR/${failure_mode}.out"
 done
+if run_plan "$WORK_DIR/inconsistent-closed-recovery" \
+    STUB_CLOSED_RECOVERY_RETRY=true \
+    >"$WORK_DIR/inconsistent-closed-recovery.out" 2>&1; then
+  echo "retirement fixture accepted inconsistent closed-recovery provenance" >&2
+  exit 1
+fi
+grep -Fq 'NO_GO azure_retirement_reason=' \
+  "$WORK_DIR/inconsistent-closed-recovery.out"
 
 printf '%s\n' initial > "$WORK_DIR/delete-phase"
 plan_output="$(run_plan "$WORK_DIR/delete-plan")"
@@ -479,7 +519,7 @@ run_plan "$WORK_DIR/delete-execute" --execute \
   ABSENCE_VERIFY_LOOPS=2 \
   ABSENCE_VERIFY_SLEEP_SECONDS=0 |
   grep -qx 'AZURE_RESOURCES_RETIRED cost_verification=pending_delayed_reporting'
-grep -Fq 'aks delete' "$WORK_DIR/az.log"
+grep -Fq 'rest --method delete' "$WORK_DIR/az.log"
 grep -Eq 'group delete .*--name MC_betstan-rg_betstan-aks_eastus' "$WORK_DIR/az.log"
 grep -Eq 'group delete .*--name betstan-rg' "$WORK_DIR/az.log"
 grep -qx 'phase=retired' "$WORK_DIR/delete-execute/retirement-state.env"
@@ -518,4 +558,4 @@ for crash_point in aks managed primary; do
     grep -qx 'AZURE_RESOURCES_RETIRED cost_verification=pending_delayed_reporting'
 done
 
-printf 'azure_retirement_contract=PASS scenarios=16\n'
+printf 'azure_retirement_contract=PASS scenarios=20\n'

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -146,6 +146,20 @@ conversation summaries are not authority.
 - Azure retirement is complete only after the AKS and managed resource groups,
   VMs/VMSS, disks, snapshots, load balancers, public IPs, alerts, and temporary
   identities are absent. CLI acceptance is not resource absence.
+- Keep retirement's strict migration-success field allowlist synchronized with
+  the producer. Recovery retries add runtime deployment lineage fields; accept
+  them only with their exact names and validate the retry flag against the
+  runtime and active source SHAs.
+- Azure resource-ID fingerprints are case-preserving. Do not lowercase the
+  live AKS ID before comparing it with migration and recovery evidence.
+- Current AKS output exposes `eTag`, not only `etag`. Some `aks-preview`
+  versions quote a supplied UUID before sending `If-Match`, although the AKS
+  delete endpoint requires the exact emitted value. Preserve the reviewed
+  ETag literally through an ARM delete request; never fall back to `*`.
+- macOS LibreSSL can finish a verified `s_client` handshake and then exit with
+  `poll error` when stdin is `/dev/null`. Send its graceful `Q` command so the
+  trust-verifying pipeline remains fail-closed without rejecting a valid
+  certificate.
 - Delayed historical charges are not current resources. Continue bounded
   Cost Management checks until no new BetStan usage appears.
 

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -254,4 +254,5 @@ inventory digest, then pass that digest and exact confirmation to `execute`.
 The operator deletes AKS first, resumes asynchronous deletion by fenced phase,
 removes only the two exact resource groups, and verifies subscription-wide
 absence twice. It reports resource retirement separately from delayed Cost
-Management completion.
+Management completion. AKS resource fingerprints and ETags are
+case-preserving; do not normalize or wildcard either value.

--- a/infra/oci/agents/smoke-liveness-stan.sh
+++ b/infra/oci/agents/smoke-liveness-stan.sh
@@ -81,11 +81,12 @@ require_served_certificate() {
   shift 2
   local certificate="$WORK_DIR/${label}.certificate.pem"
   local issuer san_text
-  openssl s_client \
-    -connect "${host}:443" \
-    -servername "$host" \
-    -verify_return_error \
-    -showcerts </dev/null 2>"$WORK_DIR/${label}.openssl.log" |
+  printf 'Q\n' |
+    openssl s_client \
+      -connect "${host}:443" \
+      -servername "$host" \
+      -verify_return_error \
+      -showcerts 2>"$WORK_DIR/${label}.openssl.log" |
     openssl x509 -out "$certificate" ||
     fail "$label did not serve a trusted parseable certificate"
   issuer="$(openssl x509 -in "$certificate" -noout -issuer)"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -78,6 +78,12 @@ grep -Fq "https://betstan.xyz" \
 grep -Fq "A successful delete command alone is not" \
     "$ROOT_DIR/.github/agents/betstan-azure-retirement.agent.md" ||
     fail "Azure retirement agent trusts delete acceptance"
+grep -Fq 'runtime_deploy_source_sha' \
+    "$ROOT_DIR/.github/agents/betstan-azure-retirement.agent.md" ||
+    fail "Azure retirement agent omits recovery deployment lineage"
+grep -Fq 'never replace optimistic concurrency with a wildcard' \
+    "$ROOT_DIR/.github/agents/betstan-azure-retirement.agent.md" ||
+    fail "Azure retirement agent permits an unfenced AKS delete"
 retirement_operator="$ROOT_DIR/infra/azure/agents/retire-production-stan.sh"
 [[ -x "$retirement_operator" ]] ||
   fail "checked-in Azure retirement operator is missing or not executable"
@@ -89,12 +95,13 @@ for retirement_contract in \
     'http_mutation_fence_removed true' \
     'azure_cluster_stopped_deallocated true' \
     'validate_initial_inventory "$INITIAL_INVENTORY_FILE"' \
-    'az aks delete' \
+    'az rest' \
+    '--headers "If-Match=${CLUSTER_ETAG}"' \
     'wait_for_cluster_absence' \
     'validate_inventory_subset "$CURRENT_INVENTORY_FILE"' \
     'verify_subscription_absence' \
     'AZURE_RESOURCES_RETIRED cost_verification=pending_delayed_reporting'; do
-    grep -Fq "$retirement_contract" "$retirement_operator" ||
+    grep -Fq -- "$retirement_contract" "$retirement_operator" ||
       fail "Azure retirement operator omits contract: $retirement_contract"
 done
 ! grep -Eq 'az (ad|role)|gh secret (delete|set)|oci |kubectl ' \


### PR DESCRIPTION
Promotes the live-proven retirement contract fixes from `dev` to `master`.

- exact closed-recovery provenance consumption
- case-preserving AKS identity and literal ETag fencing
- portable trusted certificate probing
- regression contracts and operator lessons

Source PR: #211