### PR TITLE
ci: ignore proven inert production runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Use this flow:
 
 Never push directly to `dev`; integrate focused feature, fix, or operations branches through pull requests. Pull requests into `master` from any branch other than `dev` are forbidden.
 
-Copilot CLI-created pull requests carry the `copilot-cli-managed` label. They may use `COPILOT_CLI_AUTO_APPROVE=true` only after the merge-safety script verifies the label, exact refs, trusted required checks, resolved review threads, production workflow inventory, and absence of competing production activity. Unlabelled pull requests and work created outside Copilot CLI require explicit human approval. Automatic mode never skips required checks or immutable-SHA gates.
+Copilot CLI-created pull requests carry the `copilot-cli-managed` label. They may use `COPILOT_CLI_AUTO_APPROVE=true` only after the merge-safety script verifies the label, exact refs, trusted required checks, resolved review threads, production workflow inventory, and absence of actionable competing production activity. Unlabelled pull requests and work created outside Copilot CLI require explicit human approval. Automatic mode never skips required checks or immutable-SHA gates.
 
 Protected environment approval for CLI-managed work uses `copilot-cli-run-approval-stan.sh`. It additionally requires current `master`, a single associated labelled `dev` promotion, first-attempt workflow provenance, the exact expected environment, and no competing production workflow. Automatic approval is limited to normal application build/deploy workflows; rollback, migration, and infrastructure workflows remain human-gated.
 

--- a/infra/azure/agents/README.md
+++ b/infra/azure/agents/README.md
@@ -16,6 +16,7 @@
 - `pr-validation-stan.sh` — inspects trusted required checks for a PR's exact head SHA.
 - `pr-merge-safety-stan.sh` — combines branch policy, exact-SHA validation, mergeability, and production approval gates.
 - `copilot-cli-run-approval-stan.sh` — fail-closed protected-environment approval for normal CLI-managed build/deploy runs.
+- `production-run-exclusivity-stan.sh` — blocks actionable concurrent production runs while identifying inert disabled queue records.
 - `post-merge-verification-stan.sh` — verifies merged commit workflow success plus production health across both public hosts.
 - `rollback-readiness-stan.sh` — emits explicit rollback go/no-go based on current health, queue pressure, and rollout history.
 - `node-logs-stan.sh` — node-level health/events + pod error-log extraction.
@@ -268,7 +269,7 @@ EXPECTED_ENVIRONMENT=production-emergency \
 ./infra/azure/agents/copilot-cli-run-approval-stan.sh <run-id> --approve
 ```
 
-The approver rejects stale master SHAs, reruns, unlabelled promotions, unexpected workflows/environments, and competing production activity. It does not support automatic rollback, migration, or infrastructure approval.
+The approver rejects stale master SHAs, reruns, unlabelled promotions, unexpected workflows/environments, and actionable competing production activity. Disabled records are ignored only when they are old and have no jobs or pending environments. Automatic rollback, migration, and infrastructure approval is unsupported.
 
 ## Post-merge production verification
 

--- a/infra/azure/agents/copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/copilot-cli-run-approval-stan.sh
@@ -18,6 +18,7 @@ EXPECTED_WORKFLOW="${EXPECTED_WORKFLOW:-}"
 EXPECTED_ENVIRONMENT="${EXPECTED_ENVIRONMENT:-}"
 CLI_MANAGED_LABEL="${COPILOT_CLI_MANAGED_LABEL:-copilot-cli-managed}"
 AUTO_APPROVE="${COPILOT_CLI_AUTO_APPROVE:-false}"
+PRODUCTION_RUN_EXCLUSIVITY="${PRODUCTION_RUN_EXCLUSIVITY:-./infra/azure/agents/production-run-exclusivity-stan.sh}"
 
 fail() {
   echo "safe_to_approve=no"
@@ -137,51 +138,8 @@ then
   fail "current master is not bound to one merged CLI-managed dev promotion"
 fi
 
-active_runs="$(
-  for status in queued in_progress waiting requested pending; do
-    gh api "repos/$REPO/actions/runs?status=$status&per_page=100"
-  done
-)"
-if ! python3 - "$active_runs" "$RUN_ID" <<'PY'
-import json
-import sys
-
-current_run = sys.argv[2]
-paths = {
-    ".github/workflows/production-build.yml",
-    ".github/workflows/production-deploy.yml",
-    ".github/workflows/production-rollback.yml",
-    ".github/workflows/oci-production-build.yml",
-    ".github/workflows/oci-production-deploy.yml",
-    ".github/workflows/oci-production-rollback.yml",
-    ".github/workflows/oci-infrastructure.yml",
-    ".github/workflows/oci-capacity-acquire.yml",
-    ".github/workflows/oci-migrate.yml",
-    ".github/workflows/oci-migration-recovery.yml",
-}
-decoder = json.JSONDecoder()
-payload = sys.argv[1]
-index = 0
-while index < len(payload):
-    while index < len(payload) and payload[index].isspace():
-        index += 1
-    if index >= len(payload):
-        break
-    response, index = decoder.raw_decode(payload, index)
-    if response.get("total_count", 0) > 100:
-        raise SystemExit("more than 100 active runs requires manual review")
-    for run in response.get("workflow_runs", []):
-        if str(run.get("id", "")) == current_run:
-            continue
-        if run.get("path") in paths and run.get("head_branch") == "master":
-            raise SystemExit(
-                f"active production run {run.get('id')} path={run.get('path')} "
-                f"status={run.get('status')}"
-            )
-PY
-then
-  fail "another production-capable workflow is active"
-fi
+REPO="$REPO" EXCLUDE_RUN_ID="$RUN_ID" "$PRODUCTION_RUN_EXCLUSIVITY" ||
+  fail "another actionable production-capable workflow is active"
 
 pending_json="$(read_pending)"
 environment_id="$(

--- a/infra/azure/agents/pr-merge-safety-stan.sh
+++ b/infra/azure/agents/pr-merge-safety-stan.sh
@@ -15,6 +15,7 @@ CLI_MANAGED_LABEL="${COPILOT_CLI_MANAGED_LABEL:-copilot-cli-managed}"
 BRANCH_POLICY_GUARD="${BRANCH_POLICY_GUARD:-./infra/azure/agents/branch-policy-guard-stan.sh}"
 PR_VALIDATOR="${PR_VALIDATOR:-./infra/azure/agents/pr-validation-stan.sh}"
 WORKFLOW_INVENTORY="${WORKFLOW_INVENTORY:-./infra/azure/agents/production-workflow-inventory-stan.sh}"
+PRODUCTION_RUN_EXCLUSIVITY="${PRODUCTION_RUN_EXCLUSIVITY:-./infra/azure/agents/production-run-exclusivity-stan.sh}"
 if [[ -z "$PR_NUMBER" ]]; then
   echo "usage: $0 <pr-number>" >&2
   exit 1
@@ -173,45 +174,8 @@ if [[ "$base_ref" == "master" ]]; then
   [[ "$compare_status" == "ahead" || "$compare_status" == "identical" ]] ||
     fail "current master tip is not an ancestor of the promotion head status=$compare_status"
 
-  active_runs="$(
-    for status in queued in_progress waiting requested pending; do
-      gh api "repos/$REPO/actions/runs?status=$status&per_page=100"
-    done
-  )"
-  python3 - "$active_runs" <<'PY' || fail "another production-capable workflow is active"
-import json
-import sys
-
-paths = {
-    ".github/workflows/production-build.yml",
-    ".github/workflows/production-deploy.yml",
-    ".github/workflows/production-rollback.yml",
-    ".github/workflows/oci-production-build.yml",
-    ".github/workflows/oci-production-deploy.yml",
-    ".github/workflows/oci-production-rollback.yml",
-    ".github/workflows/oci-infrastructure.yml",
-    ".github/workflows/oci-capacity-acquire.yml",
-    ".github/workflows/oci-migrate.yml",
-    ".github/workflows/oci-migration-recovery.yml",
-}
-decoder = json.JSONDecoder()
-payload = sys.argv[1]
-index = 0
-while index < len(payload):
-    while index < len(payload) and payload[index].isspace():
-        index += 1
-    if index >= len(payload):
-        break
-    response, index = decoder.raw_decode(payload, index)
-    if response.get("total_count", 0) > 100:
-        raise SystemExit("more than 100 active runs requires manual review")
-    for run in response.get("workflow_runs", []):
-        if run.get("path") in paths and run.get("head_branch") == "master":
-            raise SystemExit(
-                f"active production run {run.get('id')} path={run.get('path')} "
-                f"status={run.get('status')}"
-            )
-PY
+  REPO="$REPO" "$PRODUCTION_RUN_EXCLUSIVITY" ||
+    fail "another actionable production-capable workflow is active"
 
   expected_workflows="$(
     REPO="$REPO" PR="$PR_NUMBER" EXPECTED_HEAD_SHA="$head_sha" \

--- a/infra/azure/agents/production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/production-run-exclusivity-stan.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Purpose: block concurrent production-capable activity while ignoring only
+#          old, disabled GitHub queue records proven to have no jobs or gates.
+
+REPO="${REPO:-vasilyevstan/betstan}"
+EXCLUDE_RUN_ID="${EXCLUDE_RUN_ID:-}"
+STALE_DISABLED_MIN_AGE_SECONDS="${STALE_DISABLED_MIN_AGE_SECONDS:-600}"
+NOW_EPOCH="${NOW_EPOCH:-$(date +%s)}"
+
+[[ -z "$EXCLUDE_RUN_ID" || "$EXCLUDE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+  echo "EXCLUDE_RUN_ID must be empty or a positive integer" >&2
+  exit 1
+}
+[[ "$STALE_DISABLED_MIN_AGE_SECONDS" =~ ^[1-9][0-9]*$ ]] || {
+  echo "STALE_DISABLED_MIN_AGE_SECONDS must be a positive integer" >&2
+  exit 1
+}
+[[ "$NOW_EPOCH" =~ ^[1-9][0-9]*$ ]] || {
+  echo "NOW_EPOCH must be a positive integer" >&2
+  exit 1
+}
+
+tmp_runs="$(mktemp)"
+tmp_candidates="$(mktemp)"
+cleanup() {
+  rm -f "$tmp_runs" "$tmp_candidates"
+}
+trap cleanup EXIT
+
+for status in queued in_progress waiting requested pending; do
+  gh api "repos/$REPO/actions/runs?status=$status&per_page=100" >>"$tmp_runs"
+  printf '\n' >>"$tmp_runs"
+done
+
+python3 - "$tmp_runs" >"$tmp_candidates" <<'PY'
+import json
+import sys
+
+paths = {
+    ".github/workflows/production-build.yml",
+    ".github/workflows/production-deploy.yml",
+    ".github/workflows/production-rollback.yml",
+    ".github/workflows/oci-production-build.yml",
+    ".github/workflows/oci-production-deploy.yml",
+    ".github/workflows/oci-production-rollback.yml",
+    ".github/workflows/oci-infrastructure.yml",
+    ".github/workflows/oci-capacity-acquire.yml",
+    ".github/workflows/oci-migrate.yml",
+    ".github/workflows/oci-migration-recovery.yml",
+}
+decoder = json.JSONDecoder()
+payload = open(sys.argv[1], encoding="utf-8").read()
+index = 0
+seen = set()
+while index < len(payload):
+    while index < len(payload) and payload[index].isspace():
+        index += 1
+    if index >= len(payload):
+        break
+    response, index = decoder.raw_decode(payload, index)
+    if response.get("total_count", 0) > 100:
+        raise SystemExit("more than 100 active runs requires manual review")
+    for run in response.get("workflow_runs", []):
+        run_id = run.get("id")
+        if (
+            run_id in seen
+            or run.get("path") not in paths
+            or run.get("head_branch") != "master"
+        ):
+            continue
+        seen.add(run_id)
+        values = (
+            run_id,
+            run.get("workflow_id"),
+            run.get("path"),
+            run.get("status"),
+            run.get("updated_at"),
+        )
+        if (
+            not isinstance(run_id, int)
+            or not isinstance(run.get("workflow_id"), int)
+            or any(not isinstance(value, str) or not value for value in values[2:])
+        ):
+            raise SystemExit("active run metadata is malformed")
+        print("\t".join(str(value) for value in values))
+PY
+
+while IFS=$'\t' read -r run_id workflow_id path status updated_at; do
+  [[ -n "${run_id:-}" ]] || continue
+  if [[ "$run_id" == "$EXCLUDE_RUN_ID" ]]; then
+    continue
+  fi
+
+  workflow_json="$(gh api "repos/$REPO/actions/workflows/$workflow_id")"
+  jobs_json="$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=1")"
+  pending_json="$(gh api "repos/$REPO/actions/runs/$run_id/pending_deployments")"
+  classification="$(
+    python3 - "$workflow_json" "$jobs_json" "$pending_json" "$updated_at" \
+      "$NOW_EPOCH" "$STALE_DISABLED_MIN_AGE_SECONDS" <<'PY'
+import datetime
+import json
+import sys
+
+workflow = json.loads(sys.argv[1])
+jobs = json.loads(sys.argv[2])
+pending = json.loads(sys.argv[3])
+updated_at = datetime.datetime.fromisoformat(sys.argv[4].replace("Z", "+00:00"))
+now = datetime.datetime.fromtimestamp(int(sys.argv[5]), datetime.timezone.utc)
+minimum_age = int(sys.argv[6])
+state = workflow.get("state")
+job_count = jobs.get("total_count")
+if not isinstance(state, str) or not isinstance(job_count, int) or not isinstance(pending, list):
+    raise SystemExit("production run actionability metadata is malformed")
+age_seconds = int((now - updated_at).total_seconds())
+inert = (
+    state.startswith("disabled_")
+    and job_count == 0
+    and len(pending) == 0
+    and age_seconds >= minimum_age
+)
+print(
+    f"inert={'yes' if inert else 'no'} state={state} jobs={job_count} "
+    f"pending={len(pending)} age_seconds={age_seconds}"
+)
+PY
+  )"
+  if [[ "$classification" == inert=yes* ]]; then
+    echo "ignored_inert_run=$run_id path=$path status=$status $classification"
+    continue
+  fi
+
+  echo "active production run $run_id path=$path status=$status $classification" >&2
+  exit 1
+done <"$tmp_candidates"
+
+echo "production_run_exclusivity=PASS"

--- a/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
@@ -5,11 +5,18 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 APPROVER="$ROOT_DIR/infra/azure/agents/copilot-cli-run-approval-stan.sh"
 SHA="1111111111111111111111111111111111111111"
 RUN_ID=123
-approval_log="$(mktemp)"
+tmp_dir="$(mktemp -d)"
+approval_log="$tmp_dir/approval.log"
 cleanup() {
-  rm -f "$approval_log"
+  rm -rf "$tmp_dir"
 }
 trap cleanup EXIT
+
+cat >"$tmp_dir/production-exclusivity" <<'SH'
+#!/usr/bin/env bash
+[[ "${STUB_ACTIVE:-false}" != "true" ]]
+SH
+chmod +x "$tmp_dir/production-exclusivity"
 
 gh() {
   if [[ "$*" == *"--method POST"* ]]; then
@@ -33,16 +40,6 @@ gh() {
     fi
     printf '%s\n' \
       "[{\"number\":225,\"merged_at\":\"2026-08-21T00:00:00Z\",\"merge_commit_sha\":\"$SHA\",\"base\":{\"ref\":\"master\"},\"head\":{\"ref\":\"dev\"},\"labels\":$labels}]"
-  elif [[ "$1" == "api" && "$2" == *"/actions/runs?status="* ]]; then
-    if [[ "${STUB_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
-      printf '%s\n' \
-        '{"total_count":1,"workflow_runs":[{"id":999,"path":".github/workflows/production-deploy.yml","head_branch":"master","status":"in_progress"}]}'
-    elif [[ "${STUB_PR_VALIDATION_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
-      printf '%s\n' \
-        '{"total_count":1,"workflow_runs":[{"id":998,"path":".github/workflows/production-build.yml","event":"pull_request","head_branch":"dev","status":"in_progress"}]}'
-    else
-      printf '%s\n' "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"path\":\".github/workflows/production-build.yml\",\"head_branch\":\"master\",\"status\":\"waiting\"}]}"
-    fi
   else
     echo "unexpected gh invocation: $*" >&2
     return 1
@@ -56,12 +53,10 @@ common_env=(
   "EXPECTED_SHA=$SHA"
   "EXPECTED_WORKFLOW=production-build.yml"
   "EXPECTED_ENVIRONMENT=production-emergency"
+  "PRODUCTION_RUN_EXCLUSIVITY=$tmp_dir/production-exclusivity"
 )
 
 env "${common_env[@]}" "$APPROVER" "$RUN_ID" >/dev/null
-
-env "${common_env[@]}" STUB_PR_VALIDATION_ACTIVE=true \
-  "$APPROVER" "$RUN_ID" >/dev/null
 
 env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
   "$APPROVER" "$RUN_ID" --approve >/dev/null

--- a/infra/azure/agents/test-deployment-safety-ci-stan.sh
+++ b/infra/azure/agents/test-deployment-safety-ci-stan.sh
@@ -9,6 +9,7 @@ OCI_DEPLOY_SCRIPT="$ROOT_DIR/infra/oci/scripts/deploy.sh"
 PRE_COMMIT_CHECK="$ROOT_DIR/infra/azure/agents/pre-commit-infra-check-stan.sh"
 PR_MERGE_SAFETY_TEST="$ROOT_DIR/infra/azure/agents/test-pr-merge-safety-stan.sh"
 RUN_APPROVAL_TEST="$ROOT_DIR/infra/azure/agents/test-copilot-cli-run-approval-stan.sh"
+RUN_EXCLUSIVITY_TEST="$ROOT_DIR/infra/azure/agents/test-production-run-exclusivity-stan.sh"
 
 test_output="$(mktemp)"
 trap 'rm -f "$test_output"' EXIT
@@ -27,6 +28,7 @@ fi
 
 "$PR_MERGE_SAFETY_TEST"
 "$RUN_APPROVAL_TEST"
+"$RUN_EXCLUSIVITY_TEST"
 
 python3 - "$AZURE_WORKFLOW" "$OCI_WORKFLOW" "$BUILD_WORKFLOW" "$OCI_DEPLOY_SCRIPT" <<'PY'
 import pathlib

--- a/infra/azure/agents/test-pr-merge-safety-stan.sh
+++ b/infra/azure/agents/test-pr-merge-safety-stan.sh
@@ -26,6 +26,12 @@ echo "production_workflows=oci-production-build,production-build"
 SH
 chmod +x "$tmp_dir/workflow-inventory"
 
+cat >"$tmp_dir/production-exclusivity" <<'SH'
+#!/usr/bin/env bash
+[[ "${STUB_ACTIVE:-false}" != "true" ]]
+SH
+chmod +x "$tmp_dir/production-exclusivity"
+
 gh() {
   if [[ "$1 $2" == "pr view" ]]; then
     if [[ "$*" == *"--json headRefOid,baseRefOid"* ]]; then
@@ -49,16 +55,6 @@ gh() {
       "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"pageInfo\":{\"hasNextPage\":false},\"nodes\":$nodes}}}}}"
   elif [[ "$1" == "api" && "$2" == *"/compare/"* ]]; then
     echo "ahead"
-  elif [[ "$1" == "api" && "$2" == *"/actions/runs?status="* ]]; then
-    if [[ "${STUB_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
-      printf '%s\n' \
-        '{"total_count":1,"workflow_runs":[{"id":999,"path":".github/workflows/production-deploy.yml","head_branch":"master","status":"in_progress"}]}'
-    elif [[ "${STUB_PR_VALIDATION_ACTIVE:-false}" == "true" && "$2" == *"status=in_progress"* ]]; then
-      printf '%s\n' \
-        '{"total_count":1,"workflow_runs":[{"id":998,"path":".github/workflows/production-build.yml","event":"pull_request","head_branch":"dev","status":"in_progress"}]}'
-    else
-      printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
-    fi
   else
     echo "unexpected gh invocation: $*" >&2
     return 1
@@ -72,13 +68,11 @@ common_env=(
   "BRANCH_POLICY_GUARD=$tmp_dir/branch-policy"
   "PR_VALIDATOR=$tmp_dir/pr-validator"
   "WORKFLOW_INVENTORY=$tmp_dir/workflow-inventory"
+  "PRODUCTION_RUN_EXCLUSIVITY=$tmp_dir/production-exclusivity"
 )
 
 env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
   "$MERGE_SAFETY" 224 >/dev/null
-
-env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
-  STUB_PR_VALIDATION_ACTIVE=true "$MERGE_SAFETY" 224 >/dev/null
 
 if env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true STUB_LABEL=missing \
   "$MERGE_SAFETY" 224 >/dev/null 2>&1; then

--- a/infra/azure/agents/test-production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/test-production-run-exclusivity-stan.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+EXCLUSIVITY="$ROOT_DIR/infra/azure/agents/production-run-exclusivity-stan.sh"
+RUN_ID=123
+WORKFLOW_ID=456
+
+gh() {
+  if [[ "$1" == "api" && "$2" == *"/actions/runs?status="* ]]; then
+    if [[ "${STUB_MODE:-none}" == "none" || "$2" != *"status=in_progress"* ]]; then
+      printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
+      return
+    fi
+    if [[ "$STUB_MODE" == "overflow" ]]; then
+      printf '%s\n' '{"total_count":101,"workflow_runs":[]}'
+      return
+    fi
+    local branch=master
+    if [[ "$STUB_MODE" == "pr-validation" ]]; then
+      branch=dev
+    fi
+    local updated_at=1970-01-01T00:00:00Z
+    if [[ "$STUB_MODE" == "recent-disabled" ]]; then
+      updated_at=1970-01-01T00:33:20Z
+    fi
+    printf '%s\n' \
+      "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"workflow_id\":$WORKFLOW_ID,\"path\":\".github/workflows/production-build.yml\",\"head_branch\":\"$branch\",\"status\":\"in_progress\",\"updated_at\":\"$updated_at\"}]}"
+  elif [[ "$1" == "api" && "$2" == *"/actions/workflows/$WORKFLOW_ID"* ]]; then
+    local state=active
+    if [[ "$STUB_MODE" == *disabled* ]]; then
+      state=disabled_manually
+    fi
+    printf '%s\n' "{\"id\":$WORKFLOW_ID,\"state\":\"$state\"}"
+  elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID/jobs"* ]]; then
+    local count=1
+    if [[ "$STUB_MODE" == "stale-disabled" || "$STUB_MODE" == "recent-disabled" || "$STUB_MODE" == "pending-disabled" ]]; then
+      count=0
+    fi
+    printf '%s\n' "{\"total_count\":$count,\"jobs\":[]}"
+  elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID/pending_deployments"* ]]; then
+    if [[ "$STUB_MODE" == "pending-disabled" ]]; then
+      printf '%s\n' '[{"environment":{"id":1,"name":"production-emergency"}}]'
+    else
+      printf '%s\n' '[]'
+    fi
+  else
+    echo "unexpected gh invocation: $*" >&2
+    return 1
+  fi
+}
+export -f gh
+export RUN_ID WORKFLOW_ID
+
+REPO=example/repo NOW_EPOCH=2000 "$EXCLUSIVITY" >/dev/null
+REPO=example/repo NOW_EPOCH=2000 STUB_MODE=pr-validation \
+  "$EXCLUSIVITY" >/dev/null
+REPO=example/repo NOW_EPOCH=2000 STUB_MODE=stale-disabled \
+  "$EXCLUSIVITY" >/dev/null
+REPO=example/repo NOW_EPOCH=2000 STUB_MODE=active EXCLUDE_RUN_ID=$RUN_ID \
+  "$EXCLUSIVITY" >/dev/null
+
+for mode in active recent-disabled pending-disabled jobs-disabled overflow; do
+  if REPO=example/repo NOW_EPOCH=2000 STUB_MODE="$mode" \
+    "$EXCLUSIVITY" >/dev/null 2>&1; then
+    echo "production exclusivity accepted unsafe mode=$mode" >&2
+    exit 1
+  fi
+done
+
+echo "production_run_exclusivity_tests=PASS"


### PR DESCRIPTION
## Summary
- centralize production-run exclusivity for CLI-managed merges and environment approvals
- ignore only old disabled workflow records with zero jobs and zero pending environments
- continue blocking active, recent, job-bearing, pending-gate, malformed, or unbounded production activity

## Validation
- synthetic active/recent/pending/job-bearing/overflow cases fail closed
- PR validation runs on non-master branches do not block promotion
- real stale queued run `32117048440` is classified inert from disabled workflow + zero jobs + zero pending gates
- full deployment safety contract suite passes