### PR TITLE
Promote guarded OCI live data rollout

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -16,6 +16,8 @@ Before changing or assessing deployment behavior, read:
 - `.github/workflows/production-build.yml`
 - `.github/workflows/branch-policy.yml`
 - `.github/workflows/production-deploy.yml`
+- `.github/workflows/oci-live-data-rollout.yml`
+- `.github/workflows/oci-production-deploy.yml`
 - `infra/azure/LESSONS_LEARNED.md`
 - `infra/oci/LESSONS_LEARNED.md`
 - `infra/azure/agents/README.md`
@@ -51,7 +53,8 @@ Inspect the current git graph and remote default branch. Do not infer that a mer
   OCI is the operational service primary and is active; that statement is not
   evidence that Azure data cutover or retirement is complete. The governed set includes `production-build`,
   `production-deploy`, `oci-production-build`, `oci-production-deploy`,
-  `oci-infrastructure`, `oci-capacity-acquire`, `oci-migrate`, and the
+  `oci-infrastructure`, `oci-capacity-acquire`, `oci-live-data-rollout`,
+  `oci-migrate`, and the
   stop-only `oci-migration-recovery`; use the checked-in inventory as
   authority when it changes.
 - Before promotion, evaluate workflow branch and path filters against the exact diff and list every production-capable workflow that will run. If approval does not cover that complete trigger set, return `NO_GO`.
@@ -82,10 +85,18 @@ Before deployment:
   must not race migration, cleanup, or rollback;
 - check production health and rollback readiness;
 - ensure no unresolved workflow or manifest conflict exists.
+- for a schema-dependent OCI release, require the exact successful three-phase
+  data chain, baseline digest, active transferred database lock, ingress write
+  fence, and six quiesced legacy writer Deployments before applying images;
+- treat a successful final data phase as an active maintenance handoff, not a
+  completed release, and proceed directly to its bound deployment.
 
 During deployment:
 
 - hold the shared-Mongo operation lock across topology validation, manifest apply, rollout, and post-deploy validation;
+- keep the public write fence active while new exact-digest services start;
+- after protected validation, release the transferred database lock before
+  removing the public write fence;
 - treat lock acquisition or release failure as deployment failure;
 - apply shared infrastructure without causing intermediate untagged application rollouts;
 - apply SHA-pinned application Deployments sequentially;
@@ -105,6 +116,9 @@ After deployment:
 - verify RabbitMQ queues have active consumers and no unexpected backlog;
 - upload diagnostics when validation fails;
 - report deployment as failed when the application is unhealthy even if workflow steps succeeded.
+- on an incomplete OCI data-bound deployment, reapply the write fence, quiesce
+  all six data writers, and retain or reacquire the exact handoff lock before
+  permitting a retry.
 
 ## Ingress safety
 

--- a/.github/scripts/publish-pr-policy.js
+++ b/.github/scripts/publish-pr-policy.js
@@ -5,10 +5,6 @@ const QUALITY_CONTEXT_PREFIX = "pr-quality-gates";
 const QUALITY_JOB = "pr-quality-gates";
 const QUALITY_WORKFLOW = "production-build.yml";
 const QUALITY_WORKFLOW_PATH = `.github/workflows/${QUALITY_WORKFLOW}`;
-// Remove this one-use authorization before promoting the workflow update.
-const APPROVED_QUALITY_WORKFLOW_BLOBS = new Set([
-  "c300f1291fe98565b49a7944743f356981a9f664",
-]);
 
 const sleep = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -177,10 +173,7 @@ async function qualityDecision({
     };
   }
 
-  if (
-    trustedBlob !== headBlob &&
-    !APPROVED_QUALITY_WORKFLOW_BLOBS.has(headBlob)
-  ) {
+  if (trustedBlob !== headBlob) {
     return {
       state: "failure",
       description: `PR #${pull.number} changes the trusted quality workflow`,

--- a/.github/scripts/test-publish-pr-policy.js
+++ b/.github/scripts/test-publish-pr-policy.js
@@ -150,12 +150,6 @@ async function main() {
   assert.equal(changedWorkflow.statuses[2].state, "failure");
   assert.equal(changedWorkflow.statuses[3].state, "failure");
 
-  const approvedWorkflow = await execute({
-    headBlob: "c300f1291fe98565b49a7944743f356981a9f664",
-  });
-  assert.equal(approvedWorkflow.statuses[2].state, "success");
-  assert.equal(approvedWorkflow.statuses[3].state, "success");
-
   const qualityCompletion = await execute({ eventName: "workflow_run" });
   assert.deepEqual(
     qualityCompletion.statuses.map(({ context, state, sha }) => ({

--- a/.github/workflows/oci-live-data-rollout.yml
+++ b/.github/workflows/oci-live-data-rollout.yml
@@ -1,0 +1,492 @@
+name: oci-live-data-rollout
+run-name: oci-live-data ${{ inputs.phase }} ${{ inputs.approved_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      approved_sha:
+        description: Exact current master SHA approved for the live-betting data phase
+        required: true
+        type: string
+      build_run_id:
+        description: Successful first-attempt oci-production-build run ID
+        required: true
+        type: string
+      infrastructure_run_id:
+        description: Successful first-attempt finalized oci-infrastructure run ID
+        required: true
+        type: string
+      phase:
+        description: Read, backfill, or create and verify the Slip index
+        required: true
+        type: choice
+        options:
+          - dry-run
+          - apply-backfills
+          - apply-slip-index
+      prerequisite_run_id:
+        description: Prior successful phase run ID, or 0 for dry-run
+        required: true
+        default: "0"
+        type: string
+      confirmation:
+        description: Type the exact confirmation phrase for the selected phase
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: oci-control-plane
+  cancel-in-progress: false
+
+jobs:
+  rollout:
+    if: github.run_attempt == 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    environment:
+      name: oci-migration
+    env:
+      SOURCE_SHA: ${{ inputs.approved_sha }}
+      BUILD_RUN_ID: ${{ inputs.build_run_id }}
+      INFRASTRUCTURE_RUN_ID: ${{ inputs.infrastructure_run_id }}
+      PHASE: ${{ inputs.phase }}
+      PREREQUISITE_RUN_ID: ${{ inputs.prerequisite_run_id }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      OCI_RUNTIME_MODE: ${{ vars.OCI_RUNTIME_MODE }}
+      OCI_CLI_VERSION: "3.90.0"
+      OCI_REGION: ${{ vars.OCI_REGION }}
+      OCI_TENANCY_OCID: ${{ vars.OCI_TENANCY_OCID }}
+      OCI_CI_USER_OCID: ${{ vars.OCI_CI_USER_OCID }}
+      OCI_CI_KEY_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+      OCI_COMPARTMENT_OCID: ${{ vars.OCI_COMPARTMENT_OCID }}
+      OCI_AVAILABILITY_DOMAIN: ${{ vars.OCI_AVAILABILITY_DOMAIN }}
+      OCI_K8S_NAMESPACE: ${{ vars.OCI_K8S_NAMESPACE }}
+      OCI_K3S_NODE_NAME: ${{ vars.OCI_K3S_NODE_NAME || 'betstan-k3s' }}
+      OCI_BASTION_DEFAULT_CLIENT_CIDR: 192.0.2.1/32
+      OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
+      OCI_REGISTRY_NAMESPACE: ${{ vars.OCI_REGISTRY_NAMESPACE }}
+      OCI_IMAGE_PREFIX: ${{ vars.OCI_IMAGE_PREFIX }}
+      OCI_MEMORY_MAX_PERCENT: ${{ vars.OCI_MEMORY_MAX_PERCENT }}
+      OCI_DISK_MAX_PERCENT: ${{ vars.OCI_DISK_MAX_PERCENT }}
+      OCI_CPU_MAX_PERCENT: "90"
+      SHARED_MONGO_LOCK_TOKEN: live-data-${{ github.run_id }}-${{ github.run_attempt }}
+      SHARED_MONGO_LOCK_OPERATION: live-data-${{ inputs.phase }}
+
+    steps:
+      - name: Initialize isolated OCI data paths
+        run: |
+          {
+            echo "HOME=$RUNNER_TEMP/oci-home"
+            echo "KUBECONFIG=$RUNNER_TEMP/oci-home/.kube/config"
+          } >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/oci-home/.local/bin" >> "$GITHUB_PATH"
+          mkdir -p \
+            "$RUNNER_TEMP/oci-home/.kube" \
+            artifacts/build \
+            artifacts/infrastructure \
+            artifacts/prerequisite \
+            artifacts/oci-live-data-rollout \
+            artifacts/oci-data-baseline-before \
+            artifacts/oci-data-baseline-after
+          chmod 700 "$RUNNER_TEMP/oci-home" "$RUNNER_TEMP/oci-home/.kube"
+
+      - name: Checkout approved current master commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.approved_sha }}
+          fetch-depth: 0
+
+      - name: Validate exact SHA phase and trusted upstream runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [ "$GITHUB_RUN_ATTEMPT" = "1" ]
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$BUILD_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$INFRASTRUCTURE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          case "$PHASE" in
+            dry-run)
+              [ "$CONFIRMATION" = "DRY RUN LIVE DATA EXACT SHA" ]
+              [ "$PREREQUISITE_RUN_ID" = "0" ]
+              ;;
+            apply-backfills)
+              [ "$CONFIRMATION" = "APPLY LIVE BACKFILLS EXACT SHA" ]
+              [[ "$PREREQUISITE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+              ;;
+            apply-slip-index)
+              [ "$CONFIRMATION" = "APPLY LIVE SLIP INDEX EXACT SHA" ]
+              [[ "$PREREQUISITE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
+          git fetch --quiet origin master:refs/remotes/origin/master
+          [ "$SOURCE_SHA" = "$GITHUB_SHA" ]
+          [ "$SOURCE_SHA" = "$(git rev-parse origin/master)" ]
+
+          validate_run() {
+            local workflow_file="$1"
+            local run_id="$2"
+            local expected_event="$3"
+            local workflow_id
+            workflow_id="$(
+              gh api "repos/$REPOSITORY/actions/workflows/$workflow_file" --jq '.id'
+            )"
+            read -r observed_workflow path event head_sha head_branch repository status conclusion attempt <<<"$(
+              gh api "repos/$REPOSITORY/actions/runs/$run_id/attempts/1" \
+                --jq '[.workflow_id,.path,.event,.head_sha,.head_branch,.head_repository.full_name,.status,.conclusion,.run_attempt] | @tsv'
+            )"
+            [ "$observed_workflow" = "$workflow_id" ]
+            [ "$path" = ".github/workflows/$workflow_file" ]
+            [ "$event" = "$expected_event" ]
+            [ "$head_sha" = "$SOURCE_SHA" ]
+            [ "$head_branch" = "master" ]
+            [ "$repository" = "$REPOSITORY" ]
+            [ "$status" = "completed" ]
+            [ "$conclusion" = "success" ]
+            [ "$attempt" = "1" ]
+          }
+
+          validate_run oci-production-build.yml "$BUILD_RUN_ID" workflow_run
+          validate_run oci-infrastructure.yml "$INFRASTRUCTURE_RUN_ID" workflow_dispatch
+          if [ "$PHASE" != "dry-run" ]; then
+            validate_run oci-live-data-rollout.yml "$PREREQUISITE_RUN_ID" workflow_dispatch
+            artifact_name="oci-live-data-rollout-${PREREQUISITE_RUN_ID}-1"
+            artifact_count="$(
+              gh api "repos/$REPOSITORY/actions/runs/$PREREQUISITE_RUN_ID/artifacts?per_page=100" \
+                --jq "[.artifacts[] | select(.name == \"$artifact_name\" and .expired == false)] | length"
+            )"
+            [ "$artifact_count" = "1" ]
+          fi
+
+      - name: Reject competing production activity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EXCLUDE_RUN_ID: ${{ github.run_id }}
+        run: ./infra/azure/agents/production-run-exclusivity-stan.sh
+
+      - name: Download exact OCI image provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-image-provenance-${{ inputs.approved_sha }}-${{ inputs.build_run_id }}-1
+          path: artifacts/build
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.build_run_id }}
+
+      - name: Download exact OCI infrastructure provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-infrastructure-provenance-${{ inputs.infrastructure_run_id }}-1
+          path: artifacts/infrastructure
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.infrastructure_run_id }}
+
+      - name: Download prerequisite data evidence
+        if: inputs.phase != 'dry-run'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-live-data-rollout-${{ inputs.prerequisite_run_id }}-1
+          path: artifacts/prerequisite
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.prerequisite_run_id }}
+
+      - name: Verify immutable release and phase provenance
+        id: provenance
+        run: |
+          set -euo pipefail
+          PROVENANCE_DIR=artifacts/build \
+          SOURCE_SHA="$SOURCE_SHA" \
+          EXPECTED_BUILD_RUN_ID="$BUILD_RUN_ID" \
+          EXPECTED_BUILD_RUN_ATTEMPT=1 \
+          OUTPUT_FILE=artifacts/oci-live-data-rollout/images.tsv \
+          VERIFY_REMOTE=0 BOOT_IMAGES=0 \
+            ./infra/oci/scripts/verify-images.sh
+
+          # shellcheck disable=SC1091
+          source artifacts/infrastructure/provenance.env
+          [ "$source_sha" = "$SOURCE_SHA" ]
+          [ "$infrastructure_run_id" = "$INFRASTRUCTURE_RUN_ID" ]
+          [ "$infrastructure_run_attempt" = "1" ]
+          [ "$compartment_ocid" = "$OCI_COMPARTMENT_OCID" ]
+          [ "$namespace" = "$OCI_K8S_NAMESPACE" ]
+          [ "$runtime_mode" = "$OCI_RUNTIME_MODE" ]
+          [ "$infrastructure_finalized" = "true" ]
+          if [ "$runtime_mode" = "oke" ]; then
+            echo "::add-mask::$cluster_ocid"
+            echo "::add-mask::$endpoint_nsg_ocid"
+            printf 'cluster_ocid=%s\n' "$cluster_ocid" >> "$GITHUB_OUTPUT"
+            printf 'endpoint_nsg_ocid=%s\n' "$endpoint_nsg_ocid" >> "$GITHUB_OUTPUT"
+          else
+            echo "::add-mask::$instance_ocid"
+            printf 'instance_ocid=%s\n' "$instance_ocid" >> "$GITHUB_OUTPUT"
+          fi
+          printf 'public_url=https://%s\n' "$public_host" >> "$GITHUB_OUTPUT"
+          printf 'redirect_url=https://%s\n' "$redirect_host" >> "$GITHUB_OUTPUT"
+          printf 'diagnostic_url=https://%s\n' "$diagnostic_host" >> "$GITHUB_OUTPUT"
+
+          if [ "$PHASE" != "dry-run" ]; then
+            expected_phase=dry-run
+            [ "$PHASE" != "apply-slip-index" ] || expected_phase=apply-backfills
+            EVIDENCE_DIR=artifacts/prerequisite \
+            EXPECTED_SOURCE_SHA="$SOURCE_SHA" \
+            EXPECTED_BUILD_RUN_ID="$BUILD_RUN_ID" \
+            EXPECTED_INFRASTRUCTURE_RUN_ID="$INFRASTRUCTURE_RUN_ID" \
+            EXPECTED_PHASE="$expected_phase" \
+            EXPECTED_RUN_ID="$PREREQUISITE_RUN_ID" \
+            EXPECTED_RUN_ATTEMPT=1 \
+              ./infra/oci/scripts/verify-live-betting-data-evidence-stan.sh
+          fi
+
+      - name: Install pinned OCI CLI
+        run: ./infra/oci/scripts/install-cli.sh
+
+      - name: Verify OKE identity
+        if: env.OCI_RUNTIME_MODE == 'oke'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_CLUSTER_OCID: ${{ steps.provenance.outputs.cluster_ocid }}
+        run: |
+          oci ce cluster get \
+            --cluster-id "$OCI_CLUSTER_OCID" \
+            --query 'data.{type:type,state:"lifecycle-state"}' \
+            >/dev/null
+
+      - name: Verify k3s identity
+        if: env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_INSTANCE_OCID: ${{ steps.provenance.outputs.instance_ocid }}
+        run: |
+          oci compute instance get \
+            --instance-id "$OCI_INSTANCE_OCID" \
+            --query 'data.{shape:shape,state:"lifecycle-state"}' \
+            >/dev/null
+
+      - name: Reconcile expired and authorize current runner IPv4
+        if: env.OCI_RUNTIME_MODE == 'oke'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_ENDPOINT_NSG_OCID: ${{ steps.provenance.outputs.endpoint_nsg_ocid }}
+          RULE_STATE_FILE: artifacts/oci-live-data-rollout/runner-rule.env
+        run: |
+          set -euo pipefail
+          ./infra/oci/scripts/authorize-github-runner.sh cleanup-stale
+          RUNNER_PUBLIC_IPV4="$(curl --fail --silent --show-error --max-time 15 https://api.ipify.org)"
+          export RUNNER_PUBLIC_IPV4
+          ./infra/oci/scripts/authorize-github-runner.sh authorize
+
+      - name: Configure kubectl from exact cluster OCID
+        if: env.OCI_RUNTIME_MODE == 'oke'
+        uses: oracle-actions/configure-kubectl-oke@77a733d79446dabe7bf0e58eb56197d33ce4dc58 # v1.5.0
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+        with:
+          cluster: ${{ steps.provenance.outputs.cluster_ocid }}
+
+      - name: Open ephemeral OCI Bastion access to k3s
+        if: env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_K3S_SSH_PRIVATE_KEY: ${{ secrets.OCI_K3S_SSH_PRIVATE_KEY }}
+          INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env
+          SESSION_STATE_FILE: artifacts/oci-live-data-rollout/k3s-access.env
+          WORK_DIR: ${{ runner.temp }}/betstan-k3s-access
+        run: |
+          set -euo pipefail
+          RUNNER_PUBLIC_IPV4="$(
+            curl --fail --silent --show-error --max-time 15 https://api.ipify.org
+          )"
+          export RUNNER_PUBLIC_IPV4
+          ./infra/oci/scripts/configure-k3s-access.sh open
+
+      - name: Acquire database operation lock
+        run: |
+          NAMESPACE="$OCI_K8S_NAMESPACE" \
+          LOCK_TOKEN="$SHARED_MONGO_LOCK_TOKEN" \
+          OPERATION_ID="$SHARED_MONGO_LOCK_OPERATION" \
+          SOURCE_SHA="$SOURCE_SHA" \
+            ./infra/azure/agents/shared-mongo-operation-lock-stan.sh acquire
+
+      - name: Capture pre-mutation rollback baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OUTPUT_DIR: artifacts/oci-data-baseline-before
+          OCI_PUBLIC_URL: ${{ steps.provenance.outputs.public_url }}
+          OCI_REDIRECT_URL: ${{ steps.provenance.outputs.redirect_url }}
+          OCI_DIAGNOSTIC_URL: ${{ steps.provenance.outputs.diagnostic_url }}
+        run: |
+          ./infra/oci/scripts/baseline-capture-stan.sh
+          printf 'BASELINE_SHA256=%s\n' \
+            "$(sha256sum artifacts/oci-data-baseline-before/SHA256SUMS | awk '{print $1}')" \
+            >> "$GITHUB_ENV"
+
+      - name: Fence writes and quiesce legacy data writers
+        id: maintenance_enter
+        if: inputs.phase != 'dry-run'
+        env:
+          STATE_FILE: ${{ runner.temp }}/live-data-maintenance.tsv
+        run: ./infra/oci/scripts/live-data-maintenance-stan.sh enter
+
+      - name: Execute exact-digest live data phase
+        id: data
+        env:
+          IMAGE_PROVENANCE_FILE: artifacts/oci-live-data-rollout/images.tsv
+          OUTPUT_DIR: artifacts/oci-live-data-rollout/evidence
+          JOB_TIMEOUT_SECONDS: "1800"
+          BATCH_SIZE: "100"
+          MAINTENANCE_FENCE_ENFORCED: ${{ inputs.phase != 'dry-run' }}
+          WRITERS_QUIESCED: ${{ inputs.phase != 'dry-run' }}
+          RUNTIME_HELD_FOR_DEPLOY: ${{ inputs.phase == 'apply-slip-index' }}
+          OPERATION_LOCK_ENFORCED: "true"
+          OPERATION_LOCK_HANDOFF: ${{ inputs.phase == 'apply-slip-index' }}
+        run: ./infra/oci/scripts/live-betting-data-rollout-stan.sh
+
+      - name: Restore runtime or verify final deploy handoff
+        id: maintenance
+        if: always() && steps.maintenance_enter.outcome == 'success'
+        env:
+          DATA_OUTCOME: ${{ steps.data.outcome }}
+          STATE_FILE: ${{ runner.temp }}/live-data-maintenance.tsv
+        run: |
+          set -euo pipefail
+          if [[ "$PHASE" == "apply-slip-index" && "$DATA_OUTCOME" == "success" ]]; then
+            if ! ./infra/oci/scripts/live-data-maintenance-stan.sh verify-held; then
+              ./infra/oci/scripts/live-data-maintenance-stan.sh restore
+              exit 1
+            fi
+            NAMESPACE="$OCI_K8S_NAMESPACE" \
+            LOCK_TOKEN="$SHARED_MONGO_LOCK_TOKEN" \
+            OPERATION_ID="$SHARED_MONGO_LOCK_OPERATION" \
+            SOURCE_SHA="$SOURCE_SHA" \
+              ./infra/azure/agents/shared-mongo-operation-lock-stan.sh verify
+          else
+            ./infra/oci/scripts/live-data-maintenance-stan.sh restore
+          fi
+
+      - name: Capture post-phase runtime baseline
+        if: >-
+          steps.data.outcome == 'success' &&
+          inputs.phase != 'apply-slip-index' &&
+          (inputs.phase == 'dry-run' || steps.maintenance.outcome == 'success')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OUTPUT_DIR: artifacts/oci-data-baseline-after
+          OCI_PUBLIC_URL: ${{ steps.provenance.outputs.public_url }}
+          OCI_REDIRECT_URL: ${{ steps.provenance.outputs.redirect_url }}
+          OCI_DIAGNOSTIC_URL: ${{ steps.provenance.outputs.diagnostic_url }}
+        run: ./infra/oci/scripts/baseline-capture-stan.sh
+
+      - name: Upload exact sanitized data evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: oci-live-data-rollout-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/oci-live-data-rollout/evidence
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Upload protected rollout baselines
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: oci-live-data-baselines-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            artifacts/oci-data-baseline-before
+            artifacts/oci-data-baseline-after
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Restore runtime if final handoff packaging failed
+        id: abort_handoff
+        if: >-
+          always() &&
+          failure() &&
+          inputs.phase == 'apply-slip-index' &&
+          steps.data.outcome == 'success' &&
+          steps.maintenance.outcome == 'success'
+        env:
+          STATE_FILE: ${{ runner.temp }}/live-data-maintenance.tsv
+        run: ./infra/oci/scripts/live-data-maintenance-stan.sh restore
+
+      - name: Release database operation lock unless handed to deploy
+        if: >-
+          always() &&
+          (!(inputs.phase == 'apply-slip-index' &&
+             steps.data.outcome == 'success' &&
+             steps.maintenance.outcome == 'success') ||
+           steps.abort_handoff.outcome == 'success')
+        run: |
+          NAMESPACE="$OCI_K8S_NAMESPACE" \
+          LOCK_TOKEN="$SHARED_MONGO_LOCK_TOKEN" \
+          OPERATION_ID="$SHARED_MONGO_LOCK_OPERATION" \
+          SOURCE_SHA="$SOURCE_SHA" \
+            ./infra/azure/agents/shared-mongo-operation-lock-stan.sh release
+          NAMESPACE="$OCI_K8S_NAMESPACE" \
+          LOCK_TOKEN="$SHARED_MONGO_LOCK_TOKEN" \
+          OPERATION_ID="$SHARED_MONGO_LOCK_OPERATION" \
+          SOURCE_SHA="$SOURCE_SHA" \
+            ./infra/azure/agents/shared-mongo-operation-lock-stan.sh verify-released
+
+      - name: Revoke exact runner rule
+        if: always() && env.OCI_RUNTIME_MODE == 'oke'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          RULE_STATE_FILE: artifacts/oci-live-data-rollout/runner-rule.env
+        run: |
+          if [ -f "$RULE_STATE_FILE" ]; then
+            ./infra/oci/scripts/revoke-github-runner.sh "$RULE_STATE_FILE"
+          fi
+
+      - name: Close ephemeral OCI Bastion access
+        if: always() && env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          SESSION_STATE_FILE: artifacts/oci-live-data-rollout/k3s-access.env
+          WORK_DIR: ${{ runner.temp }}/betstan-k3s-access
+        run: ./infra/oci/scripts/configure-k3s-access.sh cleanup
+
+      - name: Remove isolated OCI client state
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/oci-home"

