### PR TITLE
chore: pin common package at 1.0.54

### DIFF
--- a/auth/package-lock.json
+++ b/auth/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@betstan/common": "^1.0.54",
+        "@betstan/common": "1.0.54",
         "@types/cookie-session": "^2.0.48",
         "@types/jsonwebtoken": "^9.0.5",
         "cookie-session": "^2.0.0",

--- a/auth/package.json
+++ b/auth/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@betstan/common": "^1.0.54",
+    "@betstan/common": "1.0.54",
     "@types/cookie-session": "^2.0.48",
     "@types/jsonwebtoken": "^9.0.5",
     "cookie-session": "^2.0.0",

--- a/backoffice/package-lock.json
+++ b/backoffice/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@betstan/common": "^1.0.54",
+        "@betstan/common": "1.0.54",
         "@types/cookie-session": "^2.0.48",
         "@types/express": "^4.17.21",
         "cookie-session": "^2.0.0",

--- a/backoffice/package.json
+++ b/backoffice/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@betstan/common": "^1.0.54",
+    "@betstan/common": "1.0.54",
     "@types/cookie-session": "^2.0.48",
     "@types/express": "^4.17.21",
     "cookie-session": "^2.0.0",

--- a/bet/package-lock.json
+++ b/bet/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@betstan/common": "^1.0.54",
+        "@betstan/common": "1.0.54",
         "@types/cookie-session": "^2.0.48",
         "@types/express": "^4.17.21",
         "cookie-session": "^2.0.0",

--- a/bet/package.json
+++ b/bet/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@betstan/common": "^1.0.54",
+    "@betstan/common": "1.0.54",
     "@types/cookie-session": "^2.0.48",
     "@types/express": "^4.17.21",
     "cookie-session": "^2.0.0",

--- a/event/package-lock.json
+++ b/event/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@betstan/common": "^1.0.54",
+        "@betstan/common": "1.0.54",
         "@faker-js/faker": "^8.2.0",
         "@types/amqplib": "^0.10.4",
         "@types/cookie-session": "^2.0.48",

--- a/event/package.json
+++ b/event/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@betstan/common": "^1.0.54",
+    "@betstan/common": "1.0.54",
     "@faker-js/faker": "^8.2.0",
     "@types/amqplib": "^0.10.4",
     "@types/cookie-session": "^2.0.48",

--- a/gamemaster/package-lock.json
+++ b/gamemaster/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@betstan/common": "^1.0.54",
+        "@betstan/common": "1.0.54",
         "@faker-js/faker": "^8.4.1",
         "mongoose": "^8.0.4",
         "ts-node-dev": "^2.0.0",

--- a/gamemaster/package.json
+++ b/gamemaster/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@betstan/common": "^1.0.54",
+    "@betstan/common": "1.0.54",
     "@faker-js/faker": "^8.4.1",
     "mongoose": "^8.0.4",
     "ts-node-dev": "^2.0.0",

--- a/moderation/package-lock.json
+++ b/moderation/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@betstan/common": "^1.0.54",
+        "@betstan/common": "1.0.54",
         "mongoose": "^8.0.4",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.3.3"

--- a/moderation/package.json
+++ b/moderation/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@betstan/common": "^1.0.54",
+    "@betstan/common": "1.0.54",
     "mongoose": "^8.0.4",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"

--- a/resulting/package-lock.json
+++ b/resulting/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@betstan/common": "^1.0.54",
+        "@betstan/common": "1.0.54",
         "mongoose": "^8.0.4",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.3.3"

--- a/resulting/package.json
+++ b/resulting/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@betstan/common": "^1.0.54",
+    "@betstan/common": "1.0.54",
     "mongoose": "^8.0.4",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"

--- a/slip/package-lock.json
+++ b/slip/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@betstan/common": "^1.0.54",
+        "@betstan/common": "1.0.54",
         "@types/cookie-session": "^2.0.48",
         "@types/express": "^4.17.21",
         "axios": "^1.6.1",

--- a/slip/package.json
+++ b/slip/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@betstan/common": "^1.0.54",
+    "@betstan/common": "1.0.54",
     "@types/cookie-session": "^2.0.48",
     "@types/express": "^4.17.21",
     "axios": "^1.6.1",


### PR DESCRIPTION
## Summary
- pin `@betstan/common` to exact `1.0.54` across backend consumers
- regenerate lockfiles without changing resolved package contents
- remove caret drift before the additive live-contract prerelease

## Validation
- deployment-safety review: SAFE_TO_REVIEW
- branch is intentionally prerequisite-only; no live feature code

## Release order
Merge through `dev` and `master` before publishing or consuming `1.1.0-rc.1`.