### PR TITLE
ci: restore production build and safe CLI approvals

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -34,7 +34,9 @@ Inspect the current git graph and remote default branch. Do not infer that a mer
 - Commits and pushes to non-`master` branches do not deploy production.
 - Never commit or push directly to `master`, even with generic user approval.
 - Normal changes enter `dev`. Only an up-to-date pull request from `dev` may promote to `master`.
-- Never merge a `dev`-to-`master` promotion, manually dispatch or rerun any production-capable workflow, initiate or directly apply any production deployment, rerun a production deployment, or initiate rollback without explicit user approval for the exact target SHA and the complete set of production-capable workflows that action will trigger.
+- For a PR created and labelled `copilot-cli-managed` by the active Copilot CLI workflow, continue without a separate human prompt only after the exact-SHA automated approval gates pass. Work without that provenance requires explicit user approval for the exact target SHA and complete production-capable workflow set.
+- Automatic approval never waives required checks, trusted workflow provenance, resolved review threads, production-run exclusivity, immutable image identity, rollback readiness, or post-deploy verification.
+- Use `copilot-cli-run-approval-stan.sh` for protected build/deploy environments in automatic mode. Never auto-approve rollback, migration, infrastructure, stale-master, rerun, unlabelled, or competing workflow activity.
 - Keep changes on a focused branch and integrate them into `dev` before production promotion.
 - After a squash promotion, immediately merge the new `master` commit back into `dev` and verify ancestry.
 - Do not amend, rewrite, reset, or force-push history unless explicitly requested.
@@ -132,7 +134,7 @@ A Running broker with missing consumers is not healthy production.
 
 - Use `branch-policy-guard-stan.sh` to reject unsupported base/head pairs.
 - Use `pr-validation-stan.sh` to verify the exact current head, base, unique merge snapshot, and trusted workflow identities.
-- Use `pr-merge-safety-stan.sh` for a conservative recommendation.
+- Use `COPILOT_CLI_AUTO_APPROVE=true pr-merge-safety-stan.sh` only for PRs created and labelled `copilot-cli-managed` by the active CLI workflow. Use normal human-approval mode for every other PR.
 - Treat skipped, stale, pending, neutral, or branch-name-only runs as non-success.
 - Separate infrastructure failures from unrelated application-test failures; never hide either.
 - Do not broaden or narrow CI scope merely to manufacture a green result.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Use this flow:
 
 Never push directly to `dev`; integrate focused feature, fix, or operations branches through pull requests. Pull requests into `master` from any branch other than `dev` are forbidden.
 
-Copilot CLI-created pull requests carry the `copilot-cli-managed` label. They may use `COPILOT_CLI_AUTO_APPROVE=true` only after the merge-safety script verifies the label, exact refs, trusted required checks, resolved review threads, production workflow inventory, and absence of competing production activity. Unlabelled pull requests and work created outside Copilot CLI require explicit human approval. Automatic mode never skips required checks or immutable-SHA gates.
+Copilot CLI-created pull requests carry the `copilot-cli-managed` label. They may use `COPILOT_CLI_AUTO_APPROVE=true` only after the merge-safety script verifies the label, exact refs, trusted required checks, resolved review threads, production workflow inventory, and absence of actionable competing production activity. Unlabelled pull requests and work created outside Copilot CLI require explicit human approval. Automatic mode never skips required checks or immutable-SHA gates.
 
 Protected environment approval for CLI-managed work uses `copilot-cli-run-approval-stan.sh`. It additionally requires current `master`, a single associated labelled `dev` promotion, first-attempt workflow provenance, the exact expected environment, and no competing production workflow. Automatic approval is limited to normal application build/deploy workflows; rollback, migration, and infrastructure workflows remain human-gated.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,14 @@ Use this flow:
 2. Validate the complete `dev` branch.
 3. Promote production only with an up-to-date pull request from `dev` to `master`.
 4. Require the trusted, base-scoped `branch-policy/master` and `pr-quality-gates/master` statuses on both the promotion head and current merge snapshot to pass.
-5. Before merging a promotion, obtain explicit approval for the exact head SHA and every production-capable workflow the diff will trigger.
+5. Before merging a promotion, bind approval to the exact head SHA and every production-capable workflow the diff will trigger.
 6. After a squash promotion, immediately merge the new `master` commit back into `dev`.
 
 Never push directly to `dev`; integrate focused feature, fix, or operations branches through pull requests. Pull requests into `master` from any branch other than `dev` are forbidden.
+
+Copilot CLI-created pull requests carry the `copilot-cli-managed` label. They may use `COPILOT_CLI_AUTO_APPROVE=true` only after the merge-safety script verifies the label, exact refs, trusted required checks, resolved review threads, production workflow inventory, and absence of competing production activity. Unlabelled pull requests and work created outside Copilot CLI require explicit human approval. Automatic mode never skips required checks or immutable-SHA gates.
+
+Protected environment approval for CLI-managed work uses `copilot-cli-run-approval-stan.sh`. It additionally requires current `master`, a single associated labelled `dev` promotion, first-attempt workflow provenance, the exact expected environment, and no competing production workflow. Automatic approval is limited to normal application build/deploy workflows; rollback, migration, and infrastructure workflows remain human-gated.
 
 ## Production safety
 

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -15,6 +15,7 @@
 - `production-workflow-inventory-stan.sh` — derives and validates the exact governed Azure-plus-OCI production workflow set matched by a promotion diff.
 - `pr-validation-stan.sh` — inspects trusted required checks for a PR's exact head SHA.
 - `pr-merge-safety-stan.sh` — combines branch policy, exact-SHA validation, mergeability, and production approval gates.
+- `copilot-cli-run-approval-stan.sh` — fail-closed protected-environment approval for normal CLI-managed build/deploy runs.
 - `post-merge-verification-stan.sh` — verifies merged commit workflow success plus production health across both public hosts.
 - `rollback-readiness-stan.sh` — emits explicit rollback go/no-go based on current health, queue pressure, and rollout history.
 - `node-logs-stan.sh` — node-level health/events + pod error-log extraction.
@@ -237,6 +238,7 @@ Use the merge-safety agent when you want a conservative yes/no recommendation:
 
 ```bash
 ./infra/azure/agents/pr-merge-safety-stan.sh 41
+COPILOT_CLI_AUTO_APPROVE=true ./infra/azure/agents/pr-merge-safety-stan.sh 41
 ```
 
 The validation agent:
@@ -248,7 +250,25 @@ The merge-safety agent:
 - rejects unsupported branch pairs;
 - requires matching trusted runs on the current head and merge snapshots;
 - recommends a `dev` merge only when validation is green;
-- requires `APPROVED_SHA` and `APPROVED_WORKFLOWS` before recommending a production promotion.
+- requires `APPROVED_SHA` and `APPROVED_WORKFLOWS` before recommending a human-managed production promotion;
+- allows automatic mode only for a `copilot-cli-managed` PR with resolved reviews and no competing production run.
+
+For a normal CLI-managed build/deploy environment gate, validate first and mutate only after the dry-run succeeds:
+
+```bash
+EXPECTED_SHA=<current-master-sha> \
+EXPECTED_WORKFLOW=production-build.yml \
+EXPECTED_ENVIRONMENT=production-emergency \
+./infra/azure/agents/copilot-cli-run-approval-stan.sh <run-id>
+
+COPILOT_CLI_AUTO_APPROVE=true \
+EXPECTED_SHA=<current-master-sha> \
+EXPECTED_WORKFLOW=production-build.yml \
+EXPECTED_ENVIRONMENT=production-emergency \
+./infra/azure/agents/copilot-cli-run-approval-stan.sh <run-id> --approve
+```
+
+The approver rejects stale master SHAs, reruns, unlabelled promotions, unexpected workflows/environments, and competing production activity. It does not support automatic rollback, migration, or infrastructure approval.
 
 ## Post-merge production verification
 

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -16,6 +16,7 @@
 - `pr-validation-stan.sh` — inspects trusted required checks for a PR's exact head SHA.
 - `pr-merge-safety-stan.sh` — combines branch policy, exact-SHA validation, mergeability, and production approval gates.
 - `copilot-cli-run-approval-stan.sh` — fail-closed protected-environment approval for normal CLI-managed build/deploy runs.
+- `production-run-exclusivity-stan.sh` — blocks actionable concurrent production runs while identifying inert disabled queue records.
 - `post-merge-verification-stan.sh` — verifies merged commit workflow success plus production health across both public hosts.
 - `rollback-readiness-stan.sh` — emits explicit rollback go/no-go based on current health, queue pressure, and rollout history.
 - `node-logs-stan.sh` — node-level health/events + pod error-log extraction.
@@ -268,7 +269,7 @@ EXPECTED_ENVIRONMENT=production-emergency \
 ./infra/azure/agents/copilot-cli-run-approval-stan.sh <run-id> --approve
 ```
 
-The approver rejects stale master SHAs, reruns, unlabelled promotions, unexpected workflows/environments, and competing production activity. It does not support automatic rollback, migration, or infrastructure approval.
+The approver rejects stale master SHAs, reruns, unlabelled promotions, unexpected workflows/environments, and actionable competing production activity. Disabled records are ignored only when they are old and have no jobs or pending environments. Automatic rollback, migration, and infrastructure approval is unsupported.
 
 ## Post-merge production verification
 

--- a/infra/azure/agents/copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/copilot-cli-run-approval-stan.sh
@@ -18,6 +18,7 @@ EXPECTED_WORKFLOW="${EXPECTED_WORKFLOW:-}"
 EXPECTED_ENVIRONMENT="${EXPECTED_ENVIRONMENT:-}"
 CLI_MANAGED_LABEL="${COPILOT_CLI_MANAGED_LABEL:-copilot-cli-managed}"
 AUTO_APPROVE="${COPILOT_CLI_AUTO_APPROVE:-false}"
+PRODUCTION_RUN_EXCLUSIVITY="${PRODUCTION_RUN_EXCLUSIVITY:-./infra/azure/agents/production-run-exclusivity-stan.sh}"
 
 fail() {
   echo "safe_to_approve=no"
@@ -137,51 +138,8 @@ then
   fail "current master is not bound to one merged CLI-managed dev promotion"
 fi
 
-active_runs="$(
-  for status in queued in_progress waiting requested pending; do
-    gh api "repos/$REPO/actions/runs?status=$status&per_page=100"
-  done
-)"
-if ! python3 - "$active_runs" "$RUN_ID" <<'PY'
-import json
-import sys
-
-current_run = sys.argv[2]
-paths = {
-    ".github/workflows/production-build.yml",
-    ".github/workflows/production-deploy.yml",
-    ".github/workflows/production-rollback.yml",
-    ".github/workflows/oci-production-build.yml",
-    ".github/workflows/oci-production-deploy.yml",
-    ".github/workflows/oci-production-rollback.yml",
-    ".github/workflows/oci-infrastructure.yml",
-    ".github/workflows/oci-capacity-acquire.yml",
-    ".github/workflows/oci-migrate.yml",
-    ".github/workflows/oci-migration-recovery.yml",
-}
-decoder = json.JSONDecoder()
-payload = sys.argv[1]
-index = 0
-while index < len(payload):
-    while index < len(payload) and payload[index].isspace():
-        index += 1
-    if index >= len(payload):
-        break
-    response, index = decoder.raw_decode(payload, index)
-    if response.get("total_count", 0) > 100:
-        raise SystemExit("more than 100 active runs requires manual review")
-    for run in response.get("workflow_runs", []):
-        if str(run.get("id", "")) == current_run:
-            continue
-        if run.get("path") in paths and run.get("head_branch") == "master":
-            raise SystemExit(
-                f"active production run {run.get('id')} path={run.get('path')} "
-                f"status={run.get('status')}"
-            )
-PY
-then
-  fail "another production-capable workflow is active"
-fi
+REPO="$REPO" EXCLUDE_RUN_ID="$RUN_ID" "$PRODUCTION_RUN_EXCLUSIVITY" ||
+  fail "another actionable production-capable workflow is active"
 
 pending_json="$(read_pending)"
 environment_id="$(

--- a/infra/azure/agents/copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/copilot-cli-run-approval-stan.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Purpose: fail-closed validation and optional approval of a normal
+#          Copilot CLI-managed production build or application deploy gate.
+# Usage:
+#   EXPECTED_SHA=<sha> EXPECTED_WORKFLOW=production-build.yml \
+#     EXPECTED_ENVIRONMENT=production-emergency \
+#     ./infra/azure/agents/copilot-cli-run-approval-stan.sh <run-id>
+#   COPILOT_CLI_AUTO_APPROVE=true ... \
+#     ./infra/azure/agents/copilot-cli-run-approval-stan.sh <run-id> --approve
+
+REPO="${REPO:-vasilyevstan/betstan}"
+RUN_ID="${1:-${RUN_ID:-}}"
+ACTION="${2:-}"
+EXPECTED_SHA="${EXPECTED_SHA:-}"
+EXPECTED_WORKFLOW="${EXPECTED_WORKFLOW:-}"
+EXPECTED_ENVIRONMENT="${EXPECTED_ENVIRONMENT:-}"
+CLI_MANAGED_LABEL="${COPILOT_CLI_MANAGED_LABEL:-copilot-cli-managed}"
+AUTO_APPROVE="${COPILOT_CLI_AUTO_APPROVE:-false}"
+
+fail() {
+  echo "safe_to_approve=no"
+  echo "reason=$*" >&2
+  exit 1
+}
+
+[[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "run ID must be a positive integer"
+[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+  fail "EXPECTED_SHA must be a complete lowercase SHA"
+[[ "$AUTO_APPROVE" == "true" || "$AUTO_APPROVE" == "false" ]] ||
+  fail "COPILOT_CLI_AUTO_APPROVE must be true or false"
+[[ -z "$ACTION" || "$ACTION" == "--approve" ]] ||
+  fail "the only supported action is --approve"
+if [[ "$ACTION" == "--approve" && "$AUTO_APPROVE" != "true" ]]; then
+  fail "--approve requires COPILOT_CLI_AUTO_APPROVE=true"
+fi
+
+case "$EXPECTED_WORKFLOW:$EXPECTED_ENVIRONMENT" in
+  production-build.yml:production-emergency)
+    expected_event="push"
+    ;;
+  production-deploy.yml:production-emergency)
+    expected_event="workflow_dispatch"
+    ;;
+  oci-production-build.yml:oci-build)
+    expected_event="workflow_run"
+    ;;
+  oci-production-deploy.yml:oci-production)
+    expected_event="workflow_dispatch"
+    ;;
+  *)
+    fail "workflow/environment pair is not eligible for automatic approval"
+    ;;
+esac
+
+read_master_sha() {
+  gh api "repos/$REPO/git/ref/heads/master" |
+    python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+print((payload.get("object") or {}).get("sha", ""))
+'
+}
+
+read_run() {
+  gh api "repos/$REPO/actions/runs/$RUN_ID"
+}
+
+read_pending() {
+  gh api "repos/$REPO/actions/runs/$RUN_ID/pending_deployments"
+}
+
+validate_run() {
+  python3 - "$1" "$RUN_ID" "$REPO" "$EXPECTED_SHA" \
+    "$EXPECTED_WORKFLOW" "$expected_event" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+run_id, repository, sha, workflow, event = sys.argv[2:]
+failures = []
+if str(payload.get("id", "")) != run_id:
+    failures.append("run ID changed")
+if payload.get("path") != f".github/workflows/{workflow}":
+    failures.append("workflow path mismatch")
+if payload.get("event") != event:
+    failures.append("workflow event mismatch")
+if payload.get("head_sha") != sha:
+    failures.append("run SHA mismatch")
+if payload.get("head_branch") != "master":
+    failures.append("run is not bound to master")
+if (payload.get("head_repository") or {}).get("full_name") != repository:
+    failures.append("run belongs to another repository")
+if payload.get("run_attempt") != 1:
+    failures.append("only first-attempt runs are eligible")
+if payload.get("status") not in {"queued", "in_progress", "waiting", "pending"}:
+    failures.append("run is not awaiting execution or approval")
+if failures:
+    raise SystemExit("; ".join(failures))
+PY
+}
+
+master_sha="$(read_master_sha)"
+[[ "$master_sha" == "$EXPECTED_SHA" ]] ||
+  fail "EXPECTED_SHA is no longer current master"
+
+run_json="$(read_run)"
+validate_run "$run_json" || fail "run provenance validation failed"
+
+promotion_json="$(gh api "repos/$REPO/commits/$EXPECTED_SHA/pulls")"
+if ! python3 - "$promotion_json" "$EXPECTED_SHA" "$CLI_MANAGED_LABEL" <<'PY'
+import json
+import sys
+
+pulls = json.loads(sys.argv[1])
+sha = sys.argv[2]
+label = sys.argv[3]
+matches = []
+for pull in pulls:
+    labels = {entry.get("name") for entry in pull.get("labels", [])}
+    if (
+        pull.get("merged_at")
+        and pull.get("merge_commit_sha") == sha
+        and (pull.get("base") or {}).get("ref") == "master"
+        and (pull.get("head") or {}).get("ref") == "dev"
+        and label in labels
+    ):
+        matches.append(pull.get("number"))
+if len(matches) != 1:
+    raise SystemExit(f"expected one CLI-managed promotion, found {matches}")
+print(f"promotion_pr={matches[0]}")
+PY
+then
+  fail "current master is not bound to one merged CLI-managed dev promotion"
+fi
+
+active_runs="$(
+  for status in queued in_progress waiting requested pending; do
+    gh api "repos/$REPO/actions/runs?status=$status&per_page=100"
+  done
+)"
+if ! python3 - "$active_runs" "$RUN_ID" <<'PY'
+import json
+import sys
+
+current_run = sys.argv[2]
+paths = {
+    ".github/workflows/production-build.yml",
+    ".github/workflows/production-deploy.yml",
+    ".github/workflows/production-rollback.yml",
+    ".github/workflows/oci-production-build.yml",
+    ".github/workflows/oci-production-deploy.yml",
+    ".github/workflows/oci-production-rollback.yml",
+    ".github/workflows/oci-infrastructure.yml",
+    ".github/workflows/oci-capacity-acquire.yml",
+    ".github/workflows/oci-migrate.yml",
+    ".github/workflows/oci-migration-recovery.yml",
+}
+decoder = json.JSONDecoder()
+payload = sys.argv[1]
+index = 0
+while index < len(payload):
+    while index < len(payload) and payload[index].isspace():
+        index += 1
+    if index >= len(payload):
+        break
+    response, index = decoder.raw_decode(payload, index)
+    if response.get("total_count", 0) > 100:
+        raise SystemExit("more than 100 active runs requires manual review")
+    for run in response.get("workflow_runs", []):
+        if str(run.get("id", "")) == current_run:
+            continue
+        if run.get("path") in paths and run.get("head_branch") == "master":
+            raise SystemExit(
+                f"active production run {run.get('id')} path={run.get('path')} "
+                f"status={run.get('status')}"
+            )
+PY
+then
+  fail "another production-capable workflow is active"
+fi
+
+pending_json="$(read_pending)"
+environment_id="$(
+  python3 - "$pending_json" "$EXPECTED_ENVIRONMENT" <<'PY'
+import json
+import sys
+
+pending = json.loads(sys.argv[1])
+expected = sys.argv[2]
+if len(pending) != 1:
+    raise SystemExit(f"expected one pending environment, found {len(pending)}")
+entry = pending[0]
+environment = entry.get("environment") or {}
+if environment.get("name") != expected:
+    raise SystemExit(
+        f"expected environment {expected}, found {environment.get('name')}"
+    )
+if entry.get("current_user_can_approve") is not True:
+    raise SystemExit("current user cannot approve the environment")
+environment_id = environment.get("id")
+if not isinstance(environment_id, int) or environment_id <= 0:
+    raise SystemExit("pending environment ID is invalid")
+print(environment_id)
+PY
+)" || fail "pending environment validation failed"
+
+[[ "$(read_master_sha)" == "$EXPECTED_SHA" ]] ||
+  fail "master changed while approval gates were running"
+latest_run_json="$(read_run)"
+validate_run "$latest_run_json" || fail "run changed while approval gates were running"
+latest_pending_json="$(read_pending)"
+[[ "$latest_pending_json" == "$pending_json" ]] ||
+  fail "pending environment changed while approval gates were running"
+
+echo "safe_to_approve=yes"
+echo "run_id=$RUN_ID"
+echo "sha=$EXPECTED_SHA"
+echo "workflow=$EXPECTED_WORKFLOW"
+echo "environment=$EXPECTED_ENVIRONMENT"
+
+if [[ "$ACTION" == "--approve" ]]; then
+  gh api --method POST \
+    "repos/$REPO/actions/runs/$RUN_ID/pending_deployments" \
+    -F "environment_ids[]=$environment_id" \
+    -f state=approved \
+    -f comment="Copilot CLI automatic approval after exact-SHA safety gates passed." \
+    >/dev/null
+  echo "approved=yes"
+else
+  echo "approved=no"
+fi

--- a/infra/azure/agents/pr-merge-safety-stan.sh
+++ b/infra/azure/agents/pr-merge-safety-stan.sh
@@ -6,13 +6,27 @@ set -euo pipefail
 #   ./infra/azure/agents/pr-merge-safety-stan.sh 41
 #   APPROVED_SHA=<sha> APPROVED_WORKFLOWS=production-build,production-deploy \
 #     ./infra/azure/agents/pr-merge-safety-stan.sh 41
+#   COPILOT_CLI_AUTO_APPROVE=true ./infra/azure/agents/pr-merge-safety-stan.sh 41
 
 REPO="${REPO:-vasilyevstan/betstan}"
 PR_NUMBER="${1:-${PR:-}}"
+AUTO_APPROVE="${COPILOT_CLI_AUTO_APPROVE:-false}"
+CLI_MANAGED_LABEL="${COPILOT_CLI_MANAGED_LABEL:-copilot-cli-managed}"
+BRANCH_POLICY_GUARD="${BRANCH_POLICY_GUARD:-./infra/azure/agents/branch-policy-guard-stan.sh}"
+PR_VALIDATOR="${PR_VALIDATOR:-./infra/azure/agents/pr-validation-stan.sh}"
+WORKFLOW_INVENTORY="${WORKFLOW_INVENTORY:-./infra/azure/agents/production-workflow-inventory-stan.sh}"
 if [[ -z "$PR_NUMBER" ]]; then
   echo "usage: $0 <pr-number>" >&2
   exit 1
 fi
+[[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || {
+  echo "pull request number must be a positive integer" >&2
+  exit 1
+}
+[[ "$AUTO_APPROVE" == "true" || "$AUTO_APPROVE" == "false" ]] || {
+  echo "COPILOT_CLI_AUTO_APPROVE must be true or false" >&2
+  exit 1
+}
 
 section() {
   printf '\n=== %s ===\n' "$1"
@@ -27,7 +41,7 @@ fail() {
 
 meta_json="$(
   gh pr view "$PR_NUMBER" --repo "$REPO" \
-    --json number,title,state,mergeable,mergeStateStatus,headRefName,headRefOid,headRepository,baseRefName,baseRefOid,url
+    --json number,title,state,mergeable,mergeStateStatus,headRefName,headRefOid,headRepository,baseRefName,baseRefOid,labels,url
 )"
 mergeable="$(python3 - <<'PY' "$meta_json"
 import json,sys
@@ -75,6 +89,12 @@ repo=json.loads(sys.argv[1]).get("headRepository") or {}
 print(repo.get("nameWithOwner",""))
 PY
 )"
+cli_managed="$(python3 - <<'PY' "$meta_json" "$CLI_MANAGED_LABEL"
+import json,sys
+labels = json.loads(sys.argv[1]).get("labels") or []
+print("yes" if any(label.get("name") == sys.argv[2] for label in labels) else "no")
+PY
+)"
 
 section "pr"
 echo "title=$title"
@@ -86,16 +106,60 @@ echo "head_sha=$head_sha"
 echo "head_repository=$head_repository"
 echo "base_ref=$base_ref"
 echo "base_sha=$base_sha"
+echo "cli_managed=$cli_managed"
 
 [[ "$state" == "OPEN" ]] || fail "pull request is not open"
 [[ "$mergeable" == "MERGEABLE" ]] || fail "pull request is not currently mergeable"
+if [[ "$AUTO_APPROVE" == "true" ]]; then
+  [[ "$cli_managed" == "yes" ]] ||
+    fail "automatic approval requires the $CLI_MANAGED_LABEL label"
+  [[ "$head_repository" == "$REPO" ]] ||
+    fail "automatic approval requires a branch in $REPO"
+fi
+
+owner="${REPO%%/*}"
+repository="${REPO#*/}"
+review_threads="$(
+  gh api graphql \
+    -f query='
+      query($owner: String!, $repository: String!, $number: Int!) {
+        repository(owner: $owner, name: $repository) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100) {
+              pageInfo { hasNextPage }
+              nodes { isResolved }
+            }
+          }
+        }
+      }
+    ' \
+    -f owner="$owner" \
+    -f repository="$repository" \
+    -F number="$PR_NUMBER"
+)"
+python3 - "$review_threads" <<'PY' || fail "pull request has unresolved or unbounded review threads"
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+threads = (
+    payload.get("data", {})
+    .get("repository", {})
+    .get("pullRequest", {})
+    .get("reviewThreads", {})
+)
+if threads.get("pageInfo", {}).get("hasNextPage"):
+    raise SystemExit("more than 100 review threads requires manual review")
+if any(not thread.get("isResolved", False) for thread in threads.get("nodes", [])):
+    raise SystemExit("unresolved review thread")
+PY
 
 BASE_REF="$base_ref" HEAD_REF="$head_ref" REPOSITORY="$REPO" \
   HEAD_REPOSITORY="$head_repository" \
-  ./infra/azure/agents/branch-policy-guard-stan.sh || fail "branch policy rejected the pull request"
+  "$BRANCH_POLICY_GUARD" || fail "branch policy rejected the pull request"
 
 REPO="$REPO" EXPECTED_HEAD_SHA="$head_sha" EXPECTED_BASE_SHA="$base_sha" \
-  ./infra/azure/agents/pr-validation-stan.sh "$PR_NUMBER" ||
+  "$PR_VALIDATOR" "$PR_NUMBER" ||
   fail "exact-head-SHA validation still has failed or incomplete jobs"
 
 if [[ "$base_ref" == "master" ]]; then
@@ -108,19 +172,66 @@ if [[ "$base_ref" == "master" ]]; then
   )"
   [[ "$compare_status" == "ahead" || "$compare_status" == "identical" ]] ||
     fail "current master tip is not an ancestor of the promotion head status=$compare_status"
-  [[ "${APPROVED_SHA:-}" == "$head_sha" ]] ||
-    fail "production promotion requires APPROVED_SHA=$head_sha"
+
+  active_runs="$(
+    for status in queued in_progress waiting requested pending; do
+      gh api "repos/$REPO/actions/runs?status=$status&per_page=100"
+    done
+  )"
+  python3 - "$active_runs" <<'PY' || fail "another production-capable workflow is active"
+import json
+import sys
+
+paths = {
+    ".github/workflows/production-build.yml",
+    ".github/workflows/production-deploy.yml",
+    ".github/workflows/production-rollback.yml",
+    ".github/workflows/oci-production-build.yml",
+    ".github/workflows/oci-production-deploy.yml",
+    ".github/workflows/oci-production-rollback.yml",
+    ".github/workflows/oci-infrastructure.yml",
+    ".github/workflows/oci-capacity-acquire.yml",
+    ".github/workflows/oci-migrate.yml",
+    ".github/workflows/oci-migration-recovery.yml",
+}
+decoder = json.JSONDecoder()
+payload = sys.argv[1]
+index = 0
+while index < len(payload):
+    while index < len(payload) and payload[index].isspace():
+        index += 1
+    if index >= len(payload):
+        break
+    response, index = decoder.raw_decode(payload, index)
+    if response.get("total_count", 0) > 100:
+        raise SystemExit("more than 100 active runs requires manual review")
+    for run in response.get("workflow_runs", []):
+        if run.get("path") in paths and run.get("head_branch") == "master":
+            raise SystemExit(
+                f"active production run {run.get('id')} path={run.get('path')} "
+                f"status={run.get('status')}"
+            )
+PY
+
   expected_workflows="$(
     REPO="$REPO" PR="$PR_NUMBER" EXPECTED_HEAD_SHA="$head_sha" \
-      ./infra/azure/agents/production-workflow-inventory-stan.sh |
+      "$WORKFLOW_INVENTORY" |
       sed -n 's/^production_workflows=//p'
   )"
-  approved_workflows="$(
-    tr ',' '\n' <<<"${APPROVED_WORKFLOWS:-}" |
-      sed '/^$/d' |
-      LC_ALL=C sort -u |
-      paste -sd, -
-  )"
+  if [[ "$AUTO_APPROVE" == "true" ]]; then
+    approved_sha="$head_sha"
+    approved_workflows="$expected_workflows"
+  else
+    approved_sha="${APPROVED_SHA:-}"
+    approved_workflows="$(
+      tr ',' '\n' <<<"${APPROVED_WORKFLOWS:-}" |
+        sed '/^$/d' |
+        LC_ALL=C sort -u |
+        paste -sd, -
+    )"
+  fi
+  [[ "$approved_sha" == "$head_sha" ]] ||
+    fail "production promotion requires APPROVED_SHA=$head_sha"
   [[ "$approved_workflows" == "$expected_workflows" ]] ||
     fail "production workflow approval mismatch expected=$expected_workflows approved=${approved_workflows:-none}"
 fi
@@ -143,4 +254,5 @@ PY
 
 section "recommendation"
 echo "safe_to_merge=yes"
+echo "approval_mode=$([[ "$AUTO_APPROVE" == "true" ]] && echo copilot-cli || echo human)"
 echo "reason=branch policy, mergeability, exact-SHA validation, and required approval gates passed"

--- a/infra/azure/agents/pr-merge-safety-stan.sh
+++ b/infra/azure/agents/pr-merge-safety-stan.sh
@@ -15,6 +15,7 @@ CLI_MANAGED_LABEL="${COPILOT_CLI_MANAGED_LABEL:-copilot-cli-managed}"
 BRANCH_POLICY_GUARD="${BRANCH_POLICY_GUARD:-./infra/azure/agents/branch-policy-guard-stan.sh}"
 PR_VALIDATOR="${PR_VALIDATOR:-./infra/azure/agents/pr-validation-stan.sh}"
 WORKFLOW_INVENTORY="${WORKFLOW_INVENTORY:-./infra/azure/agents/production-workflow-inventory-stan.sh}"
+PRODUCTION_RUN_EXCLUSIVITY="${PRODUCTION_RUN_EXCLUSIVITY:-./infra/azure/agents/production-run-exclusivity-stan.sh}"
 if [[ -z "$PR_NUMBER" ]]; then
   echo "usage: $0 <pr-number>" >&2
   exit 1
@@ -173,45 +174,8 @@ if [[ "$base_ref" == "master" ]]; then
   [[ "$compare_status" == "ahead" || "$compare_status" == "identical" ]] ||
     fail "current master tip is not an ancestor of the promotion head status=$compare_status"
 
-  active_runs="$(
-    for status in queued in_progress waiting requested pending; do
-      gh api "repos/$REPO/actions/runs?status=$status&per_page=100"
-    done
-  )"
-  python3 - "$active_runs" <<'PY' || fail "another production-capable workflow is active"
-import json
-import sys
-
-paths = {
-    ".github/workflows/production-build.yml",
-    ".github/workflows/production-deploy.yml",
-    ".github/workflows/production-rollback.yml",
-    ".github/workflows/oci-production-build.yml",
-    ".github/workflows/oci-production-deploy.yml",
-    ".github/workflows/oci-production-rollback.yml",
-    ".github/workflows/oci-infrastructure.yml",
-    ".github/workflows/oci-capacity-acquire.yml",
-    ".github/workflows/oci-migrate.yml",
-    ".github/workflows/oci-migration-recovery.yml",
-}
-decoder = json.JSONDecoder()
-payload = sys.argv[1]
-index = 0
-while index < len(payload):
-    while index < len(payload) and payload[index].isspace():
-        index += 1
-    if index >= len(payload):
-        break
-    response, index = decoder.raw_decode(payload, index)
-    if response.get("total_count", 0) > 100:
-        raise SystemExit("more than 100 active runs requires manual review")
-    for run in response.get("workflow_runs", []):
-        if run.get("path") in paths and run.get("head_branch") == "master":
-            raise SystemExit(
-                f"active production run {run.get('id')} path={run.get('path')} "
-                f"status={run.get('status')}"
-            )
-PY
+  REPO="$REPO" "$PRODUCTION_RUN_EXCLUSIVITY" ||
+    fail "another actionable production-capable workflow is active"
 
   expected_workflows="$(
     REPO="$REPO" PR="$PR_NUMBER" EXPECTED_HEAD_SHA="$head_sha" \

--- a/infra/azure/agents/pre-commit-infra-check-stan.sh
+++ b/infra/azure/agents/pre-commit-infra-check-stan.sh
@@ -24,7 +24,7 @@ fail() {
 }
 
 current_branch="${BRANCH_NAME:-$(git branch --show-current 2>/dev/null || true)}"
-if [[ "$current_branch" == "master" ]]; then
+if [[ "$current_branch" == "master" && "${GITHUB_ACTIONS:-false}" != "true" ]]; then
   echo "ERROR: direct work on master is forbidden; switch to dev or a branch based on dev" >&2
   echo "RESULT=BLOCKED"
   exit 1

--- a/infra/azure/agents/production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/production-run-exclusivity-stan.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Purpose: block concurrent production-capable activity while ignoring only
+#          old, disabled GitHub queue records proven to have no jobs or gates.
+
+REPO="${REPO:-vasilyevstan/betstan}"
+EXCLUDE_RUN_ID="${EXCLUDE_RUN_ID:-}"
+STALE_DISABLED_MIN_AGE_SECONDS="${STALE_DISABLED_MIN_AGE_SECONDS:-600}"
+NOW_EPOCH="${NOW_EPOCH:-$(date +%s)}"
+
+[[ -z "$EXCLUDE_RUN_ID" || "$EXCLUDE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+  echo "EXCLUDE_RUN_ID must be empty or a positive integer" >&2
+  exit 1
+}
+[[ "$STALE_DISABLED_MIN_AGE_SECONDS" =~ ^[1-9][0-9]*$ ]] || {
+  echo "STALE_DISABLED_MIN_AGE_SECONDS must be a positive integer" >&2
+  exit 1
+}
+[[ "$NOW_EPOCH" =~ ^[1-9][0-9]*$ ]] || {
+  echo "NOW_EPOCH must be a positive integer" >&2
+  exit 1
+}
+
+tmp_runs="$(mktemp)"
+tmp_candidates="$(mktemp)"
+cleanup() {
+  rm -f "$tmp_runs" "$tmp_candidates"
+}
+trap cleanup EXIT
+
+for status in queued in_progress waiting requested pending; do
+  gh api "repos/$REPO/actions/runs?status=$status&per_page=100" >>"$tmp_runs"
+  printf '\n' >>"$tmp_runs"
+done
+
+python3 - "$tmp_runs" >"$tmp_candidates" <<'PY'
+import json
+import sys
+
+paths = {
+    ".github/workflows/production-build.yml",
+    ".github/workflows/production-deploy.yml",
+    ".github/workflows/production-rollback.yml",
+    ".github/workflows/oci-production-build.yml",
+    ".github/workflows/oci-production-deploy.yml",
+    ".github/workflows/oci-production-rollback.yml",
+    ".github/workflows/oci-infrastructure.yml",
+    ".github/workflows/oci-capacity-acquire.yml",
+    ".github/workflows/oci-migrate.yml",
+    ".github/workflows/oci-migration-recovery.yml",
+}
+decoder = json.JSONDecoder()
+payload = open(sys.argv[1], encoding="utf-8").read()
+index = 0
+seen = set()
+while index < len(payload):
+    while index < len(payload) and payload[index].isspace():
+        index += 1
+    if index >= len(payload):
+        break
+    response, index = decoder.raw_decode(payload, index)
+    if response.get("total_count", 0) > 100:
+        raise SystemExit("more than 100 active runs requires manual review")
+    for run in response.get("workflow_runs", []):
+        run_id = run.get("id")
+        if (
+            run_id in seen
+            or run.get("path") not in paths
+            or run.get("head_branch") != "master"
+        ):
+            continue
+        seen.add(run_id)
+        values = (
+            run_id,
+            run.get("workflow_id"),
+            run.get("path"),
+            run.get("status"),
+            run.get("updated_at"),
+        )
+        if (
+            not isinstance(run_id, int)
+            or not isinstance(run.get("workflow_id"), int)
+            or any(not isinstance(value, str) or not value for value in values[2:])
+        ):
+            raise SystemExit("active run metadata is malformed")
+        print("\t".join(str(value) for value in values))
+PY
+
+while IFS=$'\t' read -r run_id workflow_id path status updated_at; do
+  [[ -n "${run_id:-}" ]] || continue
+  if [[ "$run_id" == "$EXCLUDE_RUN_ID" ]]; then
+    continue
+  fi
+
+  workflow_json="$(gh api "repos/$REPO/actions/workflows/$workflow_id")"
+  jobs_json="$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=1")"
+  pending_json="$(gh api "repos/$REPO/actions/runs/$run_id/pending_deployments")"
+  classification="$(
+    python3 - "$workflow_json" "$jobs_json" "$pending_json" "$updated_at" \
+      "$NOW_EPOCH" "$STALE_DISABLED_MIN_AGE_SECONDS" <<'PY'
+import datetime
+import json
+import sys
+
+workflow = json.loads(sys.argv[1])
+jobs = json.loads(sys.argv[2])
+pending = json.loads(sys.argv[3])
+updated_at = datetime.datetime.fromisoformat(sys.argv[4].replace("Z", "+00:00"))
+now = datetime.datetime.fromtimestamp(int(sys.argv[5]), datetime.timezone.utc)
+minimum_age = int(sys.argv[6])
+state = workflow.get("state")
+job_count = jobs.get("total_count")
+if not isinstance(state, str) or not isinstance(job_count, int) or not isinstance(pending, list):
+    raise SystemExit("production run actionability metadata is malformed")
+age_seconds = int((now - updated_at).total_seconds())
+inert = (
+    state.startswith("disabled_")
+    and job_count == 0
+    and len(pending) == 0
+    and age_seconds >= minimum_age
+)
+print(
+    f"inert={'yes' if inert else 'no'} state={state} jobs={job_count} "
+    f"pending={len(pending)} age_seconds={age_seconds}"
+)
+PY
+  )"
+  if [[ "$classification" == inert=yes* ]]; then
+    echo "ignored_inert_run=$run_id path=$path status=$status $classification"
+    continue
+  fi
+
+  echo "active production run $run_id path=$path status=$status $classification" >&2
+  exit 1
+done <"$tmp_candidates"
+
+echo "production_run_exclusivity=PASS"

--- a/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
@@ -5,11 +5,18 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 APPROVER="$ROOT_DIR/infra/azure/agents/copilot-cli-run-approval-stan.sh"
 SHA="1111111111111111111111111111111111111111"
 RUN_ID=123
-approval_log="$(mktemp)"
+tmp_dir="$(mktemp -d)"
+approval_log="$tmp_dir/approval.log"
 cleanup() {
-  rm -f "$approval_log"
+  rm -rf "$tmp_dir"
 }
 trap cleanup EXIT
+
+cat >"$tmp_dir/production-exclusivity" <<'SH'
+#!/usr/bin/env bash
+[[ "${STUB_ACTIVE:-false}" != "true" ]]
+SH
+chmod +x "$tmp_dir/production-exclusivity"
 
 gh() {
   if [[ "$*" == *"--method POST"* ]]; then
@@ -33,16 +40,6 @@ gh() {
     fi
     printf '%s\n' \
       "[{\"number\":225,\"merged_at\":\"2026-08-21T00:00:00Z\",\"merge_commit_sha\":\"$SHA\",\"base\":{\"ref\":\"master\"},\"head\":{\"ref\":\"dev\"},\"labels\":$labels}]"
-  elif [[ "$1" == "api" && "$2" == *"/actions/runs?status="* ]]; then
-    if [[ "${STUB_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
-      printf '%s\n' \
-        '{"total_count":1,"workflow_runs":[{"id":999,"path":".github/workflows/production-deploy.yml","head_branch":"master","status":"in_progress"}]}'
-    elif [[ "${STUB_PR_VALIDATION_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
-      printf '%s\n' \
-        '{"total_count":1,"workflow_runs":[{"id":998,"path":".github/workflows/production-build.yml","event":"pull_request","head_branch":"dev","status":"in_progress"}]}'
-    else
-      printf '%s\n' "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"path\":\".github/workflows/production-build.yml\",\"head_branch\":\"master\",\"status\":\"waiting\"}]}"
-    fi
   else
     echo "unexpected gh invocation: $*" >&2
     return 1
@@ -56,12 +53,10 @@ common_env=(
   "EXPECTED_SHA=$SHA"
   "EXPECTED_WORKFLOW=production-build.yml"
   "EXPECTED_ENVIRONMENT=production-emergency"
+  "PRODUCTION_RUN_EXCLUSIVITY=$tmp_dir/production-exclusivity"
 )
 
 env "${common_env[@]}" "$APPROVER" "$RUN_ID" >/dev/null
-
-env "${common_env[@]}" STUB_PR_VALIDATION_ACTIVE=true \
-  "$APPROVER" "$RUN_ID" >/dev/null
 
 env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
   "$APPROVER" "$RUN_ID" --approve >/dev/null

--- a/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+APPROVER="$ROOT_DIR/infra/azure/agents/copilot-cli-run-approval-stan.sh"
+SHA="1111111111111111111111111111111111111111"
+RUN_ID=123
+approval_log="$(mktemp)"
+cleanup() {
+  rm -f "$approval_log"
+}
+trap cleanup EXIT
+
+gh() {
+  if [[ "$*" == *"--method POST"* ]]; then
+    [[ "$*" == *"environment_ids[]=456"* ]]
+    [[ "$*" == *"state=approved"* ]]
+    [[ "$*" == *"Copilot CLI automatic approval"* ]]
+    printf 'approved\n' >>"$STUB_APPROVAL_LOG"
+    printf '%s\n' '[{"environment":"production-emergency","state":"approved"}]'
+  elif [[ "$1" == "api" && "$2" == *"/git/ref/heads/master"* ]]; then
+    printf '%s\n' "{\"object\":{\"sha\":\"${STUB_MASTER_SHA:-$SHA}\"}}"
+  elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID/pending_deployments"* ]]; then
+    printf '%s\n' \
+      "[{\"environment\":{\"id\":456,\"name\":\"${STUB_ENVIRONMENT:-production-emergency}\"},\"current_user_can_approve\":true}]"
+  elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID" ]]; then
+    printf '%s\n' \
+      "{\"id\":$RUN_ID,\"path\":\".github/workflows/${STUB_WORKFLOW:-production-build.yml}\",\"event\":\"push\",\"head_sha\":\"$SHA\",\"head_branch\":\"master\",\"head_repository\":{\"full_name\":\"example/repo\"},\"run_attempt\":${STUB_ATTEMPT:-1},\"status\":\"waiting\"}"
+  elif [[ "$1" == "api" && "$2" == *"/commits/$SHA/pulls"* ]]; then
+    local labels='[{"name":"copilot-cli-managed"}]'
+    if [[ "${STUB_LABEL:-present}" == "missing" ]]; then
+      labels='[]'
+    fi
+    printf '%s\n' \
+      "[{\"number\":225,\"merged_at\":\"2026-08-21T00:00:00Z\",\"merge_commit_sha\":\"$SHA\",\"base\":{\"ref\":\"master\"},\"head\":{\"ref\":\"dev\"},\"labels\":$labels}]"
+  elif [[ "$1" == "api" && "$2" == *"/actions/runs?status="* ]]; then
+    if [[ "${STUB_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
+      printf '%s\n' \
+        '{"total_count":1,"workflow_runs":[{"id":999,"path":".github/workflows/production-deploy.yml","head_branch":"master","status":"in_progress"}]}'
+    elif [[ "${STUB_PR_VALIDATION_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
+      printf '%s\n' \
+        '{"total_count":1,"workflow_runs":[{"id":998,"path":".github/workflows/production-build.yml","event":"pull_request","head_branch":"dev","status":"in_progress"}]}'
+    else
+      printf '%s\n' "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"path\":\".github/workflows/production-build.yml\",\"head_branch\":\"master\",\"status\":\"waiting\"}]}"
+    fi
+  else
+    echo "unexpected gh invocation: $*" >&2
+    return 1
+  fi
+}
+export -f gh
+export SHA RUN_ID STUB_APPROVAL_LOG="$approval_log"
+
+common_env=(
+  "REPO=example/repo"
+  "EXPECTED_SHA=$SHA"
+  "EXPECTED_WORKFLOW=production-build.yml"
+  "EXPECTED_ENVIRONMENT=production-emergency"
+)
+
+env "${common_env[@]}" "$APPROVER" "$RUN_ID" >/dev/null
+
+env "${common_env[@]}" STUB_PR_VALIDATION_ACTIVE=true \
+  "$APPROVER" "$RUN_ID" >/dev/null
+
+env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
+  "$APPROVER" "$RUN_ID" --approve >/dev/null
+[[ "$(wc -l <"$approval_log" | tr -d ' ')" == "1" ]]
+
+if env "${common_env[@]}" STUB_LABEL=missing \
+  "$APPROVER" "$RUN_ID" >/dev/null 2>&1; then
+  echo "run approver accepted an unlabelled promotion" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" STUB_ACTIVE=true \
+  "$APPROVER" "$RUN_ID" >/dev/null 2>&1; then
+  echo "run approver accepted competing production activity" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" STUB_ATTEMPT=2 \
+  "$APPROVER" "$RUN_ID" >/dev/null 2>&1; then
+  echo "run approver accepted a rerun" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" STUB_MASTER_SHA=2222222222222222222222222222222222222222 \
+  "$APPROVER" "$RUN_ID" >/dev/null 2>&1; then
+  echo "run approver accepted a stale master SHA" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" STUB_ENVIRONMENT=unexpected \
+  "$APPROVER" "$RUN_ID" >/dev/null 2>&1; then
+  echo "run approver accepted an unexpected environment" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=false \
+  "$APPROVER" "$RUN_ID" --approve >/dev/null 2>&1; then
+  echo "run approver mutated without automatic approval mode" >&2
+  exit 1
+fi
+
+echo "copilot_cli_run_approval_tests=PASS"

--- a/infra/azure/agents/test-deployment-safety-ci-stan.sh
+++ b/infra/azure/agents/test-deployment-safety-ci-stan.sh
@@ -9,6 +9,7 @@ OCI_DEPLOY_SCRIPT="$ROOT_DIR/infra/oci/scripts/deploy.sh"
 PRE_COMMIT_CHECK="$ROOT_DIR/infra/azure/agents/pre-commit-infra-check-stan.sh"
 PR_MERGE_SAFETY_TEST="$ROOT_DIR/infra/azure/agents/test-pr-merge-safety-stan.sh"
 RUN_APPROVAL_TEST="$ROOT_DIR/infra/azure/agents/test-copilot-cli-run-approval-stan.sh"
+RUN_EXCLUSIVITY_TEST="$ROOT_DIR/infra/azure/agents/test-production-run-exclusivity-stan.sh"
 
 test_output="$(mktemp)"
 trap 'rm -f "$test_output"' EXIT
@@ -27,6 +28,7 @@ fi
 
 "$PR_MERGE_SAFETY_TEST"
 "$RUN_APPROVAL_TEST"
+"$RUN_EXCLUSIVITY_TEST"
 
 python3 - "$AZURE_WORKFLOW" "$OCI_WORKFLOW" "$BUILD_WORKFLOW" "$OCI_DEPLOY_SCRIPT" <<'PY'
 import pathlib

--- a/infra/azure/agents/test-deployment-safety-ci-stan.sh
+++ b/infra/azure/agents/test-deployment-safety-ci-stan.sh
@@ -7,6 +7,8 @@ OCI_WORKFLOW="$ROOT_DIR/.github/workflows/oci-production-deploy.yml"
 BUILD_WORKFLOW="$ROOT_DIR/.github/workflows/production-build.yml"
 OCI_DEPLOY_SCRIPT="$ROOT_DIR/infra/oci/scripts/deploy.sh"
 PRE_COMMIT_CHECK="$ROOT_DIR/infra/azure/agents/pre-commit-infra-check-stan.sh"
+PR_MERGE_SAFETY_TEST="$ROOT_DIR/infra/azure/agents/test-pr-merge-safety-stan.sh"
+RUN_APPROVAL_TEST="$ROOT_DIR/infra/azure/agents/test-copilot-cli-run-approval-stan.sh"
 
 test_output="$(mktemp)"
 trap 'rm -f "$test_output"' EXIT
@@ -22,6 +24,9 @@ if grep -qF "direct work on master is forbidden" "$test_output"; then
   echo "ERROR: GitHub Actions master validation was blocked" >&2
   exit 1
 fi
+
+"$PR_MERGE_SAFETY_TEST"
+"$RUN_APPROVAL_TEST"
 
 python3 - "$AZURE_WORKFLOW" "$OCI_WORKFLOW" "$BUILD_WORKFLOW" "$OCI_DEPLOY_SCRIPT" <<'PY'
 import pathlib

--- a/infra/azure/agents/test-deployment-safety-ci-stan.sh
+++ b/infra/azure/agents/test-deployment-safety-ci-stan.sh
@@ -6,6 +6,22 @@ AZURE_WORKFLOW="$ROOT_DIR/.github/workflows/production-deploy.yml"
 OCI_WORKFLOW="$ROOT_DIR/.github/workflows/oci-production-deploy.yml"
 BUILD_WORKFLOW="$ROOT_DIR/.github/workflows/production-build.yml"
 OCI_DEPLOY_SCRIPT="$ROOT_DIR/infra/oci/scripts/deploy.sh"
+PRE_COMMIT_CHECK="$ROOT_DIR/infra/azure/agents/pre-commit-infra-check-stan.sh"
+
+test_output="$(mktemp)"
+trap 'rm -f "$test_output"' EXIT
+
+if BRANCH_NAME=master GITHUB_ACTIONS=false "$PRE_COMMIT_CHECK" >"$test_output" 2>&1; then
+  echo "ERROR: local master pre-commit check unexpectedly passed" >&2
+  exit 1
+fi
+grep -qF "direct work on master is forbidden" "$test_output"
+
+BRANCH_NAME=master GITHUB_ACTIONS=true "$PRE_COMMIT_CHECK" >"$test_output" 2>&1
+if grep -qF "direct work on master is forbidden" "$test_output"; then
+  echo "ERROR: GitHub Actions master validation was blocked" >&2
+  exit 1
+fi
 
 python3 - "$AZURE_WORKFLOW" "$OCI_WORKFLOW" "$BUILD_WORKFLOW" "$OCI_DEPLOY_SCRIPT" <<'PY'
 import pathlib

--- a/infra/azure/agents/test-pr-merge-safety-stan.sh
+++ b/infra/azure/agents/test-pr-merge-safety-stan.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MERGE_SAFETY="$ROOT_DIR/infra/azure/agents/pr-merge-safety-stan.sh"
+HEAD_SHA="1111111111111111111111111111111111111111"
+BASE_SHA="0000000000000000000000000000000000000000"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+for helper in branch-policy pr-validator; do
+  cat >"$tmp_dir/$helper" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$tmp_dir/$helper"
+done
+
+cat >"$tmp_dir/workflow-inventory" <<'SH'
+#!/usr/bin/env bash
+echo "production_workflows=oci-production-build,production-build"
+SH
+chmod +x "$tmp_dir/workflow-inventory"
+
+gh() {
+  if [[ "$1 $2" == "pr view" ]]; then
+    if [[ "$*" == *"--json headRefOid,baseRefOid"* ]]; then
+      printf '{"headRefOid":"%s","baseRefOid":"%s"}\n' \
+        "${STUB_LATEST_HEAD_SHA:-$HEAD_SHA}" "$BASE_SHA"
+      return
+    fi
+
+    local labels='[{"name":"copilot-cli-managed"}]'
+    if [[ "${STUB_LABEL:-present}" == "missing" ]]; then
+      labels='[]'
+    fi
+    printf '%s\n' \
+      "{\"number\":224,\"title\":\"safe promotion\",\"state\":\"OPEN\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefName\":\"dev\",\"headRefOid\":\"$HEAD_SHA\",\"headRepository\":{\"nameWithOwner\":\"example/repo\"},\"baseRefName\":\"master\",\"baseRefOid\":\"$BASE_SHA\",\"labels\":$labels,\"url\":\"https://example.invalid/pr/224\"}"
+  elif [[ "$1 $2" == "api graphql" ]]; then
+    local nodes='[]'
+    if [[ "${STUB_UNRESOLVED:-false}" == "true" ]]; then
+      nodes='[{"isResolved":false}]'
+    fi
+    printf '%s\n' \
+      "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"pageInfo\":{\"hasNextPage\":false},\"nodes\":$nodes}}}}}"
+  elif [[ "$1" == "api" && "$2" == *"/compare/"* ]]; then
+    echo "ahead"
+  elif [[ "$1" == "api" && "$2" == *"/actions/runs?status="* ]]; then
+    if [[ "${STUB_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
+      printf '%s\n' \
+        '{"total_count":1,"workflow_runs":[{"id":999,"path":".github/workflows/production-deploy.yml","head_branch":"master","status":"in_progress"}]}'
+    elif [[ "${STUB_PR_VALIDATION_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
+      printf '%s\n' \
+        '{"total_count":1,"workflow_runs":[{"id":998,"path":".github/workflows/production-build.yml","event":"pull_request","head_branch":"dev","status":"in_progress"}]}'
+    else
+      printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
+    fi
+  else
+    echo "unexpected gh invocation: $*" >&2
+    return 1
+  fi
+}
+export -f gh
+export HEAD_SHA BASE_SHA
+
+common_env=(
+  "REPO=example/repo"
+  "BRANCH_POLICY_GUARD=$tmp_dir/branch-policy"
+  "PR_VALIDATOR=$tmp_dir/pr-validator"
+  "WORKFLOW_INVENTORY=$tmp_dir/workflow-inventory"
+)
+
+env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
+  "$MERGE_SAFETY" 224 >/dev/null
+
+env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
+  STUB_PR_VALIDATION_ACTIVE=true "$MERGE_SAFETY" 224 >/dev/null
+
+if env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true STUB_LABEL=missing \
+  "$MERGE_SAFETY" 224 >/dev/null 2>&1; then
+  echo "automatic merge safety accepted an unlabelled PR" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true STUB_UNRESOLVED=true \
+  "$MERGE_SAFETY" 224 >/dev/null 2>&1; then
+  echo "automatic merge safety accepted an unresolved review thread" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true STUB_ACTIVE=true \
+  "$MERGE_SAFETY" 224 >/dev/null 2>&1; then
+  echo "automatic merge safety accepted competing production activity" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
+  STUB_LATEST_HEAD_SHA=2222222222222222222222222222222222222222 \
+  "$MERGE_SAFETY" 224 >/dev/null 2>&1; then
+  echo "automatic merge safety accepted a changed PR head" >&2
+  exit 1
+fi
+
+if env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=false \
+  "$MERGE_SAFETY" 224 >/dev/null 2>&1; then
+  echo "manual merge safety passed without explicit approval" >&2
+  exit 1
+fi
+
+env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=false \
+  APPROVED_SHA="$HEAD_SHA" \
+  APPROVED_WORKFLOWS=production-build,oci-production-build \
+  "$MERGE_SAFETY" 224 >/dev/null
+
+if env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
+  "$MERGE_SAFETY" not-a-number >/dev/null 2>&1; then
+  echo "merge safety accepted a non-numeric PR identifier" >&2
+  exit 1
+fi
+
+echo "pr_merge_safety_tests=PASS"

--- a/infra/azure/agents/test-pr-merge-safety-stan.sh
+++ b/infra/azure/agents/test-pr-merge-safety-stan.sh
@@ -26,6 +26,12 @@ echo "production_workflows=oci-production-build,production-build"
 SH
 chmod +x "$tmp_dir/workflow-inventory"
 
+cat >"$tmp_dir/production-exclusivity" <<'SH'
+#!/usr/bin/env bash
+[[ "${STUB_ACTIVE:-false}" != "true" ]]
+SH
+chmod +x "$tmp_dir/production-exclusivity"
+
 gh() {
   if [[ "$1 $2" == "pr view" ]]; then
     if [[ "$*" == *"--json headRefOid,baseRefOid"* ]]; then
@@ -49,16 +55,6 @@ gh() {
       "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"pageInfo\":{\"hasNextPage\":false},\"nodes\":$nodes}}}}}"
   elif [[ "$1" == "api" && "$2" == *"/compare/"* ]]; then
     echo "ahead"
-  elif [[ "$1" == "api" && "$2" == *"/actions/runs?status="* ]]; then
-    if [[ "${STUB_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
-      printf '%s\n' \
-        '{"total_count":1,"workflow_runs":[{"id":999,"path":".github/workflows/production-deploy.yml","head_branch":"master","status":"in_progress"}]}'
-    elif [[ "${STUB_PR_VALIDATION_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
-      printf '%s\n' \
-        '{"total_count":1,"workflow_runs":[{"id":998,"path":".github/workflows/production-build.yml","event":"pull_request","head_branch":"dev","status":"in_progress"}]}'
-    else
-      printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
-    fi
   else
     echo "unexpected gh invocation: $*" >&2
     return 1
@@ -72,13 +68,11 @@ common_env=(
   "BRANCH_POLICY_GUARD=$tmp_dir/branch-policy"
   "PR_VALIDATOR=$tmp_dir/pr-validator"
   "WORKFLOW_INVENTORY=$tmp_dir/workflow-inventory"
+  "PRODUCTION_RUN_EXCLUSIVITY=$tmp_dir/production-exclusivity"
 )
 
 env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
   "$MERGE_SAFETY" 224 >/dev/null
-
-env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
-  STUB_PR_VALIDATION_ACTIVE=true "$MERGE_SAFETY" 224 >/dev/null
 
 if env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true STUB_LABEL=missing \
   "$MERGE_SAFETY" 224 >/dev/null 2>&1; then

--- a/infra/azure/agents/test-production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/test-production-run-exclusivity-stan.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+EXCLUSIVITY="$ROOT_DIR/infra/azure/agents/production-run-exclusivity-stan.sh"
+RUN_ID=123
+WORKFLOW_ID=456
+
+gh() {
+  if [[ "$1" == "api" && "$2" == *"/actions/runs?status="* ]]; then
+    if [[ "${STUB_MODE:-none}" == "none" || "$2" != *"status=in_progress"* ]]; then
+      printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
+      return
+    fi
+    if [[ "$STUB_MODE" == "overflow" ]]; then
+      printf '%s\n' '{"total_count":101,"workflow_runs":[]}'
+      return
+    fi
+    local branch=master
+    if [[ "$STUB_MODE" == "pr-validation" ]]; then
+      branch=dev
+    fi
+    local updated_at=1970-01-01T00:00:00Z
+    if [[ "$STUB_MODE" == "recent-disabled" ]]; then
+      updated_at=1970-01-01T00:33:20Z
+    fi
+    printf '%s\n' \
+      "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"workflow_id\":$WORKFLOW_ID,\"path\":\".github/workflows/production-build.yml\",\"head_branch\":\"$branch\",\"status\":\"in_progress\",\"updated_at\":\"$updated_at\"}]}"
+  elif [[ "$1" == "api" && "$2" == *"/actions/workflows/$WORKFLOW_ID"* ]]; then
+    local state=active
+    if [[ "$STUB_MODE" == *disabled* ]]; then
+      state=disabled_manually
+    fi
+    printf '%s\n' "{\"id\":$WORKFLOW_ID,\"state\":\"$state\"}"
+  elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID/jobs"* ]]; then
+    local count=1
+    if [[ "$STUB_MODE" == "stale-disabled" || "$STUB_MODE" == "recent-disabled" || "$STUB_MODE" == "pending-disabled" ]]; then
+      count=0
+    fi
+    printf '%s\n' "{\"total_count\":$count,\"jobs\":[]}"
+  elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID/pending_deployments"* ]]; then
+    if [[ "$STUB_MODE" == "pending-disabled" ]]; then
+      printf '%s\n' '[{"environment":{"id":1,"name":"production-emergency"}}]'
+    else
+      printf '%s\n' '[]'
+    fi
+  else
+    echo "unexpected gh invocation: $*" >&2
+    return 1
+  fi
+}
+export -f gh
+export RUN_ID WORKFLOW_ID
+
+REPO=example/repo NOW_EPOCH=2000 "$EXCLUSIVITY" >/dev/null
+REPO=example/repo NOW_EPOCH=2000 STUB_MODE=pr-validation \
+  "$EXCLUSIVITY" >/dev/null
+REPO=example/repo NOW_EPOCH=2000 STUB_MODE=stale-disabled \
+  "$EXCLUSIVITY" >/dev/null
+REPO=example/repo NOW_EPOCH=2000 STUB_MODE=active EXCLUDE_RUN_ID=$RUN_ID \
+  "$EXCLUSIVITY" >/dev/null
+
+for mode in active recent-disabled pending-disabled jobs-disabled overflow; do
+  if REPO=example/repo NOW_EPOCH=2000 STUB_MODE="$mode" \
+    "$EXCLUSIVITY" >/dev/null 2>&1; then
+    echo "production exclusivity accepted unsafe mode=$mode" >&2
+    exit 1
+  fi
+done
+
+echo "production_run_exclusivity_tests=PASS"


### PR DESCRIPTION
## Summary
- allow deployment safety contracts to validate an already-merged `master` commit in GitHub Actions while retaining the local direct-master block
- mark Copilot CLI-owned PRs explicitly and auto-approve them only after exact-SHA, trusted-check, review, workflow inventory, and production exclusivity gates pass
- auto-approve only normal build/deploy environments; keep rollback, migration, and infrastructure operations human-gated

## Validation
- local master guard remains blocked
- GitHub Actions master validation passes
- CLI merge gate rejects missing labels, unresolved reviews, changed refs, and competing production runs
- protected run approver rejects stale SHA, reruns, unexpected environments, unlabelled promotions, and competing production runs
- complete protected PR matrix passed on #224