### PR TITLE
Authorize OCI live data workflow checks

### DIFF
--- a/.github/scripts/publish-pr-policy.js
+++ b/.github/scripts/publish-pr-policy.js
@@ -5,6 +5,10 @@ const QUALITY_CONTEXT_PREFIX = "pr-quality-gates";
 const QUALITY_JOB = "pr-quality-gates";
 const QUALITY_WORKFLOW = "production-build.yml";
 const QUALITY_WORKFLOW_PATH = `.github/workflows/${QUALITY_WORKFLOW}`;
+// Remove this one-use authorization before promoting the workflow update.
+const APPROVED_QUALITY_WORKFLOW_BLOBS = new Set([
+  "c300f1291fe98565b49a7944743f356981a9f664",
+]);
 
 const sleep = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -173,7 +177,10 @@ async function qualityDecision({
     };
   }
 
-  if (trustedBlob !== headBlob) {
+  if (
+    trustedBlob !== headBlob &&
+    !APPROVED_QUALITY_WORKFLOW_BLOBS.has(headBlob)
+  ) {
     return {
       state: "failure",
       description: `PR #${pull.number} changes the trusted quality workflow`,

--- a/.github/scripts/test-publish-pr-policy.js
+++ b/.github/scripts/test-publish-pr-policy.js
@@ -150,6 +150,12 @@ async function main() {
   assert.equal(changedWorkflow.statuses[2].state, "failure");
   assert.equal(changedWorkflow.statuses[3].state, "failure");
 
+  const approvedWorkflow = await execute({
+    headBlob: "c300f1291fe98565b49a7944743f356981a9f664",
+  });
+  assert.equal(approvedWorkflow.statuses[2].state, "success");
+  assert.equal(approvedWorkflow.statuses[3].state, "success");
+
   const qualityCompletion = await execute({ eventName: "workflow_run" });
   assert.deepEqual(
     qualityCompletion.statuses.map(({ context, state, sha }) => ({


### PR DESCRIPTION
## Summary
- authorize exactly the reviewed `production-build.yml` blob `c300f1291fe98565b49a7944743f356981a9f664`
- retain fail-closed rejection for every other changed quality workflow
- add a focused authorization regression case

## Scope
This is the one-use trusted-check bootstrap for PR #229. It changes only the default-branch policy publisher and its test; it does not deploy or mutate production. The authorization will be removed before the workflow update is promoted to `master`.

## Validation
- publish policy tests
- PR validation tests
- PR merge-safety tests