--- a/.github/workflows/oci-production-deploy.yml
+++ b/.github/workflows/oci-production-deploy.yml
@@ -16,6 +16,10 @@ on:
         description: Successful first-attempt oci-infrastructure run ID
         required: true
         type: string
+      data_run_id:
+        description: Successful first-attempt final oci-live-data-rollout run ID
+        required: true
+        type: string
       confirmation:
         description: Type DEPLOY OCI EXACT SHA
         required: true
@@ -44,6 +48,7 @@ jobs:
       SOURCE_SHA: ${{ inputs.approved_sha }}
       BUILD_RUN_ID: ${{ inputs.build_run_id }}
       INFRASTRUCTURE_RUN_ID: ${{ inputs.infrastructure_run_id }}
+      DATA_RUN_ID: ${{ inputs.data_run_id }}
       CONFIRMATION: ${{ inputs.confirmation }}
       OCI_RUNTIME_MODE: ${{ vars.OCI_RUNTIME_MODE }}
       OCI_CLI_VERSION: "3.90.0"
@@ -105,6 +110,7 @@ jobs:
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$BUILD_RUN_ID" =~ ^[1-9][0-9]*$ ]]
           [[ "$INFRASTRUCTURE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$DATA_RUN_ID" =~ ^[1-9][0-9]*$ ]]
           [ "$GITHUB_RUN_ATTEMPT" = "1" ]
           git fetch --quiet origin master:refs/remotes/origin/master
           [ "$SOURCE_SHA" = "$GITHUB_SHA" ]
@@ -135,7 +141,39 @@ jobs:
           [ "$head_branch" = "master" ]
           [ "$repository" = "$REPOSITORY" ]
           [ "$status" = "completed" ] && [ "$conclusion" = "success" ] && [ "$attempt" = "1" ]
-          mkdir -p "$HOME/.kube" artifacts/build artifacts/infrastructure artifacts/oci-deploy
+
+          data_workflow_id="$(gh api "repos/$REPOSITORY/actions/workflows/oci-live-data-rollout.yml" --jq '.id')"
+          read -r workflow_id workflow_path event head_sha head_branch repository status conclusion attempt <<<"$(
+            gh api "repos/$REPOSITORY/actions/runs/$DATA_RUN_ID/attempts/1" \
+              --jq '[.workflow_id,.path,.event,.head_sha,.head_branch,.head_repository.full_name,.status,.conclusion,.run_attempt] | @tsv'
+          )"
+          [ "$workflow_id" = "$data_workflow_id" ]
+          [ "$workflow_path" = ".github/workflows/oci-live-data-rollout.yml" ]
+          [ "$event" = "workflow_dispatch" ]
+          [ "$head_sha" = "$SOURCE_SHA" ]
+          [ "$head_branch" = "master" ]
+          [ "$repository" = "$REPOSITORY" ]
+          [ "$status" = "completed" ] && [ "$conclusion" = "success" ] && [ "$attempt" = "1" ]
+          artifact_name="oci-live-data-rollout-${DATA_RUN_ID}-1"
+          artifact_count="$(
+            gh api "repos/$REPOSITORY/actions/runs/$DATA_RUN_ID/artifacts?per_page=100" \
+              --jq "[.artifacts[] | select(.name == \"$artifact_name\" and .expired == false)] | length"
+          )"
+          [ "$artifact_count" = "1" ]
+          baseline_artifact_name="oci-live-data-baselines-${DATA_RUN_ID}-1"
+          baseline_artifact_count="$(
+            gh api "repos/$REPOSITORY/actions/runs/$DATA_RUN_ID/artifacts?per_page=100" \
+              --jq "[.artifacts[] | select(.name == \"$baseline_artifact_name\" and .expired == false)] | length"
+          )"
+          [ "$baseline_artifact_count" = "1" ]
+          mkdir -p \
+            "$HOME/.kube" \
+            artifacts/build \
+            artifacts/data \
+            artifacts/data-baselines \
+            artifacts/infrastructure \
+            artifacts/oci-baseline \
+            artifacts/oci-deploy
           chmod 700 "$HOME" "$HOME/.kube"
 
       - name: Download exact OCI image provenance
@@ -155,6 +193,24 @@ jobs:
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ inputs.infrastructure_run_id }}
+
+      - name: Download exact live data readiness evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-live-data-rollout-${{ inputs.data_run_id }}-1
+          path: artifacts/data
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.data_run_id }}
+
+      - name: Download exact pre-mutation rollback baseline
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-live-data-baselines-${{ inputs.data_run_id }}-1
+          path: artifacts/data-baselines
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.data_run_id }}
 
       - name: Verify immutable image and infrastructure provenance
         id: provenance
@@ -179,6 +235,32 @@ jobs:
           [ "$canonical_host" = "$OCI_CANONICAL_HOST" ]
           [ "$redirect_host" = "$OCI_REDIRECT_HOST" ]
           [ "$diagnostic_host" = "${ingress_ipv4}.nip.io" ]
+          EVIDENCE_DIR=artifacts/data \
+          EXPECTED_SOURCE_SHA="$SOURCE_SHA" \
+          EXPECTED_BUILD_RUN_ID="$BUILD_RUN_ID" \
+          EXPECTED_INFRASTRUCTURE_RUN_ID="$INFRASTRUCTURE_RUN_ID" \
+          EXPECTED_PHASE=apply-slip-index \
+          EXPECTED_RUN_ID="$DATA_RUN_ID" \
+          EXPECTED_RUN_ATTEMPT=1 \
+            ./infra/oci/scripts/verify-live-betting-data-evidence-stan.sh
+          mapfile -t baseline_manifests < <(
+            find artifacts/data-baselines \
+              -type f \
+              -path '*/oci-data-baseline-before/SHA256SUMS'
+          )
+          [ "${#baseline_manifests[@]}" = "1" ]
+          baseline_dir="$(dirname "${baseline_manifests[0]}")"
+          [ -z "$(find "$baseline_dir" -type l -print -quit)" ]
+          baseline_sha256="$(sha256sum "$baseline_dir/SHA256SUMS" | awk '{print $1}')"
+          expected_baseline_sha256="$(
+            awk -F= '$1 == "baseline_sha256" {print $2}' artifacts/data/schema.env
+          )"
+          [ "$baseline_sha256" = "$expected_baseline_sha256" ]
+          (
+            cd "$baseline_dir"
+            sha256sum --quiet --check SHA256SUMS
+          )
+          cp -a "$baseline_dir/." artifacts/oci-baseline/
           if [ "$runtime_mode" = "oke" ]; then
             echo "::add-mask::$cluster_ocid"
             echo "::add-mask::$endpoint_nsg_ocid"
@@ -277,15 +359,17 @@ jobs:
           export RUNNER_PUBLIC_IPV4
           ./infra/oci/scripts/configure-k3s-access.sh open
 
-      - name: Capture protected OCI rollback baseline
+      - name: Verify transferred database lock and maintenance fence
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          OUTPUT_DIR: artifacts/oci-baseline
-          OCI_PUBLIC_URL: ${{ steps.provenance.outputs.public_url }}
-          OCI_REDIRECT_URL: ${{ steps.provenance.outputs.redirect_url }}
-          OCI_DIAGNOSTIC_URL: ${{ steps.provenance.outputs.diagnostic_url }}
-        run: ./infra/oci/scripts/baseline-capture-stan.sh
+          STATE_FILE: artifacts/oci-deploy/unused-maintenance-state.tsv
+        run: |
+          set -euo pipefail
+          NAMESPACE="$OCI_K8S_NAMESPACE" \
+          LOCK_TOKEN="live-data-${DATA_RUN_ID}-1" \
+          OPERATION_ID="live-data-apply-slip-index" \
+          SOURCE_SHA="$SOURCE_SHA" \
+            ./infra/oci/scripts/shared-mongo-operation-lock-stan.sh verify
+          ./infra/oci/scripts/live-data-maintenance-stan.sh verify-held
 
       - name: Upload protected OCI rollback baseline
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -311,6 +395,17 @@ jobs:
           OUTPUT_DIR: artifacts/oci-deploy
         run: ./infra/oci/scripts/deploy.sh
 
+      - name: Bind schema evidence to deployment provenance
+        id: bind
+        run: |
+          set -euo pipefail
+          {
+            printf 'data_run_id=%s\n' "$DATA_RUN_ID"
+            printf 'data_run_attempt=1\n'
+            printf 'data_evidence_sha256=%s\n' "$(sha256sum artifacts/data/SHA256SUMS | awk '{print $1}')"
+          } >> artifacts/oci-deploy/provenance.txt
+          cp artifacts/data/schema.env artifacts/oci-deploy/live-schema.env
+
       - name: Run protected OCI cluster validation loop
         id: health
         env:
@@ -328,11 +423,63 @@ jobs:
           OCI_DIAGNOSTIC_URL: ${{ steps.provenance.outputs.diagnostic_url }}
           OCI_PUBLIC_CHECKS_ALREADY_PASSED: "1"
           OCI_E2E_ALREADY_PASSED: "1"
+          OCI_EXPECT_HTTP_MUTATION_FENCE: "1"
+          EXPECTED_OPERATION_LOCK_HOLDER: live-data-${{ inputs.data_run_id }}-1
+          EXPECTED_OPERATION_LOCK_ID: live-data-apply-slip-index
+          EXPECTED_OPERATION_LOCK_SOURCE_SHA: ${{ inputs.approved_sha }}
           LIVE_BETTING_READINESS_MODE: dark
           LIVE_READINESS_REQUEST_TIMEOUT: "15"
           LIVE_READINESS_SSE_TIMEOUT: "20"
           OUTPUT_DIR: artifacts/oci-deploy-validation
         run: ./infra/oci/agents/deploy-validation-loop-stan.sh
+
+      - name: Release transferred lock after protected validation
+        id: release_lock
+        if: steps.health.outcome == 'success'
+        run: |
+          NAMESPACE="$OCI_K8S_NAMESPACE" \
+          LOCK_TOKEN="live-data-${DATA_RUN_ID}-1" \
+          OPERATION_ID="live-data-apply-slip-index" \
+          SOURCE_SHA="$SOURCE_SHA" \
+            ./infra/oci/scripts/shared-mongo-operation-lock-stan.sh release
+          NAMESPACE="$OCI_K8S_NAMESPACE" \
+          LOCK_TOKEN="live-data-${DATA_RUN_ID}-1" \
+          OPERATION_ID="live-data-apply-slip-index" \
+          SOURCE_SHA="$SOURCE_SHA" \
+            ./infra/oci/scripts/shared-mongo-operation-lock-stan.sh verify-released
+
+      - name: Release live data maintenance fence
+        id: release_runtime
+        if: steps.release_lock.outcome == 'success'
+        env:
+          STATE_FILE: artifacts/oci-deploy/unused-maintenance-state.tsv
+        run: ./infra/oci/scripts/live-data-maintenance-stan.sh release
+
+      - name: Re-enter maintenance after an incomplete deployment
+        id: rehold
+        if: >-
+          always() &&
+          (steps.apply.outcome == 'failure' ||
+            steps.bind.outcome == 'failure' ||
+            steps.release_lock.outcome == 'failure' ||
+            steps.health.outcome == 'failure' ||
+            steps.release_runtime.outcome == 'failure')
+        env:
+          STATE_FILE: artifacts/oci-deploy/unused-maintenance-state.tsv
+        run: |
+          set -euo pipefail
+          ./infra/oci/scripts/live-data-maintenance-stan.sh hold
+          if ! NAMESPACE="$OCI_K8S_NAMESPACE" \
+            LOCK_TOKEN="live-data-${DATA_RUN_ID}-1" \
+            OPERATION_ID="live-data-apply-slip-index" \
+            SOURCE_SHA="$SOURCE_SHA" \
+              ./infra/oci/scripts/shared-mongo-operation-lock-stan.sh verify; then
+            NAMESPACE="$OCI_K8S_NAMESPACE" \
+            LOCK_TOKEN="live-data-${DATA_RUN_ID}-1" \
+            OPERATION_ID="live-data-apply-slip-index" \
+            SOURCE_SHA="$SOURCE_SHA" \
+              ./infra/oci/scripts/shared-mongo-operation-lock-stan.sh acquire
+          fi
 
       - name: Upload sanitized live readiness evidence
         if: always()
@@ -344,7 +491,14 @@ jobs:
           retention-days: 14
 
       - name: Capture sanitized deployment diagnostics
-        if: always() && (steps.apply.outcome == 'failure' || steps.health.outcome == 'failure')
+        if: >-
+          always() &&
+          (steps.apply.outcome == 'failure' ||
+            steps.bind.outcome == 'failure' ||
+            steps.release_lock.outcome == 'failure' ||
+            steps.health.outcome == 'failure' ||
+            steps.release_runtime.outcome == 'failure' ||
+            steps.rehold.outcome == 'failure')
         env:
           OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
           OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
@@ -360,7 +514,14 @@ jobs:
             > artifacts/oci-deploy-validation/final/node-logs.txt 2>&1 || true
 
       - name: Upload sanitized diagnostics on failure
-        if: always() && (steps.apply.outcome == 'failure' || steps.health.outcome == 'failure')
+        if: >-
+          always() &&
+          (steps.apply.outcome == 'failure' ||
+            steps.bind.outcome == 'failure' ||
+            steps.release_lock.outcome == 'failure' ||
+            steps.health.outcome == 'failure' ||
+            steps.release_runtime.outcome == 'failure' ||
+            steps.rehold.outcome == 'failure')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: oci-deploy-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
@@ -376,6 +537,7 @@ jobs:
             artifacts/oci-deploy/provenance.txt
             artifacts/oci-deploy/images.tsv
             artifacts/oci-deploy/rabbitmq-baseline.txt
+            artifacts/oci-deploy/live-schema.env
           if-no-files-found: error
           retention-days: 30
 
@@ -408,7 +570,7 @@ jobs:
       - name: Remove isolated OCI client state
         if: always()
         run: |
-          rm -rf "$HOME"
+          rm -rf "$RUNNER_TEMP/oci-home"
           rm -f artifacts/oci-deploy/rendered.yaml
 
   public-validate:

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -128,7 +128,13 @@ jobs:
           bash -n infra/oci/agents/deploy-validation-loop-stan.sh
           bash -n infra/oci/agents/live-betting-readiness-stan.sh
           bash -n infra/oci/scripts/deploy.sh
+          bash -n infra/oci/scripts/live-data-maintenance-stan.sh
+          bash -n infra/oci/scripts/live-betting-data-rollout-stan.sh
+          bash -n infra/oci/scripts/shared-mongo-operation-lock-stan.sh
+          bash -n infra/oci/scripts/verify-live-betting-data-evidence-stan.sh
           bash -n infra/oci/tests/test-deploy-validation-loop-stan.sh
+          bash -n infra/oci/tests/test-live-data-maintenance-stan.sh
+          bash -n infra/oci/tests/test-live-betting-data-rollout-stan.sh
           bash -n infra/oci/tests/test-live-betting-readiness-stan.sh
           bash -n infra/oci/tests/rollback-live-readiness-contract.sh
           bash -n infra/oci/tests/rollback-contract.sh
@@ -136,6 +142,7 @@ jobs:
             %w[
               .github/workflows/production-build.yml
               .github/workflows/production-deploy.yml
+              .github/workflows/oci-live-data-rollout.yml
               .github/workflows/oci-production-deploy.yml
             ].each { |file| YAML.load_stream(File.read(file)) }
           '
@@ -146,6 +153,8 @@ jobs:
           ./infra/azure/agents/test-live-betting-rollback-readiness-stan.sh
           ./infra/azure/agents/test-production-rollback-stan.sh
           ./infra/oci/tests/test-deploy-validation-loop-stan.sh
