### PR TITLE
ci: authorize live production workflow blob

### DIFF
--- a/.github/scripts/publish-pr-policy.js
+++ b/.github/scripts/publish-pr-policy.js
@@ -5,6 +5,10 @@ const QUALITY_CONTEXT_PREFIX = "pr-quality-gates";
 const QUALITY_JOB = "pr-quality-gates";
 const QUALITY_WORKFLOW = "production-build.yml";
 const QUALITY_WORKFLOW_PATH = `.github/workflows/${QUALITY_WORKFLOW}`;
+// Remove this one-use authorization before promoting the workflow update.
+const APPROVED_QUALITY_WORKFLOW_BLOBS = new Set([
+  "68c4d8801689b71a4b1a5e37ee24a405f981d24d",
+]);
 
 const sleep = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -173,7 +177,10 @@ async function qualityDecision({
     };
   }
 
-  if (trustedBlob !== headBlob) {
+  if (
+    trustedBlob !== headBlob &&
+    !APPROVED_QUALITY_WORKFLOW_BLOBS.has(headBlob)
+  ) {
     return {
       state: "failure",
       description: `PR #${pull.number} changes the trusted quality workflow`,

--- a/.github/scripts/test-publish-pr-policy.js
+++ b/.github/scripts/test-publish-pr-policy.js
@@ -150,6 +150,12 @@ async function main() {
   assert.equal(changedWorkflow.statuses[2].state, "failure");
   assert.equal(changedWorkflow.statuses[3].state, "failure");
 
+  const approvedWorkflow = await execute({
+    headBlob: "68c4d8801689b71a4b1a5e37ee24a405f981d24d",
+  });
+  assert.equal(approvedWorkflow.statuses[2].state, "success");
+  assert.equal(approvedWorkflow.statuses[3].state, "success");
+
   const qualityCompletion = await execute({ eventName: "workflow_run" });
   assert.deepEqual(
     qualityCompletion.statuses.map(({ context, state, sha }) => ({


### PR DESCRIPTION
## Summary
- authorize exactly Git blob `68c4d8801689b71a4b1a5e37ee24a405f981d24d` for `production-build.yml`
- add the matching trusted-publisher test
- preserve rejection for every other changed workflow blob

## Purpose
One-use bootstrap required by `CONTRIBUTING.md` so live-betting PR #219 can be validated by the protected default-branch publisher.

## Scope
Only `.github/scripts/publish-pr-policy.js` and its test change. The authorization must be removed after #219 reaches `dev` and before `dev` is promoted to `master`.