### PR TITLE
chore: sync inventory fix master ancestry

### DIFF
--- a/infra/oci/scripts/inventory.sh
+++ b/infra/oci/scripts/inventory.sh
@@ -66,6 +66,21 @@ public_ips="$(oci_normalize_list_json "$public_ips")"
 bastions="$(oci_normalize_list_json "$bastions")"
 repositories="$(oci_normalize_list_json "$repositories" items)"
 images="$(oci_normalize_list_json "$images" items)"
+images="$(
+  jq -c '{
+    data: {
+      items: [
+        .data.items[]?
+        | {
+            "repository-name": ."repository-name",
+            version,
+            digest,
+            "lifecycle-state": ."lifecycle-state"
+          }
+      ]
+    }
+  }' <<<"$images"
+)"
 buckets="$(oci_normalize_list_json "$buckets")"
 expected_repositories="$(
   jq -cn --arg prefix "$OCI_IMAGE_PREFIX" '[$prefix + "_images"]'

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -502,6 +502,8 @@ grep -Fq '(.image_count % $registry_images_per_generation) != 0' "$inventory" ||
   fail "OCI inventory must reject partial image generations"
 grep -Fq 'oci artifacts container image list' "$inventory" ||
   fail "OCI inventory must inspect exact image tags and digests"
+grep -Fq '"repository-name": ."repository-name"' "$inventory" ||
+  fail "OCI inventory must bound registry metadata before jq argument use"
 grep -Fq 'incomplete_tag_generation_count' "$inventory" ||
   fail "OCI inventory must reject incomplete service tag generations"
 grep -Fq 'digest_service_conflict_count' "$inventory" ||

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -225,7 +225,10 @@ set_registry_fixture() {
                   "sha256:" +
                   pad(($image_generation * 9) + $service_index + 1; 64)
                 ),
-                "lifecycle-state": "AVAILABLE"
+                "lifecycle-state": "AVAILABLE",
+                "defined-tags": {
+                  padding: ("x" * 60000)
+                }
               }
           ]
         }
@@ -284,6 +287,8 @@ jq -e '
   fail "valid direct-k3s inventory was rejected"
 
 set_registry_fixture 2 4
+[[ "$(wc -c < "$WORK_DIR/responses/images.json" | tr -d ' ')" -gt 2000000 ]] ||
+  fail "registry fixture does not exceed the runner argument limit"
 env "${inventory_env[@]}" \
   INVENTORY_MODE=complete \
   OUTPUT_FILE="$WORK_DIR/two-generation-inventory.json" \


### PR DESCRIPTION
Synchronize squash promotion `ccb8a7c8420327656c156f12a050fe50c9bbe703` back into `dev` after PR #239. The tree is unchanged.