### PR TITLE
Remove live data workflow authorization

### DIFF
--- a/.github/scripts/publish-pr-policy.js
+++ b/.github/scripts/publish-pr-policy.js
@@ -5,10 +5,6 @@ const QUALITY_CONTEXT_PREFIX = "pr-quality-gates";
 const QUALITY_JOB = "pr-quality-gates";
 const QUALITY_WORKFLOW = "production-build.yml";
 const QUALITY_WORKFLOW_PATH = `.github/workflows/${QUALITY_WORKFLOW}`;
-// Remove this one-use authorization before promoting the workflow update.
-const APPROVED_QUALITY_WORKFLOW_BLOBS = new Set([
-  "c300f1291fe98565b49a7944743f356981a9f664",
-]);
 
 const sleep = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -177,10 +173,7 @@ async function qualityDecision({
     };
   }
 
-  if (
-    trustedBlob !== headBlob &&
-    !APPROVED_QUALITY_WORKFLOW_BLOBS.has(headBlob)
-  ) {
+  if (trustedBlob !== headBlob) {
     return {
       state: "failure",
       description: `PR #${pull.number} changes the trusted quality workflow`,

--- a/.github/scripts/test-publish-pr-policy.js
+++ b/.github/scripts/test-publish-pr-policy.js
@@ -150,12 +150,6 @@ async function main() {
   assert.equal(changedWorkflow.statuses[2].state, "failure");
   assert.equal(changedWorkflow.statuses[3].state, "failure");
 
-  const approvedWorkflow = await execute({
-    headBlob: "c300f1291fe98565b49a7944743f356981a9f664",
-  });
-  assert.equal(approvedWorkflow.statuses[2].state, "success");
-  assert.equal(approvedWorkflow.statuses[3].state, "success");
-
   const qualityCompletion = await execute({ eventName: "workflow_run" });
   assert.deepEqual(
     qualityCompletion.statuses.map(({ context, state, sha }) => ({


### PR DESCRIPTION
## Summary
- remove the one-use authorization for quality-workflow blob `c300f1291fe98565b49a7944743f356981a9f664`
- restore exact equality with the default trusted quality workflow
- remove the temporary positive authorization fixture

PR #229 has already passed trusted checks and merged to `dev`. This cleanup is required before promotion to `master`; it does not deploy or mutate production.