### PR TITLE
fix(oci): retain bounded rollback images

### DIFF
--- a/infra/azure/agents/test-audit-oci-primary-retirement-stan.sh
+++ b/infra/azure/agents/test-audit-oci-primary-retirement-stan.sh
@@ -558,6 +558,32 @@ case "$key" in
       printf '{"data":{"items":[{"display-name":"betstan_images","image-count":9,"layer-count":49,"layers-size-in-bytes":171413487,"is-public":false,"is-immutable":null}]}}\n'
     fi
     ;;
+  artifacts/container/image/list)
+    jq -cn '
+      def services: [
+        "auth", "bet", "backoffice", "client", "event", "gamemaster",
+        "moderation", "resulting", "slip"
+      ];
+      def pad($value; $width):
+        ($value | tostring) as $text
+        | ("0" * ($width - ($text | length))) + $text;
+      {
+        data: {
+          items: [
+            range(0; 9) as $service_index
+            | {
+                "repository-name": "betstan_images",
+                version: (
+                  "oci-\(services[$service_index])-" + pad(1; 40)
+                ),
+                digest: ("sha256:" + pad($service_index + 1; 64)),
+                "lifecycle-state": "AVAILABLE"
+              }
+          ]
+        }
+      }
+    '
+    ;;
   network/internet-gateway/list)
     printf '{"data":[{"lifecycle-state":"AVAILABLE"}]}\n'
     ;;

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -29,7 +29,10 @@ remains an explicit fallback selected with `OCI_RUNTIME_MODE=oke`.
   `OCI_LB_MAX_MBPS=10`, and `OCI_EXPECTED_MONTHLY_COST=0` are immutable
   Free Tier gates.
 - OCIR repository layer storage must remain at or below
-  `OCI_REGISTRY_MAX_BYTES=500000000`.
+  `OCI_REGISTRY_MAX_BYTES=500000000`. The inventory accepts only one to three
+  complete nine-image generations: the exact candidate and up to two retained
+  rollback generations. It verifies complete service tag sets and unique
+  service/digest mappings; partial or fourth generations fail closed.
 - Frankfurt OCIR does not currently support repository-level immutability.
   One private `${OCI_IMAGE_PREFIX}_images` repository is precreated so the
   eight backend images share their identical Node layers instead of charging

--- a/infra/oci/scripts/inventory.sh
+++ b/infra/oci/scripts/inventory.sh
@@ -8,6 +8,12 @@ source "$SCRIPT_DIR/lib.sh"
 INVENTORY_MODE="${INVENTORY_MODE:-${1:-preflight}}"
 OUTPUT_FILE="${OUTPUT_FILE:-}"
 OCI_RUNTIME_MODE="$(oci_runtime_mode)"
+REGISTRY_IMAGES_PER_GENERATION=9
+REGISTRY_MAX_GENERATIONS=3
+REGISTRY_SERVICES_JSON='[
+  "auth", "bet", "backoffice", "client", "event", "gamemaster",
+  "moderation", "resulting", "slip"
+]'
 [[ "$INVENTORY_MODE" == "preflight" || "$INVENTORY_MODE" == "complete" ]] ||
   oci_die "INVENTORY_MODE must be preflight or complete"
 oci_require_cli_version
@@ -39,6 +45,12 @@ public_ips="$(
 )"
 bastions="$(oci bastion bastion list --compartment-id "$OCI_COMPARTMENT_OCID" --all)"
 repositories="$(oci artifacts container repository list --compartment-id "$OCI_COMPARTMENT_OCID" --all)"
+images="$(
+  oci artifacts container image list \
+    --compartment-id "$OCI_COMPARTMENT_OCID" \
+    --repository-name "${OCI_IMAGE_PREFIX}_images" \
+    --all
+)"
 buckets="$(oci os bucket list --compartment-id "$OCI_COMPARTMENT_OCID" --all)"
 clusters="$(oci_normalize_list_json "$clusters")"
 node_pools="$(oci_normalize_list_json "$node_pools")"
@@ -53,6 +65,7 @@ service_gateways="$(oci_normalize_list_json "$service_gateways")"
 public_ips="$(oci_normalize_list_json "$public_ips")"
 bastions="$(oci_normalize_list_json "$bastions")"
 repositories="$(oci_normalize_list_json "$repositories" items)"
+images="$(oci_normalize_list_json "$images" items)"
 buckets="$(oci_normalize_list_json "$buckets")"
 expected_repositories="$(
   jq -cn --arg prefix "$OCI_IMAGE_PREFIX" '[$prefix + "_images"]'
@@ -73,8 +86,13 @@ inventory="$(
     --argjson public_ips "$public_ips" \
     --argjson bastions "$bastions" \
     --argjson repositories "$repositories" \
+    --argjson images "$images" \
     --argjson buckets "$buckets" \
     --argjson expected_repositories "$expected_repositories" \
+    --argjson registry_images_per_generation "$REGISTRY_IMAGES_PER_GENERATION" \
+    --argjson registry_max_generations "$REGISTRY_MAX_GENERATIONS" \
+    --argjson registry_services "$REGISTRY_SERVICES_JSON" \
+    --arg expected_repository "${OCI_IMAGE_PREFIX}_images" \
     --arg mode "$INVENTORY_MODE" \
     --arg runtime_mode "$OCI_RUNTIME_MODE" \
     --argjson expected_cost "$OCI_EXPECTED_MONTHLY_COST" '
@@ -219,6 +237,72 @@ inventory="$(
           [$repositories.data.items[]? | (."layers-size-in-bytes" | type)] |
           all(. == "number")
         ),
+        registry_image_analysis: (
+          [
+            $images.data.items[]?
+            | . as $image
+            | (
+                (
+                  (.version // "")
+                  | try capture(
+                      "^oci-(?<service>auth|bet|backoffice|client|event|gamemaster|moderation|resulting|slip)-(?<source_sha>[0-9a-f]{40})$"
+                    ) catch null
+                ) // null
+              ) as $tag
+            | {
+                valid: (
+                  $tag != null and
+                  ($image.digest // "" | test("^sha256:[0-9a-f]{64}$")) and
+                  $image."repository-name" == $expected_repository and
+                  $image."lifecycle-state" == "AVAILABLE"
+                ),
+                service: ($tag.service // ""),
+                source_sha: ($tag.source_sha // ""),
+                digest: ($image.digest // "")
+              }
+          ] as $rows
+          | ($rows | map(select(.valid))) as $valid_rows
+          | ($valid_rows | group_by(.source_sha)) as $tag_generations
+          | ($valid_rows | unique_by(.digest)) as $unique_images
+          | {
+              listed_tag_count: ($rows | length),
+              valid_tag_count: ($valid_rows | length),
+              tag_generation_count: ($tag_generations | length),
+              incomplete_tag_generation_count: ([
+                $tag_generations[]
+                | select(
+                    length != $registry_images_per_generation or
+                    ([.[].service] | unique | sort) !=
+                      ($registry_services | sort) or
+                    ([.[].digest] | unique | length) !=
+                      $registry_images_per_generation
+                  )
+              ] | length),
+              unique_image_count: ($unique_images | length),
+              unique_generation_count: ([
+                $tag_generations[]
+                | sort_by(.service)
+                | map(.service + "=" + .digest)
+                | join("|")
+              ] | unique | length),
+              digest_service_conflict_count: ([
+                ($valid_rows | group_by(.digest))[]
+                | select(([.[].service] | unique | length) != 1)
+              ] | length),
+              unique_service_distribution_valid: (
+                ($unique_images | length) > 0 and
+                ([$unique_images[].service] | unique | sort) ==
+                  ($registry_services | sort) and
+                ([
+                  ($unique_images | group_by(.service))[] | length
+                ] | unique) == [
+                  (($unique_images | length) / $registry_images_per_generation)
+                ]
+              )
+            }
+        ),
+        registry_images_per_generation: $registry_images_per_generation,
+        registry_max_generations: $registry_max_generations,
         expected_registry_repositories: $expected_repositories,
         object_storage_buckets: [
           $buckets.data[]? | {name, storage_tier: ."storage-tier"}
@@ -230,7 +314,9 @@ inventory="$(
 jq -e --argjson ocpus "$OCI_A1_OCPUS" --argjson memory "$OCI_A1_MEMORY_GB" \
   --argjson lb_min "$OCI_LB_MIN_MBPS" --argjson lb_max "$OCI_LB_MAX_MBPS" \
   --argjson boot_vpus "$OCI_BOOT_VOLUME_VPUS_PER_GB" \
-  --argjson registry_max "$OCI_REGISTRY_MAX_BYTES" '
+  --argjson registry_max "$OCI_REGISTRY_MAX_BYTES" \
+  --argjson registry_images_per_generation "$REGISTRY_IMAGES_PER_GENERATION" \
+  --argjson registry_max_generations "$REGISTRY_MAX_GENERATIONS" '
     .expected_monthly_cost == 0 and
     .nat_gateway_count == 0 and
     .service_gateway_count == 0 and
@@ -266,7 +352,21 @@ jq -e --argjson ocpus "$OCI_A1_OCPUS" --argjson memory "$OCI_A1_MEMORY_GB" \
     .registry_layers_size_bytes <= $registry_max and
     ([.registry_repositories[].name] | sort) ==
       (.expected_registry_repositories | sort) and
-    ([.registry_repositories[] | select(.image_count != 9)] | length) == 0 and
+    ([.registry_repositories[] | select(
+      .image_count < $registry_images_per_generation or
+      .image_count > ($registry_images_per_generation * $registry_max_generations) or
+      (.image_count % $registry_images_per_generation) != 0
+    )] | length) == 0 and
+    .registry_image_analysis.listed_tag_count ==
+      .registry_image_analysis.valid_tag_count and
+    .registry_image_analysis.incomplete_tag_generation_count == 0 and
+    .registry_image_analysis.digest_service_conflict_count == 0 and
+    .registry_image_analysis.unique_service_distribution_valid == true and
+    .registry_image_analysis.unique_image_count ==
+      ([.registry_repositories[].image_count] | add // 0) and
+    .registry_image_analysis.unique_generation_count ==
+      (.registry_image_analysis.unique_image_count /
+       $registry_images_per_generation) and
     ([.registry_repositories[] | select(
       .public != false or (.immutable != true and .immutable != null)
     )] | length) == 0 and

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -494,8 +494,18 @@ grep -Fq 'untracked helper dependency' "$compare_image_inputs" ||
 inventory="$OCI_DIR/scripts/inventory.sh"
 grep -Fq '[$prefix + "_images"]' "$inventory" ||
   fail "OCI inventory must allow only the shared image repository"
-grep -Fq 'select(.image_count != 9)' "$inventory" ||
-  fail "OCI inventory must require all nine exact application images"
+grep -Fq 'REGISTRY_IMAGES_PER_GENERATION=9' "$inventory" ||
+  fail "OCI inventory must require complete nine-image generations"
+grep -Fq 'REGISTRY_MAX_GENERATIONS=3' "$inventory" ||
+  fail "OCI inventory must retain at most two rollback generations"
+grep -Fq '(.image_count % $registry_images_per_generation) != 0' "$inventory" ||
+  fail "OCI inventory must reject partial image generations"
+grep -Fq 'oci artifacts container image list' "$inventory" ||
+  fail "OCI inventory must inspect exact image tags and digests"
+grep -Fq 'incomplete_tag_generation_count' "$inventory" ||
+  fail "OCI inventory must reject incomplete service tag generations"
+grep -Fq 'digest_service_conflict_count' "$inventory" ||
+  fail "OCI inventory must reject cross-service digest identities"
 grep -Fq 'docker run -d --platform linux/arm64 --name "$container"' "$verify_images" ||
   fail "OCI application boot verification must run the ARM64 images"
 if grep -Eq -- '--platform linux/arm64 --name "\$(mongo|rabbit)"' "$verify_images"; then

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -91,6 +91,7 @@ case "$*" in
   "network public-ip list "*) response=public-ips.json ;;
   "bastion bastion list "*) response=bastions.json ;;
   "artifacts container repository list "*) response=repositories.json ;;
+  "artifacts container image list "*) response=images.json ;;
   "os bucket list "*) response=buckets.json ;;
   "bastion session delete "*)
     if [[ -n "${MOCK_OCI_FAIL_SESSION_ID:-}" &&
@@ -195,16 +196,58 @@ cat > "$WORK_DIR/responses/bastions.json" <<'JSON'
   }
 }]}
 JSON
-cat > "$WORK_DIR/responses/repositories.json" <<'JSON'
-{"data":{"items":[{
-  "display-name":"betstan_images",
-  "image-count":9,
-  "layer-count":18,
-  "layers-size-in-bytes":171415038,
-  "is-public":false,
-  "is-immutable":true
-}]}}
-JSON
+set_registry_fixture() {
+  local unique_generations="$1"
+  local tag_generations="${2:-$1}"
+  jq -n \
+    --argjson unique_generations "$unique_generations" \
+    --argjson tag_generations "$tag_generations" '
+      def services: [
+        "auth", "bet", "backoffice", "client", "event", "gamemaster",
+        "moderation", "resulting", "slip"
+      ];
+      def pad($value; $width):
+        ($value | tostring) as $text
+        | ("0" * ($width - ($text | length))) + $text;
+      {
+        data: {
+          items: [
+            range(0; $tag_generations) as $tag_generation
+            | range(0; 9) as $service_index
+            | ($tag_generation % $unique_generations) as $image_generation
+            | {
+                "repository-name": "betstan_images",
+                version: (
+                  "oci-\(services[$service_index])-" +
+                  pad($tag_generation + 1; 40)
+                ),
+                digest: (
+                  "sha256:" +
+                  pad(($image_generation * 9) + $service_index + 1; 64)
+                ),
+                "lifecycle-state": "AVAILABLE"
+              }
+          ]
+        }
+      }
+    ' > "$WORK_DIR/responses/images.json"
+  jq -n --argjson image_count "$((unique_generations * 9))" '
+    {
+      data: {
+        items: [{
+          "display-name": "betstan_images",
+          "image-count": $image_count,
+          "layer-count": ($image_count * 4),
+          "layers-size-in-bytes": (100000000 + ($image_count * 9000000)),
+          "is-public": false,
+          "is-immutable": true
+        }]
+      }
+    }
+  ' > "$WORK_DIR/responses/repositories.json"
+}
+set_registry_fixture 1
+
 cat > "$WORK_DIR/responses/buckets.json" <<'JSON'
 {"data":[]}
 JSON
@@ -239,6 +282,91 @@ jq -e '
   .expected_monthly_cost == 0
 ' "$WORK_DIR/k3s-inventory.json" >/dev/null ||
   fail "valid direct-k3s inventory was rejected"
+
+set_registry_fixture 2 4
+env "${inventory_env[@]}" \
+  INVENTORY_MODE=complete \
+  OUTPUT_FILE="$WORK_DIR/two-generation-inventory.json" \
+  "$OCI_DIR/scripts/inventory.sh"
+jq -e '
+  .registry_images_per_generation == 9 and
+  .registry_max_generations == 3 and
+  .registry_repositories[0].image_count == 18 and
+  .registry_image_analysis.tag_generation_count == 4 and
+  .registry_image_analysis.unique_generation_count == 2
+' "$WORK_DIR/two-generation-inventory.json" >/dev/null ||
+  fail "complete candidate and rollback image generations were rejected"
+
+set_registry_fixture 3 6
+env "${inventory_env[@]}" \
+  INVENTORY_MODE=complete \
+  OUTPUT_FILE="$WORK_DIR/three-generation-inventory.json" \
+  "$OCI_DIR/scripts/inventory.sh"
+jq -e '
+  .registry_repositories[0].image_count == 27 and
+  .registry_image_analysis.tag_generation_count == 6 and
+  .registry_image_analysis.unique_generation_count == 3 and
+  .registry_image_analysis.incomplete_tag_generation_count == 0
+' "$WORK_DIR/three-generation-inventory.json" >/dev/null ||
+  fail "three bounded complete registry generations were rejected"
+
+jq '.data.items[0].version = "invalid-tag"' \
+  "$WORK_DIR/responses/images.json" \
+  > "$WORK_DIR/responses/images.json.tmp"
+mv "$WORK_DIR/responses/images.json.tmp" "$WORK_DIR/responses/images.json"
+if env "${inventory_env[@]}" \
+    INVENTORY_MODE=complete \
+    OUTPUT_FILE="$WORK_DIR/malformed-tag-inventory.json" \
+    "$OCI_DIR/scripts/inventory.sh" >/dev/null 2>&1; then
+  fail "malformed registry image tag was accepted"
+fi
+
+set_registry_fixture 3 6
+jq '
+  .data.items[8].version = .data.items[0].version
+' "$WORK_DIR/responses/images.json" \
+  > "$WORK_DIR/responses/images.json.tmp"
+mv "$WORK_DIR/responses/images.json.tmp" "$WORK_DIR/responses/images.json"
+if env "${inventory_env[@]}" \
+    INVENTORY_MODE=complete \
+    OUTPUT_FILE="$WORK_DIR/mixed-generation-inventory.json" \
+    "$OCI_DIR/scripts/inventory.sh" >/dev/null 2>&1; then
+  fail "incomplete registry service generation was accepted"
+fi
+
+set_registry_fixture 3 6
+jq '.data.items[1].digest = .data.items[0].digest' \
+  "$WORK_DIR/responses/images.json" \
+  > "$WORK_DIR/responses/images.json.tmp"
+mv "$WORK_DIR/responses/images.json.tmp" "$WORK_DIR/responses/images.json"
+if env "${inventory_env[@]}" \
+    INVENTORY_MODE=complete \
+    OUTPUT_FILE="$WORK_DIR/cross-service-digest-inventory.json" \
+    "$OCI_DIR/scripts/inventory.sh" >/dev/null 2>&1; then
+  fail "registry digest shared across service identities was accepted"
+fi
+
+set_registry_fixture 1
+jq '.data.items[0]["image-count"] = 10' \
+  "$WORK_DIR/responses/repositories.json" \
+  > "$WORK_DIR/responses/repositories.json.tmp"
+mv "$WORK_DIR/responses/repositories.json.tmp" \
+  "$WORK_DIR/responses/repositories.json"
+if env "${inventory_env[@]}" \
+    INVENTORY_MODE=complete \
+    OUTPUT_FILE="$WORK_DIR/partial-generation-inventory.json" \
+    "$OCI_DIR/scripts/inventory.sh" >/dev/null 2>&1; then
+  fail "partial registry image generation was accepted"
+fi
+
+set_registry_fixture 4 8
+if env "${inventory_env[@]}" \
+    INVENTORY_MODE=complete \
+    OUTPUT_FILE="$WORK_DIR/fourth-generation-inventory.json" \
+    "$OCI_DIR/scripts/inventory.sh" >/dev/null 2>&1; then
+  fail "fourth registry image generation was accepted"
+fi
+set_registry_fixture 3 6
 
 cat > "$WORK_DIR/responses/public-ips.json" <<'JSON'
 {"data":[{


### PR DESCRIPTION
## Summary
- validate every OCIR exact-SHA service tag and digest instead of trusting aggregate image count
- allow at most three complete nine-image generations under the unchanged 500 MB zero-cost cap
- preserve the candidate and deployed rollback generations while rejecting partial, malformed, cross-service, or fourth generations

## Evidence
- full OCI contract suite passes, including 95 terminal retirement scenarios
- sanitized live inventory passes at 367021385 bytes, 27 unique images, 243 valid tags, and three coherent generations
- candidate and latest deployed rollback each retain nine available service digests
- independent deployment-safety verdict: READY_FOR_GUARDED_PR

## Rollout
This PR targets `dev` and synchronizes current `master` ancestry. Promotion to `master` will reuse immutable OCI digests from first-attempt build run `32536098726` only after exact input comparison, then clear the temporary protected reuse variables.