### PR TITLE
fix(oci): silence RabbitMQ queue probes

### DIFF
--- a/infra/azure/agents/live-betting-readiness-lib.sh
+++ b/infra/azure/agents/live-betting-readiness-lib.sh
@@ -2058,7 +2058,7 @@ PY
 
   if [[ -n "$rabbit_pod" ]]; then
     rabbit_stderr="$LIVE_BETTING_WORK_DIR/rabbitmq.stderr"
-    if kubectl --request-timeout="$LIVE_BETTING_KUBECTL_TIMEOUT" exec -n "$LIVE_BETTING_NAMESPACE" "$rabbit_pod" -- rabbitmqctl list_queues name messages_ready messages_unacknowledged consumers >"$LIVE_BETTING_WORK_DIR/rabbitmq.queues" 2>"$rabbit_stderr"; then
+    if kubectl --request-timeout="$LIVE_BETTING_KUBECTL_TIMEOUT" exec -n "$LIVE_BETTING_NAMESPACE" "$rabbit_pod" -- rabbitmqctl list_queues --quiet name messages_ready messages_unacknowledged consumers >"$LIVE_BETTING_WORK_DIR/rabbitmq.queues" 2>"$rabbit_stderr"; then
       live_betting_write_sanitized_file "$rabbit_stderr" "$LIVE_BETTING_OUTPUT_DIR/rabbitmq.stderr"
       live_betting_write_sanitized_file "$LIVE_BETTING_WORK_DIR/rabbitmq.queues" "$LIVE_BETTING_OUTPUT_DIR/rabbitmq.queues"
       live_betting_check_rabbitmq "$LIVE_BETTING_WORK_DIR/rabbitmq.queues" || true

--- a/infra/azure/agents/live-betting-readiness-test-lib.sh
+++ b/infra/azure/agents/live-betting-readiness-test-lib.sh
@@ -283,7 +283,7 @@ if [[ "$args" == *"get configmap gaming-mongo-migration-lock"* ]]; then
     }'
   exit 0
 fi
-if [[ "$args" == *"rabbitmqctl list_queues name messages_ready messages_unacknowledged consumers"* ]]; then
+if [[ "$args" == *"rabbitmqctl list_queues --quiet name messages_ready messages_unacknowledged consumers"* ]]; then
   [[ "$fail_command" != "rabbit" ]] || exit 1
   ready="${STUB_QUEUE_READY:-0}"
   unack="${STUB_QUEUE_UNACK:-0}"

--- a/infra/azure/agents/test-production-rollback-stan.sh
+++ b/infra/azure/agents/test-production-rollback-stan.sh
@@ -889,7 +889,8 @@ case "${1:-}" in
     ;;
   exec)
     shift
-    if [[ "$*" == *"rabbitmqctl list_queues name messages_ready messages_unacknowledged consumers"* ]]; then
+    if [[ "$*" == *"rabbitmqctl list_queues"* &&
+        "$*" == *"name messages_ready messages_unacknowledged consumers"* ]]; then
       live_ready="${STUB_LIVE_QUEUE_READY:-0}"
       live_unack="${STUB_LIVE_QUEUE_UNACK:-0}"
       baseline_ready="${STUB_BASELINE_QUEUE_READY:-0}"

--- a/infra/oci/scripts/baseline-capture-stan.sh
+++ b/infra/oci/scripts/baseline-capture-stan.sh
@@ -495,7 +495,7 @@ rabbit_pod="$(kubectl get pod -n "$OCI_K8S_NAMESPACE" -l "$RABBIT_SELECTOR" -o j
 [[ -n "$rabbit_pod" ]] || oci_die "RabbitMQ pod not found for selector ${RABBIT_SELECTOR}"
 queue_raw="$WORK_DIR/queues.raw"
 kubectl exec -n "$OCI_K8S_NAMESPACE" "$rabbit_pod" -- \
-  rabbitmqctl list_queues name messages_ready messages_unacknowledged consumers >"$queue_raw"
+  rabbitmqctl list_queues --quiet name messages_ready messages_unacknowledged consumers >"$queue_raw"
 oci_rabbitmq_queue_rows <"$queue_raw" >"$OUTPUT_DIR/queues.tsv" ||
   oci_die "unable to normalize RabbitMQ queue state"
 [[ -s "$OUTPUT_DIR/queues.tsv" ]] || oci_die "queue snapshot is empty"

--- a/infra/oci/scripts/rollback-application-stan.sh
+++ b/infra/oci/scripts/rollback-application-stan.sh
@@ -533,7 +533,7 @@ verify_queue_state() {
     return 1
   }
   kubectl exec -n "$OCI_K8S_NAMESPACE" "$rabbit_pod" -- \
-    rabbitmqctl list_queues name messages_ready messages_unacknowledged consumers >"$WORK_DIR/current-queues.raw"
+    rabbitmqctl list_queues --quiet name messages_ready messages_unacknowledged consumers >"$WORK_DIR/current-queues.raw"
   oci_rabbitmq_queue_rows <"$WORK_DIR/current-queues.raw" >"$current_queue_file" || {
     printf 'ERROR: unable to normalize RabbitMQ queue state\n' >&2
     return 1

--- a/infra/oci/scripts/rollback-readiness-stan.sh
+++ b/infra/oci/scripts/rollback-readiness-stan.sh
@@ -300,7 +300,7 @@ if [[ -z "$rabbit_pod" ]]; then
 else
   queue_raw="$WORK_DIR/queues.raw"
   kubectl exec -n "$OCI_K8S_NAMESPACE" "$rabbit_pod" -- \
-    rabbitmqctl list_queues name messages_ready messages_unacknowledged consumers >"$queue_raw" ||
+    rabbitmqctl list_queues --quiet name messages_ready messages_unacknowledged consumers >"$queue_raw" ||
     failures_file_append 'rabbitmq: unable to read queue state'
   if [[ -s "$queue_raw" ]]; then
     if oci_rabbitmq_queue_rows <"$queue_raw" >"$OUTPUT_DIR/queue-state.tsv"; then

--- a/infra/oci/tests/rollback-contract.sh
+++ b/infra/oci/tests/rollback-contract.sh
@@ -759,7 +759,7 @@ case "${1:-}" in
     ;;
   exec)
     shift
-    if [[ "$*" == *"rabbitmqctl list_queues name messages_ready messages_unacknowledged consumers"* ]]; then
+    if [[ "$*" == *"rabbitmqctl list_queues --quiet name messages_ready messages_unacknowledged consumers"* ]]; then
       live_ready="${STUB_LIVE_QUEUE_READY:-0}"
       live_unack="${STUB_LIVE_QUEUE_UNACK:-0}"
       baseline_ready="${STUB_BASELINE_QUEUE_READY:-0}"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -136,6 +136,15 @@ fi
 if oci_rabbitmq_queue_rows <<<$'name messages_ready messages_unacknowledged consumers\nname messages_ready messages_unacknowledged consumers' >/dev/null; then
   fail "duplicate RabbitMQ queue headers were accepted"
 fi
+for queue_probe in \
+  "$OCI_DIR/scripts/baseline-capture-stan.sh" \
+  "$OCI_DIR/scripts/rollback-readiness-stan.sh" \
+  "$OCI_DIR/scripts/rollback-application-stan.sh" \
+  "$ROOT_DIR/infra/azure/agents/live-betting-readiness-lib.sh"; do
+  grep -Fq 'rabbitmqctl list_queues --quiet name messages_ready messages_unacknowledged consumers' \
+    "$queue_probe" ||
+    fail "RabbitMQ queue probe does not suppress non-tabular CLI output: $queue_probe"
+done
 redacted="$(
   printf '%s\n' \
     'Authorization: Bearer header-secret' \


### PR DESCRIPTION
## Summary
- request machine-only RabbitMQ queue output during OCI baseline, readiness, and rollback probes
- keep the strict queue-state normalizer fail-closed
- lock quiet-mode invocation into shared stubs and OCI contracts

## Evidence
- reproduced the failure with the exact production RabbitMQ image: default output includes timeout/listing preambles, while `--quiet` emits only queue rows
- OCI contract and rollback suites pass
- Azure and OCI live-readiness suites pass
- failed dry-run #32567044972 stopped before write fencing, writer scaling, migration Jobs, or schema mutation

No cloud mutation, data migration, or application deployment occurred.