### PR TITLE
ci: remove live workflow blob authorization

### DIFF
--- a/.github/scripts/publish-pr-policy.js
+++ b/.github/scripts/publish-pr-policy.js
@@ -5,10 +5,6 @@ const QUALITY_CONTEXT_PREFIX = "pr-quality-gates";
 const QUALITY_JOB = "pr-quality-gates";
 const QUALITY_WORKFLOW = "production-build.yml";
 const QUALITY_WORKFLOW_PATH = `.github/workflows/${QUALITY_WORKFLOW}`;
-// Remove this one-use authorization before promoting the workflow update.
-const APPROVED_QUALITY_WORKFLOW_BLOBS = new Set([
-  "68c4d8801689b71a4b1a5e37ee24a405f981d24d",
-]);
 
 const sleep = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -177,10 +173,7 @@ async function qualityDecision({
     };
   }
 
-  if (
-    trustedBlob !== headBlob &&
-    !APPROVED_QUALITY_WORKFLOW_BLOBS.has(headBlob)
-  ) {
+  if (trustedBlob !== headBlob) {
     return {
       state: "failure",
       description: `PR #${pull.number} changes the trusted quality workflow`,

--- a/.github/scripts/test-publish-pr-policy.js
+++ b/.github/scripts/test-publish-pr-policy.js
@@ -150,12 +150,6 @@ async function main() {
   assert.equal(changedWorkflow.statuses[2].state, "failure");
   assert.equal(changedWorkflow.statuses[3].state, "failure");
 
-  const approvedWorkflow = await execute({
-    headBlob: "68c4d8801689b71a4b1a5e37ee24a405f981d24d",
-  });
-  assert.equal(approvedWorkflow.statuses[2].state, "success");
-  assert.equal(approvedWorkflow.statuses[3].state, "success");
-
   const qualityCompletion = await execute({ eventName: "workflow_run" });
   assert.deepEqual(
     qualityCompletion.statuses.map(({ context, state, sha }) => ({


### PR DESCRIPTION
## Summary
- remove the one-use trusted workflow blob authorization after live betting merged to `dev`
- restore strict default-branch workflow blob equality
- remove the temporary positive exception test

## Validation
- `node .github/scripts/test-publish-pr-policy.js`