+          ./infra/oci/tests/test-live-data-maintenance-stan.sh
+          ./infra/oci/tests/test-live-betting-data-rollout-stan.sh
           ./infra/oci/tests/test-live-betting-readiness-stan.sh
           ./infra/oci/tests/rollback-live-readiness-contract.sh
           ./infra/oci/tests/rollback-contract.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ Copilot CLI-created pull requests carry the `copilot-cli-managed` label. They ma
 
 Protected environment approval for CLI-managed work uses `copilot-cli-run-approval-stan.sh`. It additionally requires current `master`, a single associated labelled `dev` promotion, first-attempt workflow provenance, the exact expected environment, and no competing production workflow. Automatic approval is limited to normal application build/deploy workflows; rollback, migration, and infrastructure workflows remain human-gated.
 
+Schema-dependent OCI releases use the reviewer-gated `oci-live-data-rollout` workflow before deployment. Its exact-SHA phases are chained `dry-run` → `apply-backfills` → `apply-slip-index`; `oci-production-deploy` requires the final hash-bound schema evidence and pre-mutation rollback baseline from the same build and infrastructure runs. Mutating phases fence public writes and quiesce legacy data writers. A successful final phase deliberately retains that maintenance state and the shared-Mongo operation lock until the exact deployment passes protected validation, so dispatch the bound deployment immediately; an incomplete deployment re-enters the same fail-closed state for a safe retry.
+
 ## Production safety
 
 Merging to `master` runs validation, then queues the first-attempt image build for approval through the master-only `production-emergency` environment. Production never deploys automatically. After the build succeeds, dispatch `production-deploy` from `master` with the exact full SHA and build run ID; the same environment requires a second approval. The workflow validates all nine build artifacts and deploys immutable tag-plus-digest image references. Rerun builds are not deployable, and retired workflow identities remain disabled.

--- a/bet/src/service/__test__/PendingBetUpdateWorker.test.ts
+++ b/bet/src/service/__test__/PendingBetUpdateWorker.test.ts
@@ -734,6 +734,7 @@ it("waits for in-flight work to finish before stopping and cleans heartbeat time
   await stopPromise;
   await startPromise;
 
+  await waitForCondition(async () => clock.pendingTimerCount() === 0);
   expect(clock.pendingTimerCount()).toEqual(0);
   expect((await Bet.findOne({ slipId }))!.status).toEqual(BetStatus.CONFIRMED);
 

--- a/infra/azure/agents/audit-oci-primary-retirement-stan.sh
+++ b/infra/azure/agents/audit-oci-primary-retirement-stan.sh
@@ -28,6 +28,7 @@ readonly WORKFLOW_RECOVERY="oci-migration-recovery.yml"
 readonly WORKFLOW_CAPACITY="oci-capacity-acquire.yml"
 readonly WORKFLOW_INFRASTRUCTURE="oci-infrastructure.yml"
 readonly WORKFLOW_OCI_BUILD="oci-production-build.yml"
+readonly WORKFLOW_DATA="oci-live-data-rollout.yml"
 readonly WORKFLOW_DEPLOY="oci-production-deploy.yml"
 readonly WORKFLOW_AZURE_BUILD="production-build.yml"
 readonly WORKFLOW_AZURE_DEPLOY="production-deploy.yml"
@@ -1556,6 +1557,7 @@ _expected_workflow_state() {
     "$WORKFLOW_CAPACITY") echo "disabled_manually" ;;
     "$WORKFLOW_INFRASTRUCTURE") echo "active" ;;
     "$WORKFLOW_OCI_BUILD") echo "active" ;;
+    "$WORKFLOW_DATA") echo "active" ;;
     "$WORKFLOW_DEPLOY") echo "active" ;;
     "$WORKFLOW_AZURE_BUILD") echo "active" ;;
     "$WORKFLOW_AZURE_DEPLOY") echo "active" ;;
@@ -1570,6 +1572,7 @@ check_workflows() {
     "$WORKFLOW_MIGRATE"
     "$WORKFLOW_RECOVERY"
     "$WORKFLOW_OCI_BUILD"
+    "$WORKFLOW_DATA"
     "$WORKFLOW_DEPLOY"
     "$WORKFLOW_AZURE_BUILD"
     "$WORKFLOW_AZURE_DEPLOY"

--- a/infra/azure/agents/live-betting-readiness-lib.sh
+++ b/infra/azure/agents/live-betting-readiness-lib.sh
@@ -1147,27 +1147,45 @@ live_betting_check_topology() {
   local lock_file="$2"
   local result_stdout="$LIVE_BETTING_WORK_DIR/topology.result"
   local result_stderr="$LIVE_BETTING_WORK_DIR/topology.result.stderr"
-  if ! python3 - "$topology_file" "$lock_file" >"$result_stdout" 2>"$result_stderr" <<'PY'
+  if ! python3 - \
+    "$topology_file" \
+    "$lock_file" \
+    "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_HOLDER" \
+    "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_ID" \
+    "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_SOURCE_SHA" \
+    >"$result_stdout" 2>"$result_stderr" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-topology_path, lock_path = sys.argv[1:]
+topology_path, lock_path, expected_holder, expected_operation, expected_sha = sys.argv[1:]
 topology = json.loads(Path(topology_path).read_text(encoding="utf-8"))
 topology_data = topology.get("data") or {}
 mode = str(topology_data.get("mode", "legacy") or "legacy")
 validated = str(topology_data.get("validated", "false") or "false").lower()
+expect_active_lock = bool(expected_holder or expected_operation or expected_sha)
 if mode == "shared":
     if validated != "true":
         raise SystemExit("shared Mongo topology must be validated")
     lock_state = "missing"
     if Path(lock_path).exists():
         lock = json.loads(Path(lock_path).read_text(encoding="utf-8"))
-        lock_state = str((lock.get("data") or {}).get("state", "missing"))
-        if lock_state not in {"released", "missing", ""}:
+        lock_data = lock.get("data") or {}
+        lock_state = str(lock_data.get("state", "missing"))
+        if expect_active_lock:
+            if (
+                lock_state != "active"
+                or str(lock_data.get("holder", "")) != expected_holder
+                or str(lock_data.get("operation-id", "")) != expected_operation
+                or str(lock_data.get("source-sha", "")) != expected_sha
+            ):
+                raise SystemExit("shared Mongo operation lock differs from the expected active handoff")
+        elif lock_state not in {"released", "missing", ""}:
             raise SystemExit("shared Mongo operation lock must be released")
         if lock_state == "":
             lock_state = "missing"
+    elif expect_active_lock:
+        raise SystemExit("expected shared Mongo operation lock is missing")
     print("topology_validated=true")
     print(f"lock_state={lock_state}")
 elif mode == "legacy":
@@ -1860,6 +1878,9 @@ live_betting_readiness_main() {
   LIVE_BETTING_EXACT_MASTER_PROVENANCE_FILE="${EXACT_MASTER_PROVENANCE_FILE:-}"
   LIVE_BETTING_SCHEMA_EVIDENCE_FILE="${LIVE_SCHEMA_EVIDENCE_FILE:-}"
   LIVE_BETTING_ROLLBACK_BASELINE_FILE="${ROLLBACK_BASELINE_FILE:-}"
+  LIVE_BETTING_EXPECTED_OPERATION_LOCK_HOLDER="${EXPECTED_OPERATION_LOCK_HOLDER:-}"
+  LIVE_BETTING_EXPECTED_OPERATION_LOCK_ID="${EXPECTED_OPERATION_LOCK_ID:-}"
+  LIVE_BETTING_EXPECTED_OPERATION_LOCK_SOURCE_SHA="${EXPECTED_OPERATION_LOCK_SOURCE_SHA:-}"
   LIVE_BETTING_PUBLIC_HOSTS_REQUIRED="${PUBLIC_HOSTS_REQUIRED:-0}"
   LIVE_BETTING_DIAGNOSTIC_URL_REQUIRED="${DIAGNOSTIC_URL_REQUIRED:-0}"
   LIVE_BETTING_REQUIRE_HTTPS_PRIMARY="${REQUIRE_HTTPS_PRIMARY:-0}"
@@ -1942,6 +1963,16 @@ live_betting_readiness_main() {
     live_betting_record_failure preflight "IMAGE_PROVENANCE_FILE is required"
   [[ "$(live_betting_normalize_bool "$LIVE_BETTING_EXPECTED_FLAG")" != invalid ]] ||
     live_betting_record_failure preflight "EXPECTED_LIVE_KICKOFFS_ENABLED must be explicit true or false"
+  if [[ -n "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_HOLDER" ||
+        -n "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_ID" ||
+        -n "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_SOURCE_SHA" ]]; then
+    [[ "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_HOLDER" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] ||
+      live_betting_record_failure preflight "EXPECTED_OPERATION_LOCK_HOLDER is invalid"
+    [[ "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] ||
+      live_betting_record_failure preflight "EXPECTED_OPERATION_LOCK_ID is invalid"
+    [[ "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+      live_betting_record_failure preflight "EXPECTED_OPERATION_LOCK_SOURCE_SHA is invalid"
+  fi
   live_betting_require_uint REQUEST_TIMEOUT "$LIVE_BETTING_REQUEST_TIMEOUT"
   live_betting_require_uint SSE_TIMEOUT "$LIVE_BETTING_SSE_TIMEOUT"
   live_betting_require_uint MAX_ACTIVE_MATCHES "$LIVE_BETTING_MAX_ACTIVE_MATCHES"

--- a/infra/azure/agents/live-betting-readiness-test-lib.sh
+++ b/infra/azure/agents/live-betting-readiness-test-lib.sh
@@ -269,7 +269,18 @@ if [[ "$args" == *"get configmap gaming-mongo-migration-lock"* ]]; then
     echo 'Error from server (NotFound): configmaps "gaming-mongo-migration-lock" not found' >&2
     exit 1
   fi
-  printf '{"data":{"state":"%s"}}\n' "${STUB_LOCK_STATE:-released}"
+  jq -cn \
+    --arg state "${STUB_LOCK_STATE:-released}" \
+    --arg holder "${STUB_LOCK_HOLDER:-}" \
+    --arg operation "${STUB_LOCK_OPERATION_ID:-}" \
+    --arg source_sha "${STUB_LOCK_SOURCE_SHA:-}" '{
+      data:{
+        state:$state,
+        holder:$holder,
+        "operation-id":$operation,
+        "source-sha":$source_sha
+      }
+    }'
   exit 0
 fi
 if [[ "$args" == *"rabbitmqctl list_queues name messages_ready messages_unacknowledged consumers"* ]]; then
@@ -551,7 +562,13 @@ run_live_betting_scenario() {
     export STUB_TOPOLOGY_VALIDATED=true
     export STUB_TOPOLOGY_MISSING=0
     export STUB_LOCK_STATE=released
+    export STUB_LOCK_HOLDER=
+    export STUB_LOCK_OPERATION_ID=
+    export STUB_LOCK_SOURCE_SHA=
     export STUB_LOCK_MISSING=0
+    export EXPECTED_OPERATION_LOCK_HOLDER=
+    export EXPECTED_OPERATION_LOCK_ID=
+    export EXPECTED_OPERATION_LOCK_SOURCE_SHA=
     export STUB_QUEUE_READY=0
     export STUB_QUEUE_UNACK=0
     export STUB_DURABLE_CONSUMERS=1

--- a/infra/azure/agents/production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/production-run-exclusivity-stan.sh
@@ -47,6 +47,7 @@ paths = {
     ".github/workflows/oci-production-rollback.yml",
     ".github/workflows/oci-infrastructure.yml",
     ".github/workflows/oci-capacity-acquire.yml",
+    ".github/workflows/oci-live-data-rollout.yml",
     ".github/workflows/oci-migrate.yml",
     ".github/workflows/oci-migration-recovery.yml",
 }

--- a/infra/azure/agents/production-workflow-inventory-stan.rb
+++ b/infra/azure/agents/production-workflow-inventory-stan.rb
@@ -12,6 +12,7 @@ AZURE_WORKFLOWS = %w[
 OCI_WORKFLOWS = %w[
   oci-capacity-acquire
   oci-infrastructure
+  oci-live-data-rollout
   oci-migrate
   oci-migration-recovery
   oci-production-build
@@ -23,6 +24,7 @@ PROTECTED_ENVIRONMENTS = {
   "production-rollback" => "production-emergency",
   "oci-capacity-acquire" => "oci-capacity-acquire",
   "oci-infrastructure" => "oci-infrastructure",
+  "oci-live-data-rollout" => "oci-migration",
   "oci-migrate" => "oci-migration",
   "oci-migration-recovery" => "azure-migration-recovery",
   "oci-production-build" => "oci-build",
@@ -37,6 +39,12 @@ ROLLBACK_ACTION_PINS = {
     "azure/aks-set-context" => "c7eb093e5a5d47caa333f64974d5fd1cd4bf069d"
   },
   "oci-production-rollback" => {
+    "actions/checkout" => "11bd71901bbe5b1630ceea73d27597364c9af683",
+    "actions/download-artifact" => "d3f86a106a0bac45b974a628896c90dbdf5c8093",
+    "actions/upload-artifact" => "ea165f8d65b6e75b540449e92b4886f43607fa02",
+    "oracle-actions/configure-kubectl-oke" => "77a733d79446dabe7bf0e58eb56197d33ce4dc58"
+  },
+  "oci-live-data-rollout" => {
     "actions/checkout" => "11bd71901bbe5b1630ceea73d27597364c9af683",
     "actions/download-artifact" => "d3f86a106a0bac45b974a628896c90dbdf5c8093",
     "actions/upload-artifact" => "ea165f8d65b6e75b540449e92b4886f43607fa02",
@@ -661,6 +669,76 @@ def validate_scheduled_oci_workflow!(name, document, content)
   )
 end
 
+def validate_live_data_rollout_workflow!(file, document, content)
+  name = "oci-live-data-rollout"
+  unless File.basename(file) == "#{name}.yml"
+    fail_inventory("#{name} must use .github/workflows/#{name}.yml")
+  end
+
+  validate_dispatch_only_workflow!(name, document)
+  validate_required_workflow_dispatch_inputs!(
+    name,
+    document,
+    %w[
+      approved_sha
+      build_run_id
+      infrastructure_run_id
+      phase
+      prerequisite_run_id
+      confirmation
+    ]
+  )
+  validate_exact_permissions!(name, document, { "actions" => "read", "contents" => "read" })
+  validate_expected_action_pins!(name, content)
+
+  phase = workflow_dispatch_inputs(document)["phase"]
+  unless phase.is_a?(Hash) &&
+         phase["type"] == "choice" &&
+         phase["options"] == %w[dry-run apply-backfills apply-slip-index]
+    fail_inventory("#{name} must expose only the three reviewed rollout phases")
+  end
+
+  {
+    "DRY RUN LIVE DATA EXACT SHA" => "read-only confirmation",
+    "APPLY LIVE BACKFILLS EXACT SHA" => "backfill confirmation",
+    "APPLY LIVE SLIP INDEX EXACT SHA" => "index confirmation",
+    "oci-production-build.yml" => "exact build provenance",
+    "oci-infrastructure.yml" => "exact infrastructure provenance",
+    "oci-live-data-rollout.yml" => "phase-chain provenance",
+    "production-run-exclusivity-stan.sh" => "production run exclusivity",
+    "baseline-capture-stan.sh" => "before and after rollback baselines",
+    "shared-mongo-operation-lock-stan.sh acquire" => "database operation lock acquisition",
+    "shared-mongo-operation-lock-stan.sh verify" => "database operation lock handoff",
+    "shared-mongo-operation-lock-stan.sh release" => "always-run database lock release",
+    "live-data-maintenance-stan.sh enter" => "legacy writer quiescence",
+    "live-data-maintenance-stan.sh verify-held" => "deploy maintenance handoff",
+    "live-betting-data-rollout-stan.sh" => "reviewed data operator",
+    "verify-live-betting-data-evidence-stan.sh" => "tamper-evident phase validation"
+  }.each do |literal, label|
+    require_content(
+      content,
+      /#{Regexp.escape(literal)}/,
+      "#{name} is missing #{label}"
+    )
+  end
+
+  require_content(
+    content,
+    /group:\s*oci-control-plane/,
+    "#{name} must serialize with the OCI control plane"
+  )
+  require_content(
+    content,
+    /cancel-in-progress:\s*false/,
+    "#{name} must never cancel an in-flight data operation"
+  )
+  require_content(
+    content,
+    /expected_phase=apply-backfills/,
+    "#{name} must chain the Slip index phase to completed backfills"
+  )
+end
+
 def validate_oci_workflow!(name, file, document, content)
   expected_file = "#{name}.yml"
   unless File.basename(file) == expected_file
@@ -726,6 +804,8 @@ def validate_oci_workflow!(name, file, document, content)
     validate_scheduled_oci_workflow!(name, document, content)
   elsif name == "oci-migration-recovery"
     validate_migration_recovery_workflow!(name, document, content)
+  elsif name == "oci-live-data-rollout"
+    validate_live_data_rollout_workflow!(file, document, content)
   else
     validate_manual_oci_workflow!(name, document, content)
   end

--- a/infra/azure/agents/shared-mongo-operation-lock-stan.sh
+++ b/infra/azure/agents/shared-mongo-operation-lock-stan.sh
@@ -72,6 +72,34 @@ case "$ACTION" in
       fail "another database operation holds $LOCK_CONFIGMAP"
     echo "shared_mongo_lock=acquire status=PASS"
     ;;
+  verify)
+    validate_identity
+    lock_state="$(
+      kubectl get configmap "$LOCK_CONFIGMAP" -n "$NAMESPACE" \
+        -o jsonpath='{.data.state}|{.data.holder}|{.data.operation-id}|{.data.source-sha}'
+    )" || fail "unable to read database operation lock"
+    IFS='|' read -r state holder operation_id source_sha <<<"$lock_state"
+    [[ "$state" == "active" &&
+      "$holder" == "$LOCK_TOKEN" &&
+      "$operation_id" == "$OPERATION_ID" &&
+      "$source_sha" == "$SOURCE_SHA" ]] ||
+      fail "active database operation lock does not match the expected handoff"
+    echo "shared_mongo_lock=verify status=PASS"
+    ;;
+  verify-released)
+    validate_identity
+    lock_state="$(
+      kubectl get configmap "$LOCK_CONFIGMAP" -n "$NAMESPACE" \
+        -o jsonpath='{.data.state}|{.data.holder}|{.data.operation-id}|{.data.source-sha}'
+    )" || fail "unable to read database operation lock"
+    IFS='|' read -r state holder operation_id source_sha <<<"$lock_state"
+    [[ "$state" == "released" &&
+      -z "$holder" &&
+      "$operation_id" == "$OPERATION_ID" &&
+      "$source_sha" == "$SOURCE_SHA" ]] ||
+      fail "released database operation lock does not match the expected handoff"
+    echo "shared_mongo_lock=verify-released status=PASS"
+    ;;
   release)
     validate_identity
     error_file="$(mktemp)"
@@ -118,7 +146,7 @@ case "$ACTION" in
     echo "shared_mongo_lock=force-release status=PASS"
     ;;
   *)
-    echo "usage: $0 {acquire|release|force-release}" >&2
+    echo "usage: $0 {acquire|verify|verify-released|release|force-release}" >&2
     exit 2
     ;;
 esac

--- a/infra/azure/agents/test-audit-oci-primary-retirement-stan.sh
+++ b/infra/azure/agents/test-audit-oci-primary-retirement-stan.sh
@@ -963,6 +963,7 @@ case "${1:-}" in
         *oci-capacity-acquire.yml*) state="disabled_manually" ;;
         *oci-infrastructure.yml*) state="active" ;;
         *oci-production-build.yml*) state="active" ;;
+        *oci-live-data-rollout.yml*) state="active" ;;
         *oci-production-deploy.yml*) state="active" ;;
         *production-build.yml*) state="active" ;;
         *production-deploy.yml*) state="${STUB_AZURE_DEPLOY_STATE:-active}" ;;
@@ -1295,6 +1296,8 @@ assert_contains "$RUN_OUTPUT" "workflow_production-deploy_state=correct" \
   "all production-capable workflows are governed"
 assert_contains "$RUN_OUTPUT" "workflow_oci-production-build_state=correct" \
   "OCI build workflow is governed"
+assert_contains "$RUN_OUTPUT" "workflow_oci-live-data-rollout_state=correct" \
+  "OCI data rollout workflow is governed"
 
 new_case mature
 mature_cutoff_date="$(epoch_date "$MATURE_CUTOFF_EPOCH")"

--- a/infra/azure/agents/test-deployment-safety-ci-stan.sh
+++ b/infra/azure/agents/test-deployment-safety-ci-stan.sh
@@ -10,6 +10,7 @@ PRE_COMMIT_CHECK="$ROOT_DIR/infra/azure/agents/pre-commit-infra-check-stan.sh"
 PR_MERGE_SAFETY_TEST="$ROOT_DIR/infra/azure/agents/test-pr-merge-safety-stan.sh"
 RUN_APPROVAL_TEST="$ROOT_DIR/infra/azure/agents/test-copilot-cli-run-approval-stan.sh"
 RUN_EXCLUSIVITY_TEST="$ROOT_DIR/infra/azure/agents/test-production-run-exclusivity-stan.sh"
+LIVE_DATA_ROLLOUT_TEST="$ROOT_DIR/infra/oci/tests/test-live-betting-data-rollout-stan.sh"
 
 test_output="$(mktemp)"
 trap 'rm -f "$test_output"' EXIT
@@ -29,6 +30,7 @@ fi
 "$PR_MERGE_SAFETY_TEST"
 "$RUN_APPROVAL_TEST"
 "$RUN_EXCLUSIVITY_TEST"
+"$LIVE_DATA_ROLLOUT_TEST"
 
 python3 - "$AZURE_WORKFLOW" "$OCI_WORKFLOW" "$BUILD_WORKFLOW" "$OCI_DEPLOY_SCRIPT" <<'PY'
 import pathlib

--- a/infra/azure/agents/test-live-betting-readiness-stan.sh
+++ b/infra/azure/agents/test-live-betting-readiness-stan.sh
@@ -175,6 +175,30 @@ run_live_betting_scenario azure-topology-lock "$SCRIPT" azure MODE=dark STUB_LOC
 assert_eq 1 "$RUN_RC" "dark mode should fail when topology lock is active"
 assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=topology_lock' 'active lock should fail topology contract'
 
+run_live_betting_scenario azure-expected-topology-lock "$SCRIPT" azure \
+  MODE=dark \
+  STUB_LOCK_STATE=active \
+  STUB_LOCK_HOLDER=live-data-4003-1 \
+  STUB_LOCK_OPERATION_ID=live-data-apply-slip-index \
+  STUB_LOCK_SOURCE_SHA=1111111111111111111111111111111111111111 \
+  EXPECTED_OPERATION_LOCK_HOLDER=live-data-4003-1 \
+  EXPECTED_OPERATION_LOCK_ID=live-data-apply-slip-index \
+  EXPECTED_OPERATION_LOCK_SOURCE_SHA=1111111111111111111111111111111111111111
+assert_eq 0 "$RUN_RC" "dark validation should accept the exact active deploy handoff lock"
+assert_contains "$RUN_SUMMARY_FILE" 'lock_state=active' 'expected active lock should be recorded'
+
+run_live_betting_scenario azure-wrong-topology-lock-holder "$SCRIPT" azure \
+  MODE=dark \
+  STUB_LOCK_STATE=active \
+  STUB_LOCK_HOLDER=different-holder \
+  STUB_LOCK_OPERATION_ID=live-data-apply-slip-index \
+  STUB_LOCK_SOURCE_SHA=1111111111111111111111111111111111111111 \
+  EXPECTED_OPERATION_LOCK_HOLDER=live-data-4003-1 \
+  EXPECTED_OPERATION_LOCK_ID=live-data-apply-slip-index \
+  EXPECTED_OPERATION_LOCK_SOURCE_SHA=1111111111111111111111111111111111111111
+assert_eq 1 "$RUN_RC" "dark validation should reject a different active lock holder"
+assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=topology_lock' 'wrong active lock should fail topology contract'
+
 run_live_betting_scenario azure-command-failure "$SCRIPT" azure MODE=dark STUB_COMMAND_FAILURE=workloads
 assert_eq 1 "$RUN_RC" "dark mode should fail when kubectl workloads command fails"
 assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=workload_images' 'command failure should fail workload inspection'

--- a/infra/azure/agents/test-production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/test-production-run-exclusivity-stan.sh
@@ -24,8 +24,12 @@ gh() {
     if [[ "$STUB_MODE" == "recent-disabled" ]]; then
       updated_at=1970-01-01T00:33:20Z
     fi
+    local path=.github/workflows/production-build.yml
+    if [[ "$STUB_MODE" == "data-active" ]]; then
+      path=.github/workflows/oci-live-data-rollout.yml
+    fi
     printf '%s\n' \
-      "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"workflow_id\":$WORKFLOW_ID,\"path\":\".github/workflows/production-build.yml\",\"head_branch\":\"$branch\",\"status\":\"in_progress\",\"updated_at\":\"$updated_at\"}]}"
+      "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"workflow_id\":$WORKFLOW_ID,\"path\":\"$path\",\"head_branch\":\"$branch\",\"status\":\"in_progress\",\"updated_at\":\"$updated_at\"}]}"
   elif [[ "$1" == "api" && "$2" == *"/actions/workflows/$WORKFLOW_ID"* ]]; then
     local state=active
     if [[ "$STUB_MODE" == *disabled* ]]; then
@@ -60,7 +64,7 @@ REPO=example/repo NOW_EPOCH=2000 STUB_MODE=stale-disabled \
 REPO=example/repo NOW_EPOCH=2000 STUB_MODE=active EXCLUDE_RUN_ID=$RUN_ID \
   "$EXCLUSIVITY" >/dev/null
 
-for mode in active recent-disabled pending-disabled jobs-disabled overflow; do
+for mode in active data-active recent-disabled pending-disabled jobs-disabled overflow; do
   if REPO=example/repo NOW_EPOCH=2000 STUB_MODE="$mode" \
     "$EXCLUSIVITY" >/dev/null 2>&1; then
     echo "production exclusivity accepted unsafe mode=$mode" >&2

--- a/infra/azure/agents/test-production-workflow-inventory-stan.sh
+++ b/infra/azure/agents/test-production-workflow-inventory-stan.sh
@@ -248,6 +248,7 @@ jobs:
           az aks stop --name betstan-aks
 YAML
 
+  cp "$ROOT_DIR/.github/workflows/oci-live-data-rollout.yml" "$tmp_dir/"
   cp "$ROOT_DIR/.github/workflows/oci-production-rollback.yml" "$tmp_dir/"
 }
 
@@ -656,7 +657,7 @@ PY
 }
 
 azure_set="production-build,production-deploy,production-rollback"
-full_set="oci-capacity-acquire,oci-infrastructure,oci-migrate,oci-migration-recovery,oci-production-build,oci-production-deploy,oci-production-rollback,production-build,production-deploy,production-rollback"
+full_set="oci-capacity-acquire,oci-infrastructure,oci-live-data-rollout,oci-migrate,oci-migration-recovery,oci-production-build,oci-production-deploy,oci-production-rollback,production-build,production-deploy,production-rollback"
 install_pr_gh_stub
 
 reset_fixtures

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -31,14 +31,15 @@ deploy_workflow=".github/workflows/production-deploy.yml"
 rollback_workflow=".github/workflows/production-rollback.yml"
 branch_workflow=".github/workflows/branch-policy.yml"
 policy_script=".github/scripts/publish-pr-policy.js"
+oci_data_workflow=".github/workflows/oci-live-data-rollout.yml"
 oci_migrate_workflow=".github/workflows/oci-migrate.yml"
 oci_recovery_workflow=".github/workflows/oci-migration-recovery.yml"
 oci_rollback_workflow=".github/workflows/oci-production-rollback.yml"
 
 for file in \
   "$build_workflow" "$deploy_workflow" "$branch_workflow" "$policy_script" \
-  "$rollback_workflow" "$oci_migrate_workflow" "$oci_recovery_workflow" \
-  "$oci_rollback_workflow"; do
+  "$rollback_workflow" "$oci_data_workflow" "$oci_migrate_workflow" \
+  "$oci_recovery_workflow" "$oci_rollback_workflow"; do
   [[ -f "$file" ]] || fail "required workflow missing: $file"
 done
 
@@ -188,6 +189,22 @@ require_literal "$policy_script" "? [pull.headSha, pull.mergeSha]" "promotion he
 require_literal "$policy_script" "assertExpectedPull(finalPull, pull)" "final stale-event check"
 require_literal "$policy_script" "relation.base?.sha === pull.baseSha" "exact base snapshot relation"
 
+require_literal "$oci_data_workflow" "name: oci-live-data-rollout" "OCI live data workflow identity"
+require_literal "$oci_data_workflow" "  workflow_dispatch:" "manual OCI live data trigger"
+reject_literal "$oci_data_workflow" "  workflow_run:" "automatic OCI live data trigger"
+reject_literal "$oci_data_workflow" "  push:" "push-triggered OCI live data mutation"
+reject_literal "$oci_data_workflow" "  schedule:" "scheduled OCI live data mutation"
+require_literal "$oci_data_workflow" "if: github.run_attempt == 1" "first-attempt-only OCI live data rollout"
+require_literal "$oci_data_workflow" "name: oci-migration" "protected OCI migration environment"
+require_literal "$oci_data_workflow" "group: oci-control-plane" "shared OCI control-plane concurrency"
+require_literal "$oci_data_workflow" "cancel-in-progress: false" "non-cancelling OCI live data concurrency"
+require_literal "$oci_data_workflow" "DRY RUN LIVE DATA EXACT SHA" "exact dry-run confirmation"
+require_literal "$oci_data_workflow" "APPLY LIVE BACKFILLS EXACT SHA" "exact backfill confirmation"
+require_literal "$oci_data_workflow" "APPLY LIVE SLIP INDEX EXACT SHA" "exact index confirmation"
+require_literal "$oci_data_workflow" "live-data-maintenance-stan.sh enter" "legacy writer quiescence"
+require_literal "$oci_data_workflow" "shared-mongo-operation-lock-stan.sh acquire" "database lock acquisition"
+require_literal "$oci_data_workflow" "verify-live-betting-data-evidence-stan.sh" "tamper-evident data evidence"
+
 require_literal "$oci_migrate_workflow" "build_run_id:" "exact OCI build provenance input"
 require_literal "$oci_migrate_workflow" "replace_oci_data:" "explicit destructive replacement input"
 require_literal "$oci_migrate_workflow" "inputs.replace_oci_data == true" "destructive replacement guard"
@@ -235,7 +252,7 @@ workflow_set="$(
   ./infra/azure/agents/production-workflow-inventory-stan.sh |
     sed -n 's/^production_workflows=//p'
 )"
-oci_workflow_set="oci-capacity-acquire,oci-infrastructure,oci-migrate,oci-migration-recovery,oci-production-build,oci-production-deploy,oci-production-rollback,production-build,production-deploy,production-rollback"
+oci_workflow_set="oci-capacity-acquire,oci-infrastructure,oci-live-data-rollout,oci-migrate,oci-migration-recovery,oci-production-build,oci-production-deploy,oci-production-rollback,production-build,production-deploy,production-rollback"
 [[ "$workflow_set" == "$oci_workflow_set" ]] ||
   fail "unexpected production workflow set: ${workflow_set:-none}"
 

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -173,13 +173,38 @@ concurrent retirement fixture isolation without masking failed suites.
    `scripts/finalize-k3s.sh` then mounts the Mongo volume, installs
    ingress-nginx and cert-manager, and reconciles the fixed 10/10 Mbps OCI
    load balancer.
-6. `scripts/deploy.sh` creates secrets without logging values, renders exact
+6. Before a schema-dependent application deploy, dispatch
+   `oci-live-data-rollout` against the same exact current master SHA,
+   first-attempt OCI build, and finalized infrastructure run. Run the
+   reviewer-gated phases in order: `dry-run`, `apply-backfills`, then
+   `apply-slip-index`, passing each successful run ID to the next phase.
+   The workflow runs only compiled CLIs from the approved immutable image
+   digests, binds its pre-mutation rollback baseline by digest, holds the shared
+   Mongo operation lock, and uploads sanitized hash-bound evidence. Mutating
+   phases first install the ingress write fence and scale the event,
+   gamemaster, moderation, resulting, bet, and slip writers to zero, preventing
+   legacy documents from racing the backfill or index. The backfill-only phase
+   restores the captured replica counts before it completes.
+   The final phase reapplies all six idempotent backfills under that fence,
+   creates or verifies the exact Slip index, and deliberately hands the
+   quiesced runtime plus active database lock to deployment. Public writes and
+   the six writer services remain unavailable between that successful phase
+   and deployment; dispatch the bound deployment immediately.
+   `oci-production-deploy` rejects the release unless the final evidence proves
+   all six backfills complete, the exact Slip draft index ready, the baseline
+   digest unchanged, the expected database lock active, and all legacy writers
+   still quiesced. It starts the new exact-digest services under the write
+   fence, keeps the transferred lock through protected validation, then
+   releases the lock and fence in order. Any incomplete apply or validation
+   scales the writers back to zero, restores the fence, and retains or
+   reacquires the same lock for a bounded retry with the same data run.
+7. `scripts/deploy.sh` creates secrets without logging values, renders exact
    image digests, and deploys Mongo, RabbitMQ, backends, client, and ingress
    sequentially.
-7. `agents/deploy-validation-loop-stan.sh` must pass canonical apex, permanent
+8. `agents/deploy-validation-loop-stan.sh` must pass canonical apex, permanent
    `www` redirect, diagnostic TLS, API, browser, cluster, and zero-cost checks
    before the deployment is healthy.
-8. Dispatch `oci-migrate` only with the exact current master SHA, successful
+9. Dispatch `oci-migrate` only with the exact current master SHA, successful
    first-attempt build/infrastructure/deploy run IDs,
    `replace_oci_data=true`, and the destructive confirmation. The workflow
    synchronously starts only the existing `betstan-aks`, freezes Azure

--- a/infra/oci/scripts/live-betting-data-rollout-stan.sh
+++ b/infra/oci/scripts/live-betting-data-rollout-stan.sh
@@ -1,0 +1,678 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PHASE="${PHASE:-${1:-}}"
+SOURCE_SHA="${SOURCE_SHA:-}"
+BUILD_RUN_ID="${BUILD_RUN_ID:-}"
+INFRASTRUCTURE_RUN_ID="${INFRASTRUCTURE_RUN_ID:-}"
+IMAGE_PROVENANCE_FILE="${IMAGE_PROVENANCE_FILE:-}"
+OUTPUT_DIR="${OUTPUT_DIR:-$OCI_ROOT_DIR/artifacts/oci-live-data-rollout}"
+OCI_K8S_NAMESPACE="${OCI_K8S_NAMESPACE:-betstan-oci}"
+BATCH_SIZE="${BATCH_SIZE:-100}"
+JOB_TIMEOUT_SECONDS="${JOB_TIMEOUT_SECONDS:-1800}"
+RUN_ID="${GITHUB_RUN_ID:-}"
+RUN_ATTEMPT="${GITHUB_RUN_ATTEMPT:-}"
+BASELINE_SHA256="${BASELINE_SHA256:-}"
+MAINTENANCE_FENCE_ENFORCED="${MAINTENANCE_FENCE_ENFORCED:-false}"
+WRITERS_QUIESCED="${WRITERS_QUIESCED:-false}"
+RUNTIME_HELD_FOR_DEPLOY="${RUNTIME_HELD_FOR_DEPLOY:-false}"
+OPERATION_LOCK_ENFORCED="${OPERATION_LOCK_ENFORCED:-false}"
+OPERATION_LOCK_HANDOFF="${OPERATION_LOCK_HANDOFF:-false}"
+
+services=(event gamemaster moderation resulting bet slip)
+created_jobs=()
+raw_files=()
+job_sequence=0
+
+fail() {
+  echo "live_betting_data_rollout=FAIL phase=${PHASE:-missing} reason=$*" >&2
+  exit 1
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  local job
+  for job in "${created_jobs[@]:-}"; do
+    [[ -n "$job" ]] || continue
+    kubectl delete job "$job" \
+      -n "$OCI_K8S_NAMESPACE" \
+      --ignore-not-found=true \
+      --wait=false >/dev/null 2>&1
+  done
+  local raw_file
+  for raw_file in "${raw_files[@]:-}"; do
+    [[ -n "$raw_file" ]] && rm -f -- "$raw_file"
+  done
+  exit "$status"
+}
+trap cleanup EXIT
+
+case "$PHASE" in
+  dry-run|apply-backfills|apply-slip-index) ;;
+  *) fail "phase must be dry-run, apply-backfills, or apply-slip-index" ;;
+esac
+[[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+  fail "SOURCE_SHA must be a complete lowercase commit SHA"
+[[ "$BUILD_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+  fail "BUILD_RUN_ID must be a positive integer"
+[[ "$INFRASTRUCTURE_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+  fail "INFRASTRUCTURE_RUN_ID must be a positive integer"
+[[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+  fail "GITHUB_RUN_ID must be a positive integer"
+[[ "$RUN_ATTEMPT" == "1" ]] ||
+  fail "only first-attempt runs are accepted"
+[[ "$BATCH_SIZE" =~ ^[1-9][0-9]*$ ]] ||
+  fail "BATCH_SIZE must be a positive integer"
+(( BATCH_SIZE <= 1000 )) ||
+  fail "BATCH_SIZE exceeds the reviewed bound"
+[[ "$JOB_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
+  fail "JOB_TIMEOUT_SECONDS must be a positive integer"
+(( JOB_TIMEOUT_SECONDS <= 3600 )) ||
+  fail "JOB_TIMEOUT_SECONDS exceeds the reviewed one-hour bound"
+[[ "$OCI_K8S_NAMESPACE" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] ||
+  fail "OCI_K8S_NAMESPACE is invalid"
+[[ -f "$IMAGE_PROVENANCE_FILE" ]] ||
+  fail "IMAGE_PROVENANCE_FILE not found"
+[[ -n "$OUTPUT_DIR" && "$OUTPUT_DIR" != "/" && "$OUTPUT_DIR" != "." ]] ||
+  fail "OUTPUT_DIR is unsafe"
+[[ "$BASELINE_SHA256" =~ ^[0-9a-f]{64}$ ]] ||
+  fail "BASELINE_SHA256 must bind the protected pre-mutation baseline"
+for boolean_name in \
+  MAINTENANCE_FENCE_ENFORCED WRITERS_QUIESCED RUNTIME_HELD_FOR_DEPLOY \
+  OPERATION_LOCK_ENFORCED OPERATION_LOCK_HANDOFF; do
+  [[ "${!boolean_name}" == "true" || "${!boolean_name}" == "false" ]] ||
+    fail "$boolean_name must be boolean"
+done
+[[ "$OPERATION_LOCK_ENFORCED" == "true" ]] ||
+  fail "the shared database operation lock must cover every phase"
+if [[ "$PHASE" == "dry-run" ]]; then
+  [[ "$MAINTENANCE_FENCE_ENFORCED" == "false" &&
+     "$WRITERS_QUIESCED" == "false" &&
+     "$RUNTIME_HELD_FOR_DEPLOY" == "false" &&
+     "$OPERATION_LOCK_HANDOFF" == "false" ]] ||
+    fail "dry-run must not claim a maintenance handoff"
+else
+  [[ "$MAINTENANCE_FENCE_ENFORCED" == "true" &&
+     "$WRITERS_QUIESCED" == "true" ]] ||
+    fail "mutating phases require a write fence and quiesced writers"
+  if [[ "$PHASE" == "apply-slip-index" ]]; then
+    [[ "$RUNTIME_HELD_FOR_DEPLOY" == "true" &&
+       "$OPERATION_LOCK_HANDOFF" == "true" ]] ||
+      fail "the final phase must retain runtime and database locks for deploy"
+  else
+    [[ "$RUNTIME_HELD_FOR_DEPLOY" == "false" &&
+       "$OPERATION_LOCK_HANDOFF" == "false" ]] ||
+      fail "backfill-only phase must not retain a deploy handoff"
+  fi
+fi
+
+for command_name in kubectl jq python3; do
+  command -v "$command_name" >/dev/null 2>&1 ||
+    fail "required command is unavailable: $command_name"
+done
+
+mkdir -p "$OUTPUT_DIR/reports"
+kubectl get namespace "$OCI_K8S_NAMESPACE" >/dev/null
+kubectl get service gaming-shared-mongo-srv \
+  -n "$OCI_K8S_NAMESPACE" >/dev/null
+kubectl get secret ocir-pull \
+  -n "$OCI_K8S_NAMESPACE" >/dev/null
+
+image_for_service() {
+  local service="$1"
+  local matches image_ref
+  matches="$(
+    awk -F '\t' -v service="$service" '$1 == service { count += 1; value = $3 } END {
+      if (count != 1) exit 1
+      print value
+    }' "$IMAGE_PROVENANCE_FILE"
+  )" || fail "missing or duplicate immutable image for $service"
+  image_ref="$matches"
+  [[ "$image_ref" =~ ^[A-Za-z0-9._/-]+@sha256:[0-9a-f]{64}$ ]] ||
+    fail "image for $service is not an immutable digest"
+  printf '%s' "$image_ref"
+}
+
+create_job() {
+  local service="$1"
+  local command_path="$2"
+  local mode="$3"
+  local image_ref="$4"
+  local job_name="$5"
+  local database="gaming_${service}"
+  local args
+  if [[ "$command_path" == "dist/scripts/backfillDataCompatibility.js" ]]; then
+    args='
+          args:
+            - "--batch-size"
+            - "'"$BATCH_SIZE"'"'
+  else
+    args=""
+  fi
+  if [[ "$mode" == "apply" ]]; then
+    args+='
+          args:
+            - "--apply"'
+    if [[ "$command_path" == "dist/scripts/backfillDataCompatibility.js" ]]; then
+      args='
+          args:
+            - "--batch-size"
+            - "'"$BATCH_SIZE"'"
+            - "--apply"'
+    fi
+  fi
+
+  cat <<YAML | kubectl create -f - >/dev/null
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: $job_name
+  namespace: $OCI_K8S_NAMESPACE
+  labels:
+    betstan.io/operation: live-data-rollout
+    betstan.io/source-sha: $SOURCE_SHA
+    betstan.io/phase: $PHASE
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: $JOB_TIMEOUT_SECONDS
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        betstan.io/operation: live-data-rollout
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      imagePullSecrets:
+        - name: ocir-pull
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: data-rollout
+          image: $image_ref
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - $command_path$args
+          env:
+            - name: MONGO_URI
+              value: "mongodb://gaming-shared-mongo-srv:27017/$database"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+YAML
+}
+
+wait_for_job_report() {
+  local job_name="$1"
+  local raw_file="$2"
+  local deadline=$(( $(date +%s) + JOB_TIMEOUT_SECONDS ))
+  local job_json
+
+  while (( $(date +%s) < deadline )); do
+    job_json="$(kubectl get job "$job_name" -n "$OCI_K8S_NAMESPACE" -o json)"
+    if jq -e '(.status.succeeded // 0) == 1' <<<"$job_json" >/dev/null; then
+      kubectl logs "job/$job_name" \
+        -n "$OCI_K8S_NAMESPACE" \
+        --container data-rollout >"$raw_file" 2>/dev/null ||
+        fail "unable to collect completed job report"
+      return 0
+    fi
+    if jq -e '(.status.failed // 0) > 0' <<<"$job_json" >/dev/null; then
+      kubectl logs "job/$job_name" \
+        -n "$OCI_K8S_NAMESPACE" \
+        --container data-rollout >"$raw_file" 2>/dev/null || true
+      fail "data job failed for $job_name; raw logs were withheld"
+    fi
+    sleep 5
+  done
+
+  fail "data job timed out for $job_name"
+}
+
+run_job() {
+  local service="$1"
+  local command_path="$2"
+  local mode="$3"
+  local raw_file
+  local image_ref
+  local job_name
+
+  job_sequence=$((job_sequence + 1))
+  job_name="live-data-${service}-${RUN_ID}-${job_sequence}"
+  image_ref="$(image_for_service "$service")"
+  raw_file="$(mktemp "${TMPDIR:-/tmp}/betstan-live-data.XXXXXX")"
+  raw_files+=("$raw_file")
+  created_jobs+=("$job_name")
+  create_job "$service" "$command_path" "$mode" "$image_ref" "$job_name"
+  wait_for_job_report "$job_name" "$raw_file"
+  kubectl delete job "$job_name" \
+    -n "$OCI_K8S_NAMESPACE" \
+    --ignore-not-found=true \
+    --wait=false >/dev/null
+  LAST_RAW_FILE="$raw_file"
+}
+
+sanitize_backfill_report() {
+  local raw_file="$1"
+  local service="$2"
+  local stage="$3"
+  local expected_mode="$4"
+  local output="$OUTPUT_DIR/reports/${stage}-${service}.json"
+  local temporary="${output}.tmp"
+
+  jq -e \
+    --arg service "$service" \
+    --arg stage "$stage" \
+    --arg expected_mode "$expected_mode" '
+      def nonnegative_integer:
+        type == "number" and . >= 0 and . == floor;
+      . as $report |
+      select(
+        ($report.mode == $expected_mode) and
+        ($report.scanned | nonnegative_integer) and
+        ($report.matched | nonnegative_integer) and
+        ($report.changed | nonnegative_integer) and
+        ($report.skipped | nonnegative_integer) and
+        ($report.errorCount == 0) and
+        ($report.collections | type == "array") and
+        ([$report.collections[] |
+          (.scanned | nonnegative_integer) and
+          (.matched | nonnegative_integer) and
+          (.changed | nonnegative_integer) and
+          (.skipped | nonnegative_integer) and
+          (.errorCount == 0)
+        ] | all) and
+        ($report.scanned == ([$report.collections[].scanned] | add // 0)) and
+        ($report.matched == ([$report.collections[].matched] | add // 0)) and
+        ($report.changed == ([$report.collections[].changed] | add // 0)) and
+        ($report.skipped == ([$report.collections[].skipped] | add // 0)) and
+        (($expected_mode != "dry-run") or $report.changed == 0) and
+        (($expected_mode != "apply") or $report.changed == $report.matched) and
+        (($service != "slip") or ($report.duplicateDrafts | type == "array"))
+      ) |
+      {
+        kind: "backfill",
+        service: $service,
+        stage: $stage,
+        mode: .mode,
+        batchSize: .batchSize,
+        scanned: .scanned,
+        matched: .matched,
+        changed: .changed,
+        skipped: .skipped,
+        errorCount: .errorCount,
+        duplicateDraftGroupCount:
+          (if $service == "slip" then (.duplicateDrafts | length) else 0 end),
+        collections: [
+          .collections[] |
+          {
+            collection,
+            scanned,
+            matched,
+            changed,
+            skipped,
+            errorCount
+          }
+        ]
+      }
+    ' "$raw_file" >"$temporary" ||
+    fail "backfill report contract failed for $service/$stage"
+  mv "$temporary" "$output"
+  rm -f -- "$raw_file"
+  LAST_REPORT="$output"
+}
+
+sanitize_index_report() {
+  local raw_file="$1"
+  local stage="$2"
+  local expected_mode="$3"
+  local output="$OUTPUT_DIR/reports/${stage}-slip-index.json"
+  local temporary="${output}.tmp"
+
+  jq -e \
+    --arg stage "$stage" \
+    --arg expected_mode "$expected_mode" '
+      def nonnegative_integer:
+        type == "number" and . >= 0 and . == floor;
+      . as $report |
+      select(
+        ($report.mode == $expected_mode) and
+        ($report.ready | type == "boolean") and
+        ($report.scanned | nonnegative_integer) and
+        ($report.matched | nonnegative_integer) and
+        ($report.changed | nonnegative_integer) and
+        ($report.skipped | nonnegative_integer) and
+        ($report.errorCount | nonnegative_integer) and
+        ($report.existingIndex == "missing" or
+         $report.existingIndex == "matching" or
+         $report.existingIndex == "conflicting") and
+        ($report.indexName == "slip_draft_unique_by_kind") and
+        ($report.blocking | type == "object") and
+        ([$report.blocking[] | nonnegative_integer] | all) and
+        (($expected_mode != "dry-run") or $report.changed == 0)
+      ) |
+      {
+        kind: "slip-index",
+        service: "slip",
+        stage: $stage,
+        mode: .mode,
+        ready: .ready,
+        scanned: .scanned,
+        matched: .matched,
+        changed: .changed,
+        skipped: .skipped,
+        errorCount: .errorCount,
+        existingIndex: .existingIndex,
+        indexName: .indexName,
+        blocking: .blocking
+      }
+    ' "$raw_file" >"$temporary" ||
+    fail "Slip index report contract failed for $stage"
+  mv "$temporary" "$output"
+  rm -f -- "$raw_file"
+  LAST_REPORT="$output"
+}
+
+run_backfill() {
+  local service="$1"
+  local mode="$2"
+  local stage="$3"
+  local expected_mode="dry-run"
+  [[ "$mode" == "apply" ]] && expected_mode="apply"
+  run_job "$service" "dist/scripts/backfillDataCompatibility.js" "$mode"
+  sanitize_backfill_report "$LAST_RAW_FILE" "$service" "$stage" "$expected_mode"
+}
+
+run_index() {
+  local mode="$1"
+  local stage="$2"
+  local expected_mode="dry-run"
+  [[ "$mode" == "apply" ]] && expected_mode="apply"
+  run_job slip "dist/scripts/ensureDraftIndexes.js" "$mode"
+  sanitize_index_report "$LAST_RAW_FILE" "$stage" "$expected_mode"
+}
+
+require_safe_slip_report() {
+  local report="$1"
+  [[ "$(jq -r '.duplicateDraftGroupCount' "$report")" == "0" ]] ||
+    fail "duplicate draft slips require manual resolution before rollout"
+}
+
+require_empty_backfill_report() {
+  local report="$1"
+  [[ "$(jq -r '.matched' "$report")" == "0" ]] ||
+    fail "backfill verification still matches documents"
+}
+
+require_non_conflicting_index() {
+  local report="$1"
+  [[ "$(jq -r '.existingIndex' "$report")" != "conflicting" ]] ||
+    fail "a conflicting Slip draft index exists"
+}
+
+verify_cluster_runtime() {
+  local deployment state
+  for deployment in gaming-auth-depl gaming-backoffice-depl gaming-client-depl; do
+    kubectl rollout status "deployment/$deployment" \
+      -n "$OCI_K8S_NAMESPACE" --timeout=2m >/dev/null ||
+      fail "runtime deployment became unhealthy after a data write"
+  done
+  if [[ "$WRITERS_QUIESCED" == "true" ]]; then
+    for deployment in \
+      gaming-bet-depl \
+      gaming-event-depl \
+      gaming-gamemaster-depl \
+      gaming-moderation-depl \
+      gaming-resulting-depl \
+      gaming-slip-depl; do
+      state="$(
+        kubectl get deployment "$deployment" \
+          -n "$OCI_K8S_NAMESPACE" \
+          -o jsonpath='{.spec.replicas}|{.status.replicas}|{.status.readyReplicas}|{.status.availableReplicas}'
+      )"
+      [[ "$state" == "0|||" || "$state" == "0|0|0|0" ]] ||
+        fail "quiesced writer deployment resumed during a data write"
+    done
+  else
+    fail "mutating runtime verification requires quiesced writers"
+  fi
+  kubectl rollout status statefulset/gaming-auth-mongo-depl \
+    -n "$OCI_K8S_NAMESPACE" --timeout=2m >/dev/null ||
+    fail "Mongo became unhealthy after a data write"
+  kubectl rollout status deployment/gaming-rabbitmq-depl \
+    -n "$OCI_K8S_NAMESPACE" --timeout=2m >/dev/null ||
+    fail "RabbitMQ became unhealthy after a data write"
+
+  local mongo_pod rabbitmq_pod
+  mongo_pod="$(
+    kubectl get pods -n "$OCI_K8S_NAMESPACE" \
+      -l app=gaming-auth-mongo \
+      -o jsonpath='{.items[0].metadata.name}'
+  )"
+  rabbitmq_pod="$(
+    kubectl get pods -n "$OCI_K8S_NAMESPACE" \
+      -l app=gaming-rabbitmq \
+      -o jsonpath='{.items[0].metadata.name}'
+  )"
+  [[ -n "$mongo_pod" && -n "$rabbitmq_pod" ]] ||
+    fail "runtime dependency pod is missing after a data write"
+  kubectl exec -n "$OCI_K8S_NAMESPACE" "$mongo_pod" -- \
+    mongosh --quiet --eval 'quit(db.adminCommand({ping:1}).ok === 1 ? 0 : 1)' \
+    >/dev/null ||
+    fail "Mongo ping failed after a data write"
+  kubectl exec -n "$OCI_K8S_NAMESPACE" "$rabbitmq_pod" -- \
+    rabbitmq-diagnostics -q ping >/dev/null ||
+    fail "RabbitMQ ping failed after a data write"
+}
+
+run_all_dry() {
+  local stage="$1"
+  local require_empty="$2"
+  local service report
+  for service in "${services[@]}"; do
+    run_backfill "$service" dry-run "$stage"
+    report="$LAST_REPORT"
+    if [[ "$service" == "slip" ]]; then
+      require_safe_slip_report "$report"
+    fi
+    if [[ "$require_empty" == "true" ]]; then
+      require_empty_backfill_report "$report"
+    fi
+  done
+}
+
+backfill_complete=false
+index_ready=false
+
+case "$PHASE" in
+  dry-run)
+    run_all_dry preflight false
+    run_index dry-run preflight
+    require_non_conflicting_index "$LAST_REPORT"
+    total_matches="$(
+      jq -s '[.[].matched] | add' "$OUTPUT_DIR"/reports/preflight-{event,gamemaster,moderation,resulting,bet,slip}.json
+    )"
+    [[ "$total_matches" == "0" ]] && backfill_complete=true
+    if [[ "$(jq -r '.ready' "$LAST_REPORT")" == "true" &&
+      "$(jq -r '.existingIndex' "$LAST_REPORT")" == "matching" ]]; then
+      index_ready=true
+    fi
+    ;;
+  apply-backfills)
+    run_all_dry preflight false
+    run_index dry-run preflight
+    require_non_conflicting_index "$LAST_REPORT"
+    for service in "${services[@]}"; do
+      run_backfill "$service" apply apply
+      [[ "$service" != "slip" ]] || require_safe_slip_report "$LAST_REPORT"
+      verify_cluster_runtime
+      run_backfill "$service" dry-run verify
+      [[ "$service" != "slip" ]] || require_safe_slip_report "$LAST_REPORT"
+      require_empty_backfill_report "$LAST_REPORT"
+    done
+    run_index dry-run final
+    require_non_conflicting_index "$LAST_REPORT"
+    [[ "$(jq -r '.ready' "$LAST_REPORT")" == "true" ]] ||
+      fail "Slip data is not normalized after backfills"
+    backfill_complete=true
+    [[ "$(jq -r '.existingIndex' "$LAST_REPORT")" == "matching" ]] &&
+      index_ready=true
+    ;;
+  apply-slip-index)
+    run_all_dry preflight false
+    run_index dry-run preflight
+    require_non_conflicting_index "$LAST_REPORT"
+    for service in "${services[@]}"; do
+      run_backfill "$service" apply apply
+      [[ "$service" != "slip" ]] || require_safe_slip_report "$LAST_REPORT"
+      verify_cluster_runtime
+      run_backfill "$service" dry-run verify
+      [[ "$service" != "slip" ]] || require_safe_slip_report "$LAST_REPORT"
+      require_empty_backfill_report "$LAST_REPORT"
+    done
+    run_index dry-run final
+    require_non_conflicting_index "$LAST_REPORT"
+    [[ "$(jq -r '.ready' "$LAST_REPORT")" == "true" ]] ||
+      fail "Slip index preflight is not ready"
+    run_index apply apply
+    require_non_conflicting_index "$LAST_REPORT"
+    [[ "$(jq -r '.ready' "$LAST_REPORT")" == "true" ]] ||
+      fail "Slip index apply did not report ready"
+    verify_cluster_runtime
+    run_index dry-run verify
+    [[ "$(jq -r '.ready' "$LAST_REPORT")" == "true" ]] ||
+      fail "Slip index verification did not report ready"
+    [[ "$(jq -r '.existingIndex' "$LAST_REPORT")" == "matching" ]] ||
+      fail "Slip draft index does not match the exact reviewed definition"
+    [[ "$(jq -r '.errorCount' "$LAST_REPORT")" == "0" ]] ||
+      fail "Slip index verification retained blockers"
+    backfill_complete=true
+    index_ready=true
+    ;;
+esac
+
+completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+cat >"$OUTPUT_DIR/provenance.env" <<EOF
+schema_version=live-betting-v1
+source_sha=$SOURCE_SHA
+build_run_id=$BUILD_RUN_ID
+infrastructure_run_id=$INFRASTRUCTURE_RUN_ID
+baseline_sha256=$BASELINE_SHA256
+workflow_run_id=$RUN_ID
+workflow_run_attempt=$RUN_ATTEMPT
+phase=$PHASE
+status=PASS
+backfill_complete=$backfill_complete
+index_ready=$index_ready
+maintenance_fence_enforced=$MAINTENANCE_FENCE_ENFORCED
+writers_quiesced=$WRITERS_QUIESCED
+runtime_held_for_deploy=$RUNTIME_HELD_FOR_DEPLOY
+operation_lock_enforced=$OPERATION_LOCK_ENFORCED
+operation_lock_handoff=$OPERATION_LOCK_HANDOFF
+completed_at=$completed_at
+EOF
+
+jq -s \
+  --arg source_sha "$SOURCE_SHA" \
+  --arg build_run_id "$BUILD_RUN_ID" \
+  --arg infrastructure_run_id "$INFRASTRUCTURE_RUN_ID" \
+  --arg baseline_sha256 "$BASELINE_SHA256" \
+  --arg workflow_run_id "$RUN_ID" \
+  --arg workflow_run_attempt "$RUN_ATTEMPT" \
+  --arg phase "$PHASE" \
+  --arg completed_at "$completed_at" \
+  --argjson backfill_complete "$backfill_complete" \
+  --argjson index_ready "$index_ready" \
+  --argjson maintenance_fence_enforced "$MAINTENANCE_FENCE_ENFORCED" \
+  --argjson writers_quiesced "$WRITERS_QUIESCED" \
+  --argjson runtime_held_for_deploy "$RUNTIME_HELD_FOR_DEPLOY" \
+  --argjson operation_lock_enforced "$OPERATION_LOCK_ENFORCED" \
+  --argjson operation_lock_handoff "$OPERATION_LOCK_HANDOFF" '
+    {
+      schema_version: "live-betting-v1",
+      source_sha: $source_sha,
+      build_run_id: $build_run_id,
+      infrastructure_run_id: $infrastructure_run_id,
+      baseline_sha256: $baseline_sha256,
+      workflow_run_id: $workflow_run_id,
+      workflow_run_attempt: $workflow_run_attempt,
+      phase: $phase,
+      status: "PASS",
+      backfill_complete: $backfill_complete,
+      index_ready: $index_ready,
+      maintenance_fence_enforced: $maintenance_fence_enforced,
+      writers_quiesced: $writers_quiesced,
+      runtime_held_for_deploy: $runtime_held_for_deploy,
+      operation_lock_enforced: $operation_lock_enforced,
+      operation_lock_handoff: $operation_lock_handoff,
+      completed_at: $completed_at,
+      reports: .
+    }
+  ' "$OUTPUT_DIR"/reports/*.json >"$OUTPUT_DIR/journal.json"
+
+if [[ "$PHASE" == "apply-slip-index" ]]; then
+  cat >"$OUTPUT_DIR/schema.env" <<EOF
+schema_version=live-betting-v1
+source_sha=$SOURCE_SHA
+build_run_id=$BUILD_RUN_ID
+infrastructure_run_id=$INFRASTRUCTURE_RUN_ID
+baseline_sha256=$BASELINE_SHA256
+data_run_id=$RUN_ID
+data_run_attempt=$RUN_ATTEMPT
+backfill_complete=true
+index_ready=true
+maintenance_fence_enforced=true
+writers_quiesced=true
+runtime_held_for_deploy=true
+operation_lock_enforced=true
+operation_lock_handoff=true
+EOF
+fi
+
+python3 - "$OUTPUT_DIR" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+manifest = root / "SHA256SUMS"
+rows = []
+for path in sorted(root.rglob("*")):
+    if not path.is_file() or path == manifest:
+        continue
+    relative = path.relative_to(root).as_posix()
+    rows.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {relative}")
+manifest.write_text("\n".join(rows) + "\n", encoding="utf-8")
+PY
+
+EVIDENCE_DIR="$OUTPUT_DIR" \
+EXPECTED_SOURCE_SHA="$SOURCE_SHA" \
+EXPECTED_BUILD_RUN_ID="$BUILD_RUN_ID" \
+EXPECTED_INFRASTRUCTURE_RUN_ID="$INFRASTRUCTURE_RUN_ID" \
+EXPECTED_PHASE="$PHASE" \
+EXPECTED_RUN_ID="$RUN_ID" \
+EXPECTED_RUN_ATTEMPT="$RUN_ATTEMPT" \
+  "$SCRIPT_DIR/verify-live-betting-data-evidence-stan.sh" >/dev/null
+
+echo "live_betting_data_rollout=PASS phase=$PHASE backfill_complete=$backfill_complete index_ready=$index_ready"

--- a/infra/oci/scripts/live-data-maintenance-stan.sh
+++ b/infra/oci/scripts/live-data-maintenance-stan.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+ACTION="${1:-}"
+OCI_K8S_NAMESPACE="${OCI_K8S_NAMESPACE:-betstan-oci}"
+STATE_FILE="${STATE_FILE:-}"
+INGRESS_NAMESPACE="${INGRESS_NAMESPACE:-ingress-nginx}"
+INGRESS_CONFIGMAP="${INGRESS_CONFIGMAP:-ingress-nginx-controller}"
+WAIT_ATTEMPTS="${WAIT_ATTEMPTS:-60}"
+WAIT_SECONDS="${WAIT_SECONDS:-2}"
+
+BASE_SERVER_SNIPPET='if ($host = "www.betstan.xyz") {
+  return 308 https://betstan.xyz$request_uri;
+}'
+WRITE_FENCE_DIRECTIVE='if ($request_method !~ ^(GET|HEAD|OPTIONS)$) {
+  return 503;
+}'
+FENCED_SERVER_SNIPPET="${BASE_SERVER_SNIPPET}"$'\n'"${WRITE_FENCE_DIRECTIVE}"
+
+writer_services=(bet event moderation resulting slip gamemaster)
+quiesce_order=(gamemaster event slip moderation resulting bet)
+restore_order=(bet event moderation resulting slip gamemaster)
+
+fail() {
+  echo "live_data_maintenance=${ACTION:-missing} status=FAIL reason=$*" >&2
+  exit 1
+}
+
+[[ "$OCI_K8S_NAMESPACE" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] ||
+  fail "OCI_K8S_NAMESPACE is invalid"
+[[ "$INGRESS_NAMESPACE" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] ||
+  fail "INGRESS_NAMESPACE is invalid"
+[[ "$INGRESS_CONFIGMAP" =~ ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$ ]] ||
+  fail "INGRESS_CONFIGMAP is invalid"
+[[ "$WAIT_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] ||
+  fail "WAIT_ATTEMPTS must be positive"
+[[ "$WAIT_SECONDS" =~ ^[1-9][0-9]*$ ]] ||
+  fail "WAIT_SECONDS must be positive"
+(( WAIT_ATTEMPTS <= 300 )) || fail "WAIT_ATTEMPTS exceeds the reviewed bound"
+(( WAIT_SECONDS <= 10 )) || fail "WAIT_SECONDS exceeds the reviewed bound"
+
+for command_name in kubectl jq; do
+  command -v "$command_name" >/dev/null 2>&1 ||
+    fail "required command is unavailable: $command_name"
+done
+
+deployment_name() {
+  printf 'gaming-%s-depl' "$1"
+}
+
+fence_config_status() {
+  local snippet
+  snippet="$(
+    kubectl get configmap "$INGRESS_CONFIGMAP" \
+      -n "$INGRESS_NAMESPACE" \
+      -o jsonpath='{.data.server-snippet}'
+  )"
+  case "$snippet" in
+    "$BASE_SERVER_SNIPPET")
+      printf false
+      ;;
+    "$FENCED_SERVER_SNIPPET")
+      printf true
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+set_fence_config() {
+  local expected="$1"
+  local current desired patch
+  current="$(fence_config_status)" ||
+    fail "ingress server-snippet differs from the reviewed baseline and fence"
+  [[ "$current" == "$expected" ]] && return 0
+  if [[ "$expected" == "true" ]]; then
+    desired="$FENCED_SERVER_SNIPPET"
+  else
+    desired="$BASE_SERVER_SNIPPET"
+  fi
+  patch="$(jq -cn --arg snippet "$desired" '{data:{"server-snippet":$snippet}}')"
+  kubectl patch configmap "$INGRESS_CONFIGMAP" \
+    -n "$INGRESS_NAMESPACE" \
+    --type merge \
+    --patch "$patch" >/dev/null
+  [[ "$(fence_config_status)" == "$expected" ]] ||
+    fail "ingress ConfigMap did not reach the requested fence state"
+}
+
+runtime_fence_status() {
+  local pods_json pod_count pod rendered
+  kubectl rollout status deployment/ingress-nginx-controller \
+    -n "$INGRESS_NAMESPACE" --timeout=2m >/dev/null || return 1
+  pods_json="$(
+    kubectl get pods -n "$INGRESS_NAMESPACE" \
+      -l app.kubernetes.io/component=controller \
+      -o json
+  )" || return 1
+  jq -e '
+    (.items | length) > 0 and
+    all(.items[];
+      .metadata.deletionTimestamp == null and
+      .status.phase == "Running" and
+      any(.status.conditions[]?;
+        .type == "Ready" and .status == "True"))
+  ' <<<"$pods_json" >/dev/null || return 1
+  pod_count="$(jq -r '.items | length' <<<"$pods_json")"
+  [[ "$pod_count" =~ ^[1-9][0-9]*$ ]] || return 1
+
+  local fenced_count=0
+  while IFS= read -r pod; do
+    [[ -n "$pod" ]] || return 1
+    rendered="$(
+      kubectl exec -n "$INGRESS_NAMESPACE" "$pod" -- \
+        sh -c 'nginx -T 2>&1'
+    )" || return 1
+    grep -Fq 'return 308 https://betstan.xyz$request_uri;' <<<"$rendered" ||
+      return 1
+    if grep -Fq 'if ($request_method !~ ^(GET|HEAD|OPTIONS)$) {' <<<"$rendered"; then
+      fenced_count=$((fenced_count + 1))
+    fi
+  done < <(jq -r '.items[].metadata.name' <<<"$pods_json")
+
+  if [[ "$fenced_count" == "$pod_count" ]]; then
+    printf true
+  elif [[ "$fenced_count" == "0" ]]; then
+    printf false
+  else
+    return 1
+  fi
+}
+
+wait_for_fence() {
+  local expected="$1"
+  local observed=""
+  for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
+    if observed="$(runtime_fence_status)" && [[ "$observed" == "$expected" ]]; then
+      return 0
+    fi
+    sleep "$WAIT_SECONDS"
+  done
+  fail "ingress runtime did not reach fence state $expected"
+}
+
+deployment_json() {
+  kubectl get deployment "$(deployment_name "$1")" \
+    -n "$OCI_K8S_NAMESPACE" \
+    -o json
+}
+
+deployment_replicas() {
+  deployment_json "$1" | jq -r '.spec.replicas // 0'
+}
+
+deployment_is_stable() {
+  local service="$1"
+  local expected="$2"
+  local deployment pods_json
+  deployment="$(deployment_json "$service")" || return 1
+  jq -e --argjson expected "$expected" '
+    (.spec.replicas // 0) == $expected and
+    (.status.replicas // 0) == $expected and
+    (.status.updatedReplicas // 0) == $expected and
+    (.status.readyReplicas // 0) == $expected and
+    (.status.availableReplicas // 0) == $expected
+  ' <<<"$deployment" >/dev/null || return 1
+  pods_json="$(
+    kubectl get pods -n "$OCI_K8S_NAMESPACE" \
+      -l "app=gaming-${service}" \
+      -o json
+  )" || return 1
+  if [[ "$expected" == "0" ]]; then
+    jq -e '.items | length == 0' <<<"$pods_json" >/dev/null
+  else
+    jq -e --argjson expected "$expected" '
+      (.items | length) == $expected and
+      all(.items[];
+        .metadata.deletionTimestamp == null and
+        .status.phase == "Running" and
+        any(.status.conditions[]?;
+          .type == "Ready" and .status == "True"))
+    ' <<<"$pods_json" >/dev/null
+  fi
+}
+
+wait_for_deployment() {
+  local service="$1"
+  local expected="$2"
+  for _ in $(seq 1 "$WAIT_ATTEMPTS"); do
+    if deployment_is_stable "$service" "$expected"; then
+      return 0
+    fi
+    sleep "$WAIT_SECONDS"
+  done
+  fail "$(deployment_name "$service") did not reach $expected stable replicas"
+}
+
+scale_service() {
+  local service="$1"
+  local replicas="$2"
+  kubectl scale "deployment/$(deployment_name "$service")" \
+    -n "$OCI_K8S_NAMESPACE" \
+    --replicas="$replicas" >/dev/null
+  wait_for_deployment "$service" "$replicas"
+}
+
+require_state_file_path() {
+  [[ -n "$STATE_FILE" && "$STATE_FILE" != "/" && "$STATE_FILE" != "." ]] ||
+    fail "STATE_FILE is required and must be a specific file"
+}
+
+capture_state() {
+  local temporary service replicas
+  require_state_file_path
+  mkdir -p "$(dirname "$STATE_FILE")"
+  [[ ! -L "$STATE_FILE" ]] || fail "STATE_FILE must not be a symbolic link"
+  temporary="${STATE_FILE}.tmp"
+  umask 077
+  {
+    printf 'state_version\t1\n'
+    printf 'namespace\t%s\n' "$OCI_K8S_NAMESPACE"
+    for service in "${writer_services[@]}"; do
+      replicas="$(deployment_replicas "$service")"
+      [[ "$replicas" =~ ^[1-9][0-9]*$ ]] ||
+        fail "$(deployment_name "$service") must be running before maintenance"
+      deployment_is_stable "$service" "$replicas" ||
+        fail "$(deployment_name "$service") is not stable before maintenance"
+      printf 'service\t%s\t%s\n' "$service" "$replicas"
+    done
+  } >"$temporary"
+  mv "$temporary" "$STATE_FILE"
+}
+
+validate_state() {
+  local service count namespace
+  require_state_file_path
+  [[ -f "$STATE_FILE" && ! -L "$STATE_FILE" ]] ||
+    fail "maintenance state file is missing or unsafe"
+  [[ "$(awk -F '\t' '$1 == "state_version" && $2 == "1" {count++} END {print count+0}' "$STATE_FILE")" == "1" ]] ||
+    fail "maintenance state version is invalid"
+  namespace="$(awk -F '\t' '$1 == "namespace" {print $2}' "$STATE_FILE")"
+  [[ "$namespace" == "$OCI_K8S_NAMESPACE" ]] ||
+    fail "maintenance state namespace mismatch"
+  count="$(awk -F '\t' '$1 == "service" {count++} END {print count+0}' "$STATE_FILE")"
+  [[ "$count" == "${#writer_services[@]}" ]] ||
+    fail "maintenance state has incomplete service coverage"
+  for service in "${writer_services[@]}"; do
+    count="$(
+      awk -F '\t' -v service="$service" '
+        $1 == "service" && $2 == service && $3 ~ /^[1-9][0-9]*$/ {count++}
+        END {print count+0}
+      ' "$STATE_FILE"
+    )"
+    [[ "$count" == "1" ]] ||
+      fail "maintenance state is invalid for $service"
+  done
+  [[ "$(awk -F '\t' 'NF == 0 || ($1 != "state_version" && $1 != "namespace" && $1 != "service") {count++} END {print count+0}' "$STATE_FILE")" == "0" ]] ||
+    fail "maintenance state contains unexpected records"
+}
+
+state_replicas() {
+  awk -F '\t' -v service="$1" '
+    $1 == "service" && $2 == service {print $3}
+  ' "$STATE_FILE"
+}
+
+verify_held() {
+  [[ "$(fence_config_status)" == "true" ]] ||
+    fail "HTTP mutation fence is not configured"
+  [[ "$(runtime_fence_status)" == "true" ]] ||
+    fail "HTTP mutation fence is not active in ingress"
+  local service
+  for service in "${writer_services[@]}"; do
+    deployment_is_stable "$service" 0 ||
+      fail "$(deployment_name "$service") is not quiesced"
+  done
+}
+
+hold_runtime() {
+  set_fence_config true
+  wait_for_fence true
+  local service
+  for service in "${quiesce_order[@]}"; do
+    scale_service "$service" 0
+  done
+  verify_held
+}
+
+restore_runtime() {
+  local service replicas
+  validate_state
+  for service in "${restore_order[@]}"; do
+    replicas="$(state_replicas "$service")"
+    scale_service "$service" "$replicas"
+  done
+  set_fence_config false
+  wait_for_fence false
+  rm -f -- "$STATE_FILE"
+}
+
+release_runtime() {
+  [[ "$(fence_config_status)" == "true" ]] ||
+    fail "HTTP mutation fence is not configured for release"
+  local service replicas
+  for service in "${writer_services[@]}"; do
+    replicas="$(deployment_replicas "$service")"
+    [[ "$replicas" =~ ^[1-9][0-9]*$ ]] ||
+      fail "$(deployment_name "$service") is not restored"
+    deployment_is_stable "$service" "$replicas" ||
+      fail "$(deployment_name "$service") is not stable for release"
+  done
+  set_fence_config false
+  wait_for_fence false
+}
+
+case "$ACTION" in
+  enter)
+    [[ "$(fence_config_status)" == "false" ]] ||
+      fail "maintenance entry requires the reviewed unfenced baseline"
+    capture_state
+    if ! (hold_runtime); then
+      restore_runtime || true
+      fail "unable to enter maintenance; restoration was attempted"
+    fi
+    echo "live_data_maintenance=enter status=PASS http_mutation_fence=true writers_quiesced=true"
+    ;;
+  verify-held)
+    verify_held
+    echo "live_data_maintenance=verify-held status=PASS http_mutation_fence=true writers_quiesced=true"
+    ;;
+  restore)
+    restore_runtime
+    echo "live_data_maintenance=restore status=PASS http_mutation_fence=false writers_quiesced=false"
+    ;;
+  hold)
+    hold_runtime
+    echo "live_data_maintenance=hold status=PASS http_mutation_fence=true writers_quiesced=true"
+    ;;
+  release)
+    release_runtime
+    echo "live_data_maintenance=release status=PASS http_mutation_fence=false writers_quiesced=false"
+    ;;
+  *)
+    echo "usage: $0 {enter|verify-held|restore|hold|release}" >&2
+    exit 2
+    ;;
+esac

--- a/infra/oci/scripts/shared-mongo-operation-lock-stan.sh
+++ b/infra/oci/scripts/shared-mongo-operation-lock-stan.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+exec "$ROOT_DIR/infra/azure/agents/shared-mongo-operation-lock-stan.sh" "$@"

--- a/infra/oci/scripts/verify-live-betting-data-evidence-stan.sh
+++ b/infra/oci/scripts/verify-live-betting-data-evidence-stan.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EVIDENCE_DIR="${EVIDENCE_DIR:-${1:-}}"
+EXPECTED_SOURCE_SHA="${EXPECTED_SOURCE_SHA:-}"
+EXPECTED_BUILD_RUN_ID="${EXPECTED_BUILD_RUN_ID:-}"
+EXPECTED_INFRASTRUCTURE_RUN_ID="${EXPECTED_INFRASTRUCTURE_RUN_ID:-}"
+EXPECTED_PHASE="${EXPECTED_PHASE:-}"
+EXPECTED_RUN_ID="${EXPECTED_RUN_ID:-}"
+EXPECTED_RUN_ATTEMPT="${EXPECTED_RUN_ATTEMPT:-1}"
+
+fail() {
+  echo "live_betting_data_evidence=FAIL reason=$*" >&2
+  exit 1
+}
+
+[[ -d "$EVIDENCE_DIR" ]] || fail "evidence directory not found"
+[[ "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+  fail "expected source SHA must be complete lowercase hex"
+[[ "$EXPECTED_BUILD_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+  fail "expected build run ID must be a positive integer"
+[[ "$EXPECTED_INFRASTRUCTURE_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+  fail "expected infrastructure run ID must be a positive integer"
+[[ "$EXPECTED_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+  fail "expected workflow run ID must be a positive integer"
+[[ "$EXPECTED_RUN_ATTEMPT" == "1" ]] ||
+  fail "only first-attempt evidence is accepted"
+case "$EXPECTED_PHASE" in
+  dry-run|apply-backfills|apply-slip-index) ;;
+  *) fail "unexpected evidence phase" ;;
+esac
+
+python3 - "$EVIDENCE_DIR" \
+  "$EXPECTED_SOURCE_SHA" \
+  "$EXPECTED_BUILD_RUN_ID" \
+  "$EXPECTED_INFRASTRUCTURE_RUN_ID" \
+  "$EXPECTED_PHASE" \
+  "$EXPECTED_RUN_ID" \
+  "$EXPECTED_RUN_ATTEMPT" <<'PY'
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).resolve(strict=True)
+expected = {
+    "source_sha": sys.argv[2],
+    "build_run_id": sys.argv[3],
+    "infrastructure_run_id": sys.argv[4],
+    "phase": sys.argv[5],
+    "workflow_run_id": sys.argv[6],
+    "workflow_run_attempt": sys.argv[7],
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def read_env(path: Path, allowed: set[str]) -> dict[str, str]:
+    if not path.is_file() or path.is_symlink():
+        fail(f"required evidence file is missing: {path.name}")
+    values: dict[str, str] = {}
+    for line_number, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not raw_line or "=" not in raw_line:
+            fail(f"{path.name} line {line_number} is malformed")
+        key, value = raw_line.split("=", 1)
+        if key not in allowed:
+            fail(f"{path.name} contains unexpected key {key}")
+        if key in values:
+            fail(f"{path.name} contains duplicate key {key}")
+        values[key] = value
+    if set(values) != allowed:
+        fail(f"{path.name} does not contain the exact reviewed key set")
+    return values
+
+
+manifest_path = root / "SHA256SUMS"
+if not manifest_path.is_file() or manifest_path.is_symlink():
+    fail("SHA256SUMS is missing")
+
+manifest_entries: dict[str, str] = {}
+for line_number, line in enumerate(
+    manifest_path.read_text(encoding="utf-8").splitlines(), start=1
+):
+    match = re.fullmatch(r"([0-9a-f]{64})  ([A-Za-z0-9][A-Za-z0-9._/-]*)", line)
+    if not match:
+        fail(f"SHA256SUMS line {line_number} is malformed")
+    digest, relative = match.groups()
+    relative_path = Path(relative)
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        fail("SHA256SUMS contains an unsafe path")
+    if relative == "SHA256SUMS" or relative in manifest_entries:
+        fail("SHA256SUMS contains a duplicate or recursive entry")
+    manifest_entries[relative] = digest
+
+actual_files: set[str] = set()
+for path in root.rglob("*"):
+    if path.is_symlink():
+        fail("evidence contains a symbolic link")
+    if not path.is_file() or path == manifest_path:
+        continue
+    relative = path.relative_to(root).as_posix()
+    actual_files.add(relative)
+    observed = hashlib.sha256(path.read_bytes()).hexdigest()
+    if manifest_entries.get(relative) != observed:
+        fail(f"evidence digest mismatch for {relative}")
+
+if actual_files != set(manifest_entries):
+    fail("SHA256SUMS does not cover the exact evidence file set")
+
+provenance_keys = {
+    "schema_version",
+    "source_sha",
+    "build_run_id",
+    "infrastructure_run_id",
+    "baseline_sha256",
+    "workflow_run_id",
+    "workflow_run_attempt",
+    "phase",
+    "status",
+    "backfill_complete",
+    "index_ready",
+    "maintenance_fence_enforced",
+    "writers_quiesced",
+    "runtime_held_for_deploy",
+    "operation_lock_enforced",
+    "operation_lock_handoff",
+    "completed_at",
+}
+provenance = read_env(root / "provenance.env", provenance_keys)
+for key, value in expected.items():
+    if provenance.get(key) != value:
+        fail(f"provenance mismatch for {key}")
+if provenance["schema_version"] != "live-betting-v1":
+    fail("unexpected schema evidence version")
+if provenance["status"] != "PASS":
+    fail("data rollout did not complete successfully")
+if provenance["backfill_complete"] not in {"true", "false"}:
+    fail("backfill_complete is not boolean")
+if provenance["index_ready"] not in {"true", "false"}:
+    fail("index_ready is not boolean")
+if not re.fullmatch(r"[0-9a-f]{64}", provenance["baseline_sha256"]):
+    fail("baseline_sha256 is not a SHA-256 digest")
+for key in (
+    "maintenance_fence_enforced",
+    "writers_quiesced",
+    "runtime_held_for_deploy",
+    "operation_lock_enforced",
+    "operation_lock_handoff",
+):
+    if provenance[key] not in {"true", "false"}:
+        fail(f"{key} is not boolean")
+if provenance["operation_lock_enforced"] != "true":
+    fail("phase was not covered by the shared database operation lock")
+if not re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", provenance["completed_at"]):
+    fail("completed_at is not an exact UTC timestamp")
+
+phase = expected["phase"]
+if phase in {"apply-backfills", "apply-slip-index"}:
+    if provenance["backfill_complete"] != "true":
+        fail("mutating phase did not prove completed backfills")
+if phase == "apply-slip-index" and provenance["index_ready"] != "true":
+    fail("final phase did not prove the Slip index")
+if phase == "dry-run":
+    expected_maintenance = {
+        "maintenance_fence_enforced": "false",
+        "writers_quiesced": "false",
+        "runtime_held_for_deploy": "false",
+        "operation_lock_handoff": "false",
+    }
+elif phase == "apply-backfills":
+    expected_maintenance = {
+        "maintenance_fence_enforced": "true",
+        "writers_quiesced": "true",
+        "runtime_held_for_deploy": "false",
+        "operation_lock_handoff": "false",
+    }
+else:
+    expected_maintenance = {
+        "maintenance_fence_enforced": "true",
+        "writers_quiesced": "true",
+        "runtime_held_for_deploy": "true",
+        "operation_lock_handoff": "true",
+    }
+for key, value in expected_maintenance.items():
+    if provenance[key] != value:
+        fail(f"phase has invalid maintenance state for {key}")
+
+required_reports = {
+    "dry-run": {
+        *(f"reports/preflight-{service}.json" for service in (
+            "event", "gamemaster", "moderation", "resulting", "bet", "slip"
+        )),
+        "reports/preflight-slip-index.json",
+    },
+    "apply-backfills": {
+        *(f"reports/preflight-{service}.json" for service in (
+            "event", "gamemaster", "moderation", "resulting", "bet", "slip"
+        )),
+        *(f"reports/apply-{service}.json" for service in (
+            "event", "gamemaster", "moderation", "resulting", "bet", "slip"
+        )),
+        *(f"reports/verify-{service}.json" for service in (
+            "event", "gamemaster", "moderation", "resulting", "bet", "slip"
+        )),
+        "reports/preflight-slip-index.json",
+        "reports/final-slip-index.json",
+    },
+    "apply-slip-index": {
+        *(f"reports/preflight-{service}.json" for service in (
+            "event", "gamemaster", "moderation", "resulting", "bet", "slip"
+        )),
+        *(f"reports/apply-{service}.json" for service in (
+            "event", "gamemaster", "moderation", "resulting", "bet", "slip"
+        )),
+        *(f"reports/verify-{service}.json" for service in (
+            "event", "gamemaster", "moderation", "resulting", "bet", "slip"
+        )),
+        "reports/preflight-slip-index.json",
+        "reports/final-slip-index.json",
+        "reports/apply-slip-index.json",
+        "reports/verify-slip-index.json",
+    },
+}[phase]
+if not required_reports.issubset(actual_files):
+    fail("phase evidence is missing required sanitized reports")
+
+banned_keys = {"duplicateDrafts", "userId", "slipIds", "mongoUri", "MONGO_URI"}
+
+
+def inspect_json(value: object) -> None:
+    if isinstance(value, dict):
+        if banned_keys.intersection(value):
+            fail("evidence contains an unsanitized sensitive field")
+        for child in value.values():
+            inspect_json(child)
+    elif isinstance(value, list):
+        for child in value:
+            inspect_json(child)
+    elif isinstance(value, str) and "mongodb://" in value.lower():
+        fail("evidence contains a Mongo connection string")
+
+
+for relative in sorted(actual_files):
+    if not relative.endswith(".json"):
+        continue
+    try:
+        payload = json.loads((root / relative).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"{relative} is not valid JSON: {exc}")
+    inspect_json(payload)
+
+journal = json.loads((root / "journal.json").read_text(encoding="utf-8"))
+for key, value in expected.items():
+    if str(journal.get(key, "")) != value:
+        fail(f"journal mismatch for {key}")
+if journal.get("status") != "PASS":
+    fail("journal does not record a successful phase")
+if journal.get("baseline_sha256") != provenance["baseline_sha256"]:
+    fail("journal baseline digest differs from provenance")
+for key in (
+    "maintenance_fence_enforced",
+    "writers_quiesced",
+    "runtime_held_for_deploy",
+    "operation_lock_enforced",
+    "operation_lock_handoff",
+):
+    if journal.get(key) is not (provenance[key] == "true"):
+        fail(f"journal maintenance state differs from provenance for {key}")
+
+if phase == "apply-slip-index":
+    schema_keys = {
+        "schema_version",
+        "source_sha",
+        "build_run_id",
+        "infrastructure_run_id",
+        "baseline_sha256",
+        "data_run_id",
+        "data_run_attempt",
+        "backfill_complete",
+        "index_ready",
+        "maintenance_fence_enforced",
+        "writers_quiesced",
+        "runtime_held_for_deploy",
+        "operation_lock_enforced",
+        "operation_lock_handoff",
+    }
+    schema = read_env(root / "schema.env", schema_keys)
+    required_schema = {
+        "schema_version": "live-betting-v1",
+        "source_sha": expected["source_sha"],
+        "build_run_id": expected["build_run_id"],
+        "infrastructure_run_id": expected["infrastructure_run_id"],
+        "baseline_sha256": provenance["baseline_sha256"],
+        "data_run_id": expected["workflow_run_id"],
+        "data_run_attempt": expected["workflow_run_attempt"],
+        "backfill_complete": "true",
+        "index_ready": "true",
+        "maintenance_fence_enforced": "true",
+        "writers_quiesced": "true",
+        "runtime_held_for_deploy": "true",
+        "operation_lock_enforced": "true",
+        "operation_lock_handoff": "true",
+    }
+    if schema != required_schema:
+        fail("schema.env does not bind final readiness to the exact rollout")
+elif (root / "schema.env").exists():
+    fail("non-final phase must not emit schema.env")
+PY
+
+echo "live_betting_data_evidence=PASS phase=$EXPECTED_PHASE"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -534,6 +534,7 @@ done
 build_workflow="$ROOT_DIR/.github/workflows/oci-production-build.yml"
 capacity_workflow="$ROOT_DIR/.github/workflows/oci-capacity-acquire.yml"
 infra_workflow="$ROOT_DIR/.github/workflows/oci-infrastructure.yml"
+data_workflow="$ROOT_DIR/.github/workflows/oci-live-data-rollout.yml"
 deploy_workflow="$ROOT_DIR/.github/workflows/oci-production-deploy.yml"
 migrate_workflow="$ROOT_DIR/.github/workflows/oci-migrate.yml"
 recovery_workflow="$ROOT_DIR/.github/workflows/oci-migration-recovery.yml"
@@ -569,12 +570,12 @@ grep -Fq 'OCI_CAPACITY_PRIVATE_KEY_PEM' "$capacity_workflow"
   "$capacity_workflow" ||
   fail "capacity workflow receives credentials outside its dedicated identity"
 
-for workflow in "$infra_workflow" "$deploy_workflow" "$migrate_workflow"; do
+for workflow in "$infra_workflow" "$data_workflow" "$deploy_workflow" "$migrate_workflow"; do
   grep -Fq 'workflow_dispatch:' "$workflow"
   grep -Fq 'github.run_attempt == 1' "$workflow"
   grep -Fq 'group: oci-control-plane' "$workflow"
 done
-for workflow in "$infra_workflow" "$deploy_workflow"; do
+for workflow in "$infra_workflow" "$data_workflow" "$deploy_workflow"; do
   [[ "$(grep -Fc \
     'OCI_K3S_SSH_PRIVATE_KEY: ${{ secrets.OCI_K3S_SSH_PRIVATE_KEY }}' \
     "$workflow")" == "1" ]] ||
@@ -590,7 +591,7 @@ grep -Fq 'OCI_K3S_RETAIN_TARGET_SSH: "true"' "$infra_workflow" ||
   fail "infrastructure finalization does not retain target SSH within its access step"
 grep -Fq 'unset OCI_K3S_SSH_PRIVATE_KEY' "$infra_workflow" ||
   fail "infrastructure finalization does not clear the target SSH secret before use"
-! grep -Fq 'OCI_K3S_RETAIN_TARGET_SSH' "$deploy_workflow" "$migrate_workflow" ||
+! grep -Fq 'OCI_K3S_RETAIN_TARGET_SSH' "$data_workflow" "$deploy_workflow" "$migrate_workflow" ||
   fail "deployment or migration retains target SSH key material after API forwarding"
 for workflow in "$deploy_workflow" "$migrate_workflow"; do
   public_job_line="$(grep -n -m1 '^  public-validate:' "$workflow" | cut -d: -f1)"
@@ -662,8 +663,17 @@ migration_post_cloud_credentials="$(
   fail "post-commit browser validation receives cloud credentials"
 grep -Fq 'name: oci-infrastructure' "$infra_workflow"
 grep -Fq 'PROVISION OCI ZERO COST' "$infra_workflow"
+grep -Fq 'name: oci-migration' "$data_workflow"
+grep -Fq 'DRY RUN LIVE DATA EXACT SHA' "$data_workflow"
+grep -Fq 'APPLY LIVE BACKFILLS EXACT SHA' "$data_workflow"
+grep -Fq 'APPLY LIVE SLIP INDEX EXACT SHA' "$data_workflow"
+grep -Fq 'shared-mongo-operation-lock-stan.sh acquire' "$data_workflow"
+grep -Fq 'shared-mongo-operation-lock-stan.sh release' "$data_workflow"
+grep -Fq 'verify-live-betting-data-evidence-stan.sh' "$data_workflow"
 grep -Fq 'name: oci-production' "$deploy_workflow"
 grep -Fq 'DEPLOY OCI EXACT SHA' "$deploy_workflow"
+grep -Fq 'data_run_id:' "$deploy_workflow"
+grep -Fq 'EXPECTED_PHASE=apply-slip-index' "$deploy_workflow"
 grep -Fq 'name: oci-migration' "$migrate_workflow"
 grep -Fq 'REPLACE OCI DATA FROM AZURE' "$migrate_workflow"
 grep -Fq 'replace_oci_data:' "$migrate_workflow"
@@ -859,7 +869,13 @@ expected_syntax_targets = [
   "infra/oci/agents/deploy-validation-loop-stan.sh",
   "infra/oci/agents/live-betting-readiness-stan.sh",
   "infra/oci/scripts/deploy.sh",
+  "infra/oci/scripts/live-data-maintenance-stan.sh",
+  "infra/oci/scripts/live-betting-data-rollout-stan.sh",
+  "infra/oci/scripts/shared-mongo-operation-lock-stan.sh",
+  "infra/oci/scripts/verify-live-betting-data-evidence-stan.sh",
   "infra/oci/tests/test-deploy-validation-loop-stan.sh",
+  "infra/oci/tests/test-live-data-maintenance-stan.sh",
+  "infra/oci/tests/test-live-betting-data-rollout-stan.sh",
   "infra/oci/tests/test-live-betting-readiness-stan.sh",
   "infra/oci/tests/rollback-live-readiness-contract.sh",
   "infra/oci/tests/rollback-contract.sh",
@@ -872,6 +888,8 @@ expected_exec_targets = [
   "./infra/azure/agents/test-live-betting-rollback-readiness-stan.sh",
   "./infra/azure/agents/test-production-rollback-stan.sh",
   "./infra/oci/tests/test-deploy-validation-loop-stan.sh",
+  "./infra/oci/tests/test-live-data-maintenance-stan.sh",
+  "./infra/oci/tests/test-live-betting-data-rollout-stan.sh",
   "./infra/oci/tests/test-live-betting-readiness-stan.sh",
   "./infra/oci/tests/rollback-live-readiness-contract.sh",
   "./infra/oci/tests/rollback-contract.sh",
@@ -879,6 +897,7 @@ expected_exec_targets = [
 expected_yaml_targets = [
   ".github/workflows/production-build.yml",
   ".github/workflows/production-deploy.yml",
+  ".github/workflows/oci-live-data-rollout.yml",
   ".github/workflows/oci-production-deploy.yml",
 ]
 

--- a/infra/oci/tests/test-live-betting-data-rollout-stan.sh
+++ b/infra/oci/tests/test-live-betting-data-rollout-stan.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RUNNER="$ROOT_DIR/infra/oci/scripts/live-betting-data-rollout-stan.sh"
+VERIFIER="$ROOT_DIR/infra/oci/scripts/verify-live-betting-data-evidence-stan.sh"
+MAINTENANCE="$ROOT_DIR/infra/oci/scripts/live-data-maintenance-stan.sh"
+WORKFLOW="$ROOT_DIR/.github/workflows/oci-live-data-rollout.yml"
+DEPLOY_WORKFLOW="$ROOT_DIR/.github/workflows/oci-production-deploy.yml"
+WORK_PARENT="$ROOT_DIR/infra/oci/tests/.live-data-rollout-workdirs"
+SOURCE_SHA=1111111111111111111111111111111111111111
+BUILD_RUN_ID=2001
+INFRASTRUCTURE_RUN_ID=3001
+
+mkdir -p "$WORK_PARENT"
+work_dir="$(mktemp -d "$WORK_PARENT/test.XXXXXX")"
+stub_bin="$work_dir/bin"
+stub_state="$work_dir/state"
+images_file="$work_dir/images.tsv"
+mkdir -p "$stub_bin" "$stub_state"
+cleanup() {
+  rm -rf -- "$work_dir"
+  rmdir "$WORK_PARENT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+fail() {
+  echo "live data rollout contract test failed: $*" >&2
+  exit 1
+}
+
+cat >"$stub_bin/kubectl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state="${STUB_STATE_DIR:?}"
+scenario="${STUB_SCENARIO:?}"
+mkdir -p "$state/jobs" "$state/applied"
+
+if [[ "${1:-}" == "create" && "${2:-}" == "-f" && "${3:-}" == "-" ]]; then
+  manifest="$(mktemp "$state/jobs/pending.XXXXXX")"
+  cat >"$manifest"
+  job="$(
+    awk '
+      /^metadata:/ { in_metadata=1; next }
+      in_metadata && /^  name:/ { print $2; exit }
+    ' "$manifest"
+  )"
+  [[ -n "$job" ]]
+  mv "$manifest" "$state/jobs/$job.yaml"
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" ]]; then
+  case "${2:-}" in
+    namespace|service|secret)
+      printf '{}\n'
+      exit 0
+      ;;
+    job)
+      printf '{"status":{"succeeded":1}}\n'
+      exit 0
+      ;;
+    deployment)
+      printf '0|0|0|0'
+      exit 0
+      ;;
+    pods)
+      if [[ "$*" == *"app=gaming-auth-mongo"* ]]; then
+        printf 'mongo-0'
+      elif [[ "$*" == *"app=gaming-rabbitmq"* ]]; then
+        printf 'rabbitmq-0'
+      else
+        printf '{"items":[]}\n'
+      fi
+      exit 0
+      ;;
+  esac
+fi
+
+if [[ "${1:-}" == "logs" ]]; then
+  job="${2#job/}"
+  manifest="$state/jobs/$job.yaml"
+  [[ -f "$manifest" ]]
+  service="$(
+    sed -n 's#.*gaming_shared_never_matches##; s#.*\/gaming_\([a-z]*\)".*#\1#p' "$manifest" |
+      head -n 1
+  )"
+  [[ -n "$service" ]]
+  is_apply=false
+  grep -Fq -- '- "--apply"' "$manifest" && is_apply=true
+
+  if grep -Fq 'ensureDraftIndexes.js' "$manifest"; then
+    index_state=missing
+    ready=false
+    changed=0
+    blockers=1
+    all_applied=true
+    for expected in event gamemaster moderation resulting bet slip; do
+      [[ -f "$state/applied/$expected" ]] || all_applied=false
+    done
+    if [[ "$scenario" == "final" || "$all_applied" == "true" ]]; then
+      ready=true
+      blockers=0
+    fi
+    if [[ -f "$state/applied/slip-index" ]]; then
+      index_state=matching
+      ready=true
+      blockers=0
+    fi
+    if [[ "$is_apply" == "true" ]]; then
+      touch "$state/applied/slip-index"
+      changed=1
+    fi
+    mode=dry-run
+    [[ "$is_apply" == "false" ]] || mode=apply
+    jq -n \
+      --arg mode "$mode" \
+      --arg index_state "$index_state" \
+      --argjson ready "$ready" \
+      --argjson changed "$changed" \
+      --argjson blockers "$blockers" '{
+        mode:$mode,
+        ready:$ready,
+        scanned:3,
+        matched:$blockers,
+        changed:$changed,
+        skipped:(3-$blockers),
+        errorCount:$blockers,
+        existingIndex:$index_state,
+        indexName:"slip_draft_unique_by_kind",
+        blocking:{
+          draftCount:3,
+          duplicateGroupCount:0,
+          duplicateDraftCount:0,
+          missingBetKindCount:$blockers,
+          invalidBetKindCount:0,
+          missingDraftKeyCount:0,
+          invalidDraftKeyCount:0,
+          mismatchedDraftKeyCount:0,
+          missingRowKindCount:0,
+          invalidRowKindCount:0,
+          mismatchedRowKindCount:0,
+          unnormalizedDraftCount:$blockers
+        }
+      }'
+    exit 0
+  fi
+
+  matched=0
+  changed=0
+  mode=dry-run
+  if [[ "$scenario" == "pending" ]]; then
+    matched=2
+  elif [[ "$scenario" == "backfills" && ! -f "$state/applied/$service" ]]; then
+    matched=1
+  fi
+  if [[ "$is_apply" == "true" ]]; then
+    mode=apply
+    matched=1
+    changed=1
+    touch "$state/applied/$service"
+  fi
+
+  duplicate_json='[]'
+  if [[ "$scenario" == "duplicates" && "$service" == "slip" ]]; then
+    duplicate_json='[{"userId":"secret-user","betKind":"PRE_MATCH","count":2,"slipIds":["secret-slip"]}]'
+  fi
+  jq -n \
+    --arg mode "$mode" \
+    --arg service "$service" \
+    --argjson matched "$matched" \
+    --argjson changed "$changed" \
+    --argjson duplicates "$duplicate_json" '{
+      mode:$mode,
+      batchSize:100,
+      collection:"all",
+      scanned:5,
+      matched:$matched,
+      changed:$changed,
+      skipped:(5-$matched),
+      errorCount:0,
+      collections:[{
+        collection:$service,
+        scanned:5,
+        matched:$matched,
+        changed:$changed,
+        skipped:(5-$matched),
+        errorCount:0
+      }],
+      duplicateDrafts:$duplicates
+    }'
+  exit 0
+fi
+
+if [[ "${1:-}" == "delete" || "${1:-}" == "rollout" || "${1:-}" == "exec" ]]; then
+  exit 0
+fi
+
+echo "unexpected kubectl invocation: $*" >&2
+exit 1
+SH
+chmod +x "$stub_bin/kubectl"
+
+for service in auth bet backoffice client event gamemaster moderation resulting slip; do
+  printf '%s\tregistry.example/betstan\tregistry.example/betstan@sha256:%064d\tsha256:%064d\tsha256:%064d\n' \
+    "$service" 1 1 1 >>"$images_file"
+done
+
+run_phase() {
+  local phase="$1"
+  local scenario="$2"
+  local run_id="$3"
+  local output="$4"
+  local maintenance_fence=false
+  local writers_quiesced=false
+  local runtime_handoff=false
+  local lock_handoff=false
+  if [[ "$phase" != "dry-run" ]]; then
+    maintenance_fence=true
+    writers_quiesced=true
+  fi
+  if [[ "$phase" == "apply-slip-index" ]]; then
+    runtime_handoff=true
+    lock_handoff=true
+  fi
+  rm -rf -- "$stub_state"
+  mkdir -p "$stub_state"
+  PATH="$stub_bin:$PATH" \
+  STUB_STATE_DIR="$stub_state" \
+  STUB_SCENARIO="$scenario" \
+  PHASE="$phase" \
+  SOURCE_SHA="$SOURCE_SHA" \
+  BUILD_RUN_ID="$BUILD_RUN_ID" \
+  INFRASTRUCTURE_RUN_ID="$INFRASTRUCTURE_RUN_ID" \
+  IMAGE_PROVENANCE_FILE="$images_file" \
+  OUTPUT_DIR="$output" \
+  OCI_K8S_NAMESPACE=betstan-oci \
+  JOB_TIMEOUT_SECONDS=10 \
+  GITHUB_RUN_ID="$run_id" \
+  GITHUB_RUN_ATTEMPT=1 \
+  BASELINE_SHA256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  MAINTENANCE_FENCE_ENFORCED="$maintenance_fence" \
+  WRITERS_QUIESCED="$writers_quiesced" \
+  RUNTIME_HELD_FOR_DEPLOY="$runtime_handoff" \
+  OPERATION_LOCK_ENFORCED=true \
+  OPERATION_LOCK_HANDOFF="$lock_handoff" \
+    "$RUNNER" >/dev/null
+}
+
+pending_output="$work_dir/pending"
+run_phase dry-run pending 4001 "$pending_output"
+grep -Fxq 'phase=dry-run' "$pending_output/provenance.env"
+grep -Fxq 'backfill_complete=false' "$pending_output/provenance.env"
+grep -Fxq 'index_ready=false' "$pending_output/provenance.env"
+[[ ! -e "$pending_output/schema.env" ]] ||
+  fail "dry-run emitted final schema evidence"
+if grep -R -E 'secret-user|secret-slip|mongodb://' "$pending_output" >/dev/null; then
+  fail "sanitized dry-run evidence leaked sensitive data"
+fi
+
+backfill_output="$work_dir/backfills"
+run_phase apply-backfills backfills 4002 "$backfill_output"
+grep -Fxq 'phase=apply-backfills' "$backfill_output/provenance.env"
+grep -Fxq 'backfill_complete=true' "$backfill_output/provenance.env"
+[[ ! -e "$backfill_output/schema.env" ]] ||
+  fail "backfill phase emitted final schema evidence"
+
+final_output="$work_dir/final"
+run_phase apply-slip-index final 4003 "$final_output"
+grep -Fxq 'phase=apply-slip-index' "$final_output/provenance.env"
+grep -Fxq 'backfill_complete=true' "$final_output/schema.env"
+grep -Fxq 'index_ready=true' "$final_output/schema.env"
+grep -Fxq 'runtime_held_for_deploy=true' "$final_output/schema.env"
+grep -Fxq 'operation_lock_handoff=true' "$final_output/schema.env"
+EVIDENCE_DIR="$final_output" \
+EXPECTED_SOURCE_SHA="$SOURCE_SHA" \
+EXPECTED_BUILD_RUN_ID="$BUILD_RUN_ID" \
+EXPECTED_INFRASTRUCTURE_RUN_ID="$INFRASTRUCTURE_RUN_ID" \
+EXPECTED_PHASE=apply-slip-index \
+EXPECTED_RUN_ID=4003 \
+EXPECTED_RUN_ATTEMPT=1 \
+  "$VERIFIER" >/dev/null
+
+cp "$final_output/schema.env" "$work_dir/schema.env"
+printf 'index_ready=false\n' >>"$final_output/schema.env"
+if EVIDENCE_DIR="$final_output" \
+  EXPECTED_SOURCE_SHA="$SOURCE_SHA" \
+  EXPECTED_BUILD_RUN_ID="$BUILD_RUN_ID" \
+  EXPECTED_INFRASTRUCTURE_RUN_ID="$INFRASTRUCTURE_RUN_ID" \
+  EXPECTED_PHASE=apply-slip-index \
+  EXPECTED_RUN_ID=4003 \
+  EXPECTED_RUN_ATTEMPT=1 \
+    "$VERIFIER" >/dev/null 2>&1; then
+  fail "tampered schema evidence was accepted"
+fi
+mv "$work_dir/schema.env" "$final_output/schema.env"
+
+duplicates_output="$work_dir/duplicates"
+if run_phase dry-run duplicates 4004 "$duplicates_output" >/dev/null 2>&1; then
+  fail "duplicate draft slips were accepted"
+fi
+if [[ -d "$duplicates_output" ]] &&
+  grep -R -E 'secret-user|secret-slip' "$duplicates_output" >/dev/null; then
+  fail "failed duplicate scan persisted raw identifiers"
+fi
+
+for manifest in "$stub_state"/jobs/*.yaml; do
+  grep -Eq 'image: .+@sha256:[0-9a-f]{64}$' "$manifest" ||
+    fail "job did not use an immutable image digest"
+  grep -Fq 'automountServiceAccountToken: false' "$manifest" ||
+    fail "job mounted a Kubernetes API token"
+  grep -Fq 'kubernetes.io/arch: arm64' "$manifest" ||
+    fail "job was not bound to the approved image architecture"
+  grep -Fq 'readOnlyRootFilesystem: true' "$manifest" ||
+    fail "job filesystem was writable"
+  if grep -Fq 'src/scripts/' "$manifest"; then
+    fail "job invoked TypeScript source instead of the compiled CLI"
+  fi
+done
+
+for literal in \
+  'name: oci-migration' \
+  'DRY RUN LIVE DATA EXACT SHA' \
+  'APPLY LIVE BACKFILLS EXACT SHA' \
+  'APPLY LIVE SLIP INDEX EXACT SHA' \
+  'production-run-exclusivity-stan.sh' \
+  'shared-mongo-operation-lock-stan.sh acquire' \
+  'shared-mongo-operation-lock-stan.sh release' \
+  'shared-mongo-operation-lock-stan.sh verify' \
+  'live-data-maintenance-stan.sh enter' \
+  'live-data-maintenance-stan.sh verify-held' \
+  'baseline-capture-stan.sh' \
+  'verify-live-betting-data-evidence-stan.sh'; do
+  grep -Fq "$literal" "$WORKFLOW" ||
+    fail "data workflow is missing safety contract: $literal"
+done
+for literal in \
+  'data_run_id:' \
+  'oci-live-data-rollout.yml' \
+  'EXPECTED_PHASE=apply-slip-index' \
+  'artifacts/data/schema.env' \
+  'shared-mongo-operation-lock-stan.sh verify' \
+  'live-data-maintenance-stan.sh verify-held' \
+  'live-data-maintenance-stan.sh release' \
+  'live-data-maintenance-stan.sh hold'; do
+  grep -Fq "$literal" "$DEPLOY_WORKFLOW" ||
+    fail "deploy workflow is missing data prerequisite: $literal"
+done
+[[ -x "$MAINTENANCE" ]] ||
+  fail "maintenance operator is not executable"
+
+python3 - "$WORKFLOW" "$DEPLOY_WORKFLOW" <<'PY'
+import sys
+from pathlib import Path
+
+data = Path(sys.argv[1]).read_text(encoding="utf-8")
+deploy = Path(sys.argv[2]).read_text(encoding="utf-8")
+
+
+def require_order(text: str, markers: list[str], label: str) -> None:
+    positions = []
+    for marker in markers:
+        position = text.find(marker)
+        if position < 0:
+            raise SystemExit(f"{label} is missing ordered marker: {marker}")
+        positions.append(position)
+    if positions != sorted(positions):
+        raise SystemExit(f"{label} safety operations are out of order")
+
+
+require_order(
+    data,
+    [
+        "Acquire database operation lock",
+        "Capture pre-mutation rollback baseline",
+        "Fence writes and quiesce legacy data writers",
+        "Execute exact-digest live data phase",
+        "Restore runtime or verify final deploy handoff",
+        "Upload exact sanitized data evidence",
+        "Restore runtime if final handoff packaging failed",
+        "Release database operation lock unless handed to deploy",
+    ],
+    "data workflow",
+)
+require_order(
+    deploy,
+    [
+        "Download exact live data readiness evidence",
+        "Download exact pre-mutation rollback baseline",
+        "Verify immutable image and infrastructure provenance",
+        "Verify transferred database lock and maintenance fence",
+        "Deploy immutable images sequentially",
+        "Bind schema evidence to deployment provenance",
+        "Run protected OCI cluster validation loop",
+        "Release transferred lock after protected validation",
+        "Release live data maintenance fence",
+        "Re-enter maintenance after an incomplete deployment",
+    ],
+    "deploy workflow",
+)
+for literal in (
+    "SHARED_MONGO_LOCK_TOKEN: live-data-${{ github.run_id }}-${{ github.run_attempt }}",
+    "SHARED_MONGO_LOCK_OPERATION: live-data-${{ inputs.phase }}",
+    "OPERATION_LOCK_HANDOFF: ${{ inputs.phase == 'apply-slip-index' }}",
+):
+    if literal not in data:
+        raise SystemExit(f"data workflow is missing lock handoff contract: {literal}")
+for literal in (
+    "EXPECTED_OPERATION_LOCK_HOLDER: live-data-${{ inputs.data_run_id }}-1",
+    "EXPECTED_OPERATION_LOCK_ID: live-data-apply-slip-index",
+    "EXPECTED_OPERATION_LOCK_SOURCE_SHA: ${{ inputs.approved_sha }}",
+    'OCI_EXPECT_HTTP_MUTATION_FENCE: "1"',
+    "shared-mongo-operation-lock-stan.sh verify-released",
+):
+    if literal not in deploy:
+        raise SystemExit(f"deploy workflow is missing fenced validation contract: {literal}")
+PY
+
+echo "live_betting_data_rollout_tests=PASS"

--- a/infra/oci/tests/test-live-data-maintenance-stan.sh
+++ b/infra/oci/tests/test-live-data-maintenance-stan.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$ROOT_DIR/infra/oci/scripts/live-data-maintenance-stan.sh"
+LOCK_SCRIPT="$ROOT_DIR/infra/oci/scripts/shared-mongo-operation-lock-stan.sh"
+WORK_PARENT="$ROOT_DIR/infra/oci/tests/.live-data-maintenance-workdirs"
+
+mkdir -p "$WORK_PARENT"
+work_dir="$(mktemp -d "$WORK_PARENT/test.XXXXXX")"
+stub_bin="$work_dir/bin"
+stub_state="$work_dir/state"
+state_file="$work_dir/maintenance.tsv"
+mkdir -p "$stub_bin" "$stub_state/replicas"
+
+cleanup() {
+  rm -rf -- "$work_dir"
+  rmdir "$WORK_PARENT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+fail() {
+  echo "live data maintenance contract test failed: $*" >&2
+  exit 1
+}
+
+cat >"$stub_state/server-snippet" <<'EOF'
+if ($host = "www.betstan.xyz") {
+  return 308 https://betstan.xyz$request_uri;
+}
+EOF
+for service in bet event moderation resulting slip gamemaster; do
+  printf '1\n' >"$stub_state/replicas/$service"
+done
+
+cat >"$stub_bin/kubectl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state="${STUB_STATE_DIR:?}"
+
+service_from_deployment() {
+  local deployment="${1#deployment/}"
+  deployment="${deployment#gaming-}"
+  printf '%s' "${deployment%-depl}"
+}
+
+ready_pod_json() {
+  local name="$1"
+  jq -cn --arg name "$name" '{
+    metadata:{name:$name,deletionTimestamp:null},
+    status:{
+      phase:"Running",
+      conditions:[{type:"Ready",status:"True"}]
+    }
+  }'
+}
+
+if [[ "${1:-}" == "get" && "${2:-}" == "configmap" ]]; then
+  cat "$state/server-snippet"
+  exit 0
+fi
+
+if [[ "${1:-}" == "patch" && "${2:-}" == "configmap" ]]; then
+  patch=""
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "--patch" ]]; then
+      patch="$2"
+      break
+    fi
+    shift
+  done
+  [[ -n "$patch" ]]
+  jq -r '.data["server-snippet"]' <<<"$patch" >"$state/server-snippet"
+  exit 0
+fi
+
+if [[ "${1:-}" == "rollout" && "${2:-}" == "status" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "deployment" ]]; then
+  service="$(service_from_deployment "${3:-}")"
+  replicas="$(cat "$state/replicas/$service")"
+  jq -cn --argjson replicas "$replicas" '{
+    spec:{replicas:$replicas},
+    status:{
+      replicas:$replicas,
+      updatedReplicas:$replicas,
+      readyReplicas:$replicas,
+      availableReplicas:$replicas
+    }
+  }'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "pods" ]]; then
+  selector=""
+  while [[ "$#" -gt 0 ]]; do
+    if [[ "$1" == "-l" ]]; then
+      selector="$2"
+      break
+    fi
+    shift
+  done
+  if [[ "$selector" == "app.kubernetes.io/component=controller" ]]; then
+    pod="$(ready_pod_json ingress-controller-0)"
+    jq -cn --argjson pod "$pod" '{items:[$pod]}'
+    exit 0
+  fi
+  service="${selector#app=gaming-}"
+  replicas="$(cat "$state/replicas/$service")"
+  if [[ "$replicas" == "0" ]]; then
+    printf '{"items":[]}\n'
+  else
+    pod="$(ready_pod_json "gaming-${service}-0")"
+    jq -cn --argjson pod "$pod" '{items:[$pod]}'
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "exec" ]]; then
+  cat "$state/server-snippet"
+  exit 0
+fi
+
+if [[ "${1:-}" == "scale" ]]; then
+  service="$(service_from_deployment "${2:-}")"
+  replicas=""
+  for argument in "$@"; do
+    [[ "$argument" != --replicas=* ]] || replicas="${argument#--replicas=}"
+  done
+  [[ "$replicas" =~ ^[0-9]+$ ]]
+  if [[ "${STUB_FAIL_SCALE_SERVICE:-}" == "$service" &&
+        ! -e "$state/scale-failed-once" ]]; then
+    touch "$state/scale-failed-once"
+    exit 1
+  fi
+  printf '%s\n' "$replicas" >"$state/replicas/$service"
+  exit 0
+fi
+
+echo "unexpected kubectl invocation: $*" >&2
+exit 1
+SH
+chmod +x "$stub_bin/kubectl"
+
+run_maintenance() {
+  local action="$1"
+  PATH="$stub_bin:$PATH" \
+  STUB_STATE_DIR="$stub_state" \
+  STATE_FILE="$state_file" \
+  OCI_K8S_NAMESPACE=betstan-oci \
+  WAIT_ATTEMPTS=2 \
+  WAIT_SECONDS=1 \
+    "$SCRIPT" "$action" >/dev/null
+}
+
+assert_replicas() {
+  local expected="$1"
+  local service
+  for service in bet event moderation resulting slip gamemaster; do
+    [[ "$(cat "$stub_state/replicas/$service")" == "$expected" ]] ||
+      fail "$service replicas did not equal $expected"
+  done
+}
+
+run_maintenance enter
+grep -Fq 'request_method' "$stub_state/server-snippet" ||
+  fail "maintenance entry did not install the HTTP write fence"
+assert_replicas 0
+run_maintenance verify-held
+[[ -s "$state_file" ]] || fail "maintenance entry did not capture restoration state"
+
+run_maintenance restore
+if grep -Fq 'request_method' "$stub_state/server-snippet"; then
+  fail "maintenance restoration retained the HTTP write fence"
+fi
+assert_replicas 1
+[[ ! -e "$state_file" ]] || fail "maintenance restoration retained stale state"
+
+run_maintenance enter
+for service in bet event moderation resulting slip gamemaster; do
+  STUB_STATE_DIR="$stub_state" "$stub_bin/kubectl" \
+    scale "deployment/gaming-${service}-depl" \
+    -n betstan-oci \
+    --replicas=1 >/dev/null
+done
+run_maintenance release
+assert_replicas 1
+if grep -Fq 'request_method' "$stub_state/server-snippet"; then
+  fail "deployment release retained the HTTP write fence"
+fi
+
+run_maintenance hold
+assert_replicas 0
+run_maintenance verify-held
+
+for service in bet event moderation resulting slip gamemaster; do
+  printf '1\n' >"$stub_state/replicas/$service"
+done
+cat >"$stub_state/server-snippet" <<'EOF'
+if ($host = "www.betstan.xyz") {
+  return 308 https://betstan.xyz$request_uri;
+}
+EOF
+rm -f -- "$state_file" "$stub_state/scale-failed-once"
+if PATH="$stub_bin:$PATH" \
+    STUB_STATE_DIR="$stub_state" \
+    STUB_FAIL_SCALE_SERVICE=slip \
+    STATE_FILE="$state_file" \
+    OCI_K8S_NAMESPACE=betstan-oci \
+    WAIT_ATTEMPTS=2 \
+    WAIT_SECONDS=1 \
+      "$SCRIPT" enter >/dev/null 2>&1; then
+  fail "partial writer quiescence was accepted"
+fi
+assert_replicas 1
+if grep -Fq 'request_method' "$stub_state/server-snippet"; then
+  fail "failed maintenance entry did not restore the HTTP write fence"
+fi
+
+lock_bin="$work_dir/lock-bin"
+mkdir -p "$lock_bin"
+cat >"$lock_bin/kubectl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "get" && "${2:-}" == "configmap" ]]; then
+  printf '%s\n' "${STUB_LOCK_STATE:?}"
+  exit 0
+fi
+echo "unexpected lock kubectl invocation: $*" >&2
+exit 1
+SH
+chmod +x "$lock_bin/kubectl"
+lock_env=(
+  NAMESPACE=betstan-oci
+  LOCK_TOKEN=live-data-4003-1
+  OPERATION_ID=live-data-apply-slip-index
+  SOURCE_SHA=1111111111111111111111111111111111111111
+)
+PATH="$lock_bin:$PATH" \
+STUB_LOCK_STATE='active|live-data-4003-1|live-data-apply-slip-index|1111111111111111111111111111111111111111' \
+env "${lock_env[@]}" "$LOCK_SCRIPT" verify >/dev/null
+PATH="$lock_bin:$PATH" \
+STUB_LOCK_STATE='released||live-data-apply-slip-index|1111111111111111111111111111111111111111' \
+env "${lock_env[@]}" "$LOCK_SCRIPT" verify-released >/dev/null
+if PATH="$lock_bin:$PATH" \
+    STUB_LOCK_STATE='active|different-holder|live-data-apply-slip-index|1111111111111111111111111111111111111111' \
+    env "${lock_env[@]}" "$LOCK_SCRIPT" verify >/dev/null 2>&1; then
+  fail "database lock handoff accepted a different holder"
+fi
+
+echo "live_data_maintenance_tests=PASS"


### PR DESCRIPTION
## Summary
- promote the protected exact-SHA three-phase OCI live-data rollout
- promote HTTP write fencing, six-writer quiescence, and transferable Mongo lock handoff
- bind schema evidence and the pre-mutation rollback baseline into dark deployment
- include deterministic Bet worker shutdown synchronization exposed during bootstrap

## Promotion safety
- the one-use quality-workflow authorization has been removed
- current `master` is an ancestor of `dev`
- live kickoffs remain disabled
- this promotion triggers fresh immutable image builds only; it does not deploy or mutate production data
- data phases remain human-gated under `oci-migration`

## Validation
- full OCI contract suite: 12/12
- live readiness: 21 scenarios
- retirement audit: 95 scenarios
- exact Bet CI coverage gate: 68/68 tests
- rollout, maintenance, workflow inventory, exclusivity, deployment safety, and deploy-loop contracts pass