### PR TITLE
fix(rollout): match bet stats array contract

### DIFF
--- a/infra/azure/agents/baseline-capture-stan.sh
+++ b/infra/azure/agents/baseline-capture-stan.sh
@@ -22,7 +22,7 @@ API_CONTRACTS=(
   "/api/event|prematch"
   "/api/slip|object"
   "/api/bet|object"
-  "/api/bet/stats|object"
+  "/api/bet/stats|array"
   "/api/backoffice|array"
 )
 SSE_PATH="${SSE_PATH:-/api/event/stream}"

--- a/infra/azure/agents/rollback-application-stan.sh
+++ b/infra/azure/agents/rollback-application-stan.sh
@@ -31,7 +31,7 @@ API_CONTRACTS=(
   "/api/event|prematch"
   "/api/slip|object"
   "/api/bet|object"
-  "/api/bet/stats|object"
+  "/api/bet/stats|array"
   "/api/backoffice|array"
 )
 

--- a/infra/azure/agents/test-production-rollback-stan.sh
+++ b/infra/azure/agents/test-production-rollback-stan.sh
@@ -1073,7 +1073,7 @@ case "$url" in
     ;;
   */api/bet/stats)
     content_type='application/json'
-    body='{}'
+    body='[]'
     ;;
   */api/backoffice)
     content_type='application/json'

--- a/infra/oci/scripts/baseline-capture-stan.sh
+++ b/infra/oci/scripts/baseline-capture-stan.sh
@@ -28,7 +28,7 @@ API_CONTRACTS=(
   "/api/event|prematch"
   "/api/slip|object"
   "/api/bet|object"
-  "/api/bet/stats|object"
+  "/api/bet/stats|array"
   "/api/backoffice|array"
 )
 SSE_PATH="${SSE_PATH:-/api/event/stream}"

--- a/infra/oci/scripts/rollback-application-stan.sh
+++ b/infra/oci/scripts/rollback-application-stan.sh
@@ -36,7 +36,7 @@ API_CONTRACTS=(
   "/api/event|prematch"
   "/api/slip|object"
   "/api/bet|object"
-  "/api/bet/stats|object"
+  "/api/bet/stats|array"
   "/api/backoffice|array"
 )
 

--- a/infra/oci/scripts/rollback-readiness-stan.sh
+++ b/infra/oci/scripts/rollback-readiness-stan.sh
@@ -32,7 +32,7 @@ API_CONTRACTS=(
   "/api/event|prematch"
   "/api/slip|object"
   "/api/bet|object"
-  "/api/bet/stats|object"
+  "/api/bet/stats|array"
   "/api/backoffice|array"
 )
 

--- a/infra/oci/tests/rollback-contract.sh
+++ b/infra/oci/tests/rollback-contract.sh
@@ -1043,7 +1043,7 @@ elif [[ "$url" == *'/api/event' ]]; then
 elif [[ "$url" == *'/api/slip' ]]; then
   body='{}'
 elif [[ "$url" == *'/api/bet/stats' ]]; then
-  body='{}'
+  body='[]'
 elif [[ "$url" == *'/api/bet' ]]; then
   body='{}'
 elif [[ "$url" == *'/api/backoffice' ]]; then

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -145,6 +145,15 @@ for queue_probe in \
     "$queue_probe" ||
     fail "RabbitMQ queue probe does not suppress non-tabular CLI output: $queue_probe"
 done
+for api_contract_probe in \
+  "$OCI_DIR/scripts/baseline-capture-stan.sh" \
+  "$OCI_DIR/scripts/rollback-readiness-stan.sh" \
+  "$OCI_DIR/scripts/rollback-application-stan.sh" \
+  "$ROOT_DIR/infra/azure/agents/baseline-capture-stan.sh" \
+  "$ROOT_DIR/infra/azure/agents/rollback-application-stan.sh"; do
+  grep -Fq '"/api/bet/stats|array"' "$api_contract_probe" ||
+    fail "bet stats rollback contract is not array-shaped: $api_contract_probe"
+done
 redacted="$(
   printf '%s\n' \
     'Authorization: Bearer header-secret' \


### PR DESCRIPTION
## Summary
- correct pre-mutation baseline and rollback contracts for the array-shaped `/api/bet/stats` response
- keep object validation for `/api/bet` and `/api/slip` unchanged
- align OCI and Azure fixtures and enforce the route shape in the OCI contract suite

## Evidence
- deployed legacy API and current route tests both establish an array response
- full OCI contract suite passes, including 95 retirement audit scenarios
- OCI rollback and Azure production rollback suites pass
- dry-run #32572079768 released its lock and stopped before fencing, scaling, migration Jobs, or schema mutation

No cloud or application-data mutation occurred.