### PR TITLE
Promote guarded OCI registry pruning

### DIFF
--- a/.github/workflows/oci-infrastructure.yml
+++ b/.github/workflows/oci-infrastructure.yml
@@ -9,17 +9,53 @@ on:
         required: true
         type: string
       confirmation:
-        description: Type PROVISION OCI ZERO COST
+        description: Type the exact confirmation required by the selected phase
         required: true
         type: string
       phase:
-        description: Prepare free networking or finalize an acquired k3s instance
+        description: Prepare/finalize zero-cost infrastructure or prune one obsolete image generation
         required: true
         default: prepare
         type: choice
         options:
           - prepare
           - finalize
+          - prune-registry
+      candidate_build_run_id:
+        description: Current-master OCI build run protected during registry pruning
+        required: false
+        default: ""
+        type: string
+      obsolete_sha:
+        description: Obsolete source SHA whose complete image generation may be pruned
+        required: false
+        default: ""
+        type: string
+      obsolete_build_run_id:
+        description: First-attempt OCI build provenance for the obsolete generation
+        required: false
+        default: ""
+        type: string
+      deployed_sha:
+        description: Currently deployed source SHA protected during registry pruning
+        required: false
+        default: ""
+        type: string
+      deployed_run_id:
+        description: Successful OCI deployment provenance for the deployed SHA
+        required: false
+        default: ""
+        type: string
+      fallback_sha:
+        description: Compatible fallback source SHA protected during registry pruning
+        required: false
+        default: ""
+        type: string
+      fallback_build_run_id:
+        description: First-attempt OCI build provenance for the fallback SHA
+        required: false
+        default: ""
+        type: string
 
 permissions:
   actions: read
@@ -30,8 +66,285 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  prune-registry:
+    if: github.run_attempt == 1 && inputs.phase == 'prune-registry'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: oci-infrastructure
+    env:
+      SOURCE_SHA: ${{ inputs.approved_sha }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      CANDIDATE_BUILD_RUN_ID: ${{ inputs.candidate_build_run_id }}
+      OBSOLETE_SHA: ${{ inputs.obsolete_sha }}
+      OBSOLETE_BUILD_RUN_ID: ${{ inputs.obsolete_build_run_id }}
+      DEPLOYED_SHA: ${{ inputs.deployed_sha }}
+      DEPLOYED_RUN_ID: ${{ inputs.deployed_run_id }}
+      FALLBACK_SHA: ${{ inputs.fallback_sha }}
+      FALLBACK_BUILD_RUN_ID: ${{ inputs.fallback_build_run_id }}
+      OCI_CLI_VERSION: "3.90.0"
+      OCI_REGION: ${{ vars.OCI_REGION }}
+      OCI_TENANCY_OCID: ${{ vars.OCI_TENANCY_OCID }}
+      OCI_COMPARTMENT_OCID: ${{ vars.OCI_COMPARTMENT_OCID }}
+      OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST }}
+      OCI_REGISTRY_NAMESPACE: ${{ vars.OCI_REGISTRY_NAMESPACE }}
+      OCI_IMAGE_PREFIX: ${{ vars.OCI_IMAGE_PREFIX }}
+      OCI_REGISTRY_MAX_BYTES: ${{ vars.OCI_REGISTRY_MAX_BYTES || '500000000' }}
+      PROVENANCE_DIR: artifacts/oci-registry-prune
+
+    steps:
+      - name: Initialize isolated OCI paths
+        run: |
+          {
+            echo "HOME=$RUNNER_TEMP/oci-registry-prune-home"
+            echo "WORK_DIR=$RUNNER_TEMP/oci-registry-prune-work"
+          } >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/oci-registry-prune-home/.local/bin" >> "$GITHUB_PATH"
+          mkdir -p \
+            "$RUNNER_TEMP/oci-registry-prune-home" \
+            "$RUNNER_TEMP/oci-registry-prune-work" \
+            "$PROVENANCE_DIR"
+          chmod 700 \
+            "$RUNNER_TEMP/oci-registry-prune-home" \
+            "$RUNNER_TEMP/oci-registry-prune-work"
+          printf '%s\n' \
+            "source_sha=$SOURCE_SHA" \
+            "candidate_build_run_id=$CANDIDATE_BUILD_RUN_ID" \
+            "obsolete_sha=$OBSOLETE_SHA" \
+            "obsolete_build_run_id=$OBSOLETE_BUILD_RUN_ID" \
+            "deployed_sha=$DEPLOYED_SHA" \
+            "deployed_run_id=$DEPLOYED_RUN_ID" \
+            "fallback_sha=$FALLBACK_SHA" \
+            "fallback_build_run_id=$FALLBACK_BUILD_RUN_ID" \
+            "workflow_run_id=$GITHUB_RUN_ID" \
+            "workflow_run_attempt=$GITHUB_RUN_ATTEMPT" \
+            > "$PROVENANCE_DIR/dispatch.env"
+
+      - name: Checkout exact current master
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.approved_sha }}
+          fetch-depth: 0
+
+      - name: Validate exact registry prune request
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [ "$CONFIRMATION" = "PRUNE OBSOLETE OCI IMAGE GENERATION" ]
+          for sha in \
+            "$SOURCE_SHA" "$OBSOLETE_SHA" "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
+            [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
+            git cat-file -e "${sha}^{commit}"
+          done
+          for run_id in \
+            "$CANDIDATE_BUILD_RUN_ID" "$OBSOLETE_BUILD_RUN_ID" \
+            "$DEPLOYED_RUN_ID" "$FALLBACK_BUILD_RUN_ID"; do
+            [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+          done
+          [ "$GITHUB_RUN_ATTEMPT" = "1" ]
+          [ "$SOURCE_SHA" = "$GITHUB_SHA" ]
+          [ "$SOURCE_SHA" = "$(git rev-parse HEAD)" ]
+          git fetch --quiet origin master:refs/remotes/origin/master
+          [ "$SOURCE_SHA" = "$(git rev-parse origin/master)" ]
+          [ "$OBSOLETE_SHA" != "$SOURCE_SHA" ]
+          [ "$OBSOLETE_SHA" != "$DEPLOYED_SHA" ]
+          [ "$OBSOLETE_SHA" != "$FALLBACK_SHA" ]
+          [ "$DEPLOYED_SHA" != "$FALLBACK_SHA" ]
+          for ancestor in "$OBSOLETE_SHA" "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
+            git merge-base --is-ancestor "$ancestor" "$SOURCE_SHA"
+          done
+
+      - name: Download and validate protected image provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          validate_run() {
+            local workflow_file="$1"
+            local run_id="$2"
+            local event="$3"
+            local expected_sha="$4"
+            local workflow_id
+            local run_json
+            workflow_id="$(
+              gh api "repos/$REPOSITORY/actions/workflows/$workflow_file" \
+                --jq '.id'
+            )"
+            run_json="$(
+              gh api "repos/$REPOSITORY/actions/runs/$run_id/attempts/1"
+            )"
+            jq -e \
+              --argjson workflow_id "$workflow_id" \
+              --arg workflow_path ".github/workflows/$workflow_file" \
+              --arg event "$event" \
+              --arg sha "$expected_sha" \
+              --arg repository "$REPOSITORY" '
+                .workflow_id == $workflow_id and
+                .path == $workflow_path and
+                .event == $event and
+                .head_sha == $sha and
+                .head_branch == "master" and
+                .head_repository.full_name == $repository and
+                .status == "completed" and
+                .conclusion == "success" and
+                .run_attempt == 1
+              ' <<<"$run_json" >/dev/null
+          }
+          download_artifact() {
+            local run_id="$1"
+            local artifact_name="$2"
+            local destination="$3"
+            local artifact_count
+            artifact_count="$(
+              gh api \
+                "repos/$REPOSITORY/actions/runs/$run_id/artifacts?per_page=100" \
+                --jq "[.artifacts[] | select(
+                  .name == \"$artifact_name\" and .expired == false
+                )] | length"
+            )"
+            [ "$artifact_count" = "1" ]
+            mkdir -p "$destination"
+            gh run download "$run_id" \
+              --name "$artifact_name" \
+              --dir "$destination"
+          }
+
+          validate_run \
+            oci-production-build.yml \
+            "$CANDIDATE_BUILD_RUN_ID" workflow_run "$SOURCE_SHA"
+          validate_run \
+            oci-production-build.yml \
+            "$OBSOLETE_BUILD_RUN_ID" workflow_run "$OBSOLETE_SHA"
+          validate_run \
+            oci-production-deploy.yml \
+            "$DEPLOYED_RUN_ID" workflow_dispatch "$DEPLOYED_SHA"
+          validate_run \
+            oci-production-build.yml \
+            "$FALLBACK_BUILD_RUN_ID" workflow_run "$FALLBACK_SHA"
+
+          download_artifact \
+            "$CANDIDATE_BUILD_RUN_ID" \
+            "oci-image-provenance-${SOURCE_SHA}-${CANDIDATE_BUILD_RUN_ID}-1" \
+            "$WORK_DIR/candidate"
+          download_artifact \
+            "$OBSOLETE_BUILD_RUN_ID" \
+            "oci-image-provenance-${OBSOLETE_SHA}-${OBSOLETE_BUILD_RUN_ID}-1" \
+            "$WORK_DIR/obsolete"
+          download_artifact \
+            "$DEPLOYED_RUN_ID" \
+            "oci-deploy-provenance-${DEPLOYED_RUN_ID}-1" \
+            "$WORK_DIR/deployed"
+          download_artifact \
+            "$FALLBACK_BUILD_RUN_ID" \
+            "oci-image-provenance-${FALLBACK_SHA}-${FALLBACK_BUILD_RUN_ID}-1" \
+            "$WORK_DIR/fallback"
+
+          for pair in \
+            "candidate:$SOURCE_SHA:$CANDIDATE_BUILD_RUN_ID" \
+            "obsolete:$OBSOLETE_SHA:$OBSOLETE_BUILD_RUN_ID" \
+            "fallback:$FALLBACK_SHA:$FALLBACK_BUILD_RUN_ID"; do
+            IFS=: read -r directory expected_sha expected_run_id <<<"$pair"
+            grep -Fxq "source_sha=$expected_sha" \
+              "$WORK_DIR/$directory/build-chain.txt"
+            grep -Fxq "build_run_id=$expected_run_id" \
+              "$WORK_DIR/$directory/build-chain.txt"
+            grep -Fxq "build_run_attempt=1" \
+              "$WORK_DIR/$directory/build-chain.txt"
+            test -s "$WORK_DIR/$directory/images.tsv"
+          done
+          for pair in "deployed:$DEPLOYED_SHA:$DEPLOYED_RUN_ID"; do
+            IFS=: read -r directory expected_sha expected_run_id <<<"$pair"
+            grep -Fxq "source_sha=$expected_sha" \
+              "$WORK_DIR/$directory/provenance.txt"
+            grep -Fxq "deployment_run_id=$expected_run_id" \
+              "$WORK_DIR/$directory/provenance.txt"
+            grep -Fxq "deployment_run_attempt=1" \
+              "$WORK_DIR/$directory/provenance.txt"
+            test -s "$WORK_DIR/$directory/images.tsv"
+          done
+
+          cp "$WORK_DIR/obsolete/images.tsv" "$PROVENANCE_DIR/obsolete.tsv"
+          cat \
+            "$WORK_DIR/candidate/images.tsv" \
+            "$WORK_DIR/deployed/images.tsv" \
+            "$WORK_DIR/fallback/images.tsv" \
+            > "$PROVENANCE_DIR/protected.tsv"
+
+      - name: Install pinned OCI CLI and verify identity
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_HOME_REGION_QUERY: 'data[?"is-home-region" == `true`]."region-name" | [0]'
+        run: |
+          set -euo pipefail
+          ./infra/oci/scripts/install-cli.sh
+          home_region="$(
+            oci iam region-subscription list \
+              --tenancy-id "$OCI_CLI_TENANCY" \
+              --query "$OCI_HOME_REGION_QUERY" \
+              --raw-output
+          )"
+          [ "$home_region" = "$OCI_CLI_REGION" ]
+
+      - name: Prune only the obsolete complete generation
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          TARGET_IMAGES_FILE: artifacts/oci-registry-prune/obsolete.tsv
+          PROTECTED_IMAGES_FILE: artifacts/oci-registry-prune/protected.tsv
+          TARGET_SOURCE_SHA: ${{ inputs.obsolete_sha }}
+          CURRENT_SOURCE_SHA: ${{ inputs.approved_sha }}
+          OUTPUT_DIR: artifacts/oci-registry-prune
+        run: ./infra/oci/scripts/prune-registry-generation.sh
+
+      - name: Record registry prune provenance
+        run: |
+          set -euo pipefail
+          test -s "$PROVENANCE_DIR/after-summary.json"
+          jq -e \
+            --arg obsolete_sha "$OBSOLETE_SHA" \
+            --arg source_sha "$SOURCE_SHA" '
+              .target_source_sha == $obsolete_sha and
+              .current_source_sha == $source_sha and
+              .terminal_status == "PRUNED" and
+              .unique_images == 27
+            ' "$PROVENANCE_DIR/after-summary.json" >/dev/null
+          printf '%s\n' \
+            "source_sha=$SOURCE_SHA" \
+            "candidate_build_run_id=$CANDIDATE_BUILD_RUN_ID" \
+            "obsolete_sha=$OBSOLETE_SHA" \
+            "obsolete_build_run_id=$OBSOLETE_BUILD_RUN_ID" \
+            "deployed_sha=$DEPLOYED_SHA" \
+            "deployed_run_id=$DEPLOYED_RUN_ID" \
+            "fallback_sha=$FALLBACK_SHA" \
+            "fallback_build_run_id=$FALLBACK_BUILD_RUN_ID" \
+            "workflow_run_id=$GITHUB_RUN_ID" \
+            "workflow_run_attempt=$GITHUB_RUN_ATTEMPT" \
+            "terminal_status=PRUNED" \
+            > "$PROVENANCE_DIR/provenance.env"
+
+      - name: Upload registry prune evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: oci-registry-prune-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/oci-registry-prune
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove isolated OCI client state
+        if: always()
+        run: rm -rf "$HOME" "$WORK_DIR"
+
   provision:
-    if: github.run_attempt == 1
+    if: github.run_attempt == 1 && inputs.phase != 'prune-registry'
     runs-on: ubuntu-latest
     timeout-minutes: 150
     environment:

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -155,6 +155,15 @@ concurrent retirement fixture isolation without masking failed suites.
 2. `scripts/build-images.sh` builds ARM64 OCI-only images; the production
    workflow records and verifies immutable digests with
    `scripts/verify-images.sh`.
+   If a fresh build creates a fourth complete generation, dispatch
+   `oci-infrastructure` with phase `prune-registry` before infrastructure
+   finalization. Bind the request to the exact current candidate build, the
+   currently deployed release, one compatible fallback build, and one
+   obsolete build. The protected job deletes only when those four
+   nine-service generations are pairwise disjoint and exhaust the registry;
+   it waits until the obsolete digests are absent, all 27 protected digests
+   remain, provider image accounting reaches 27, and retained layers are
+   within the configured Free Tier ceiling.
 3. Dispatch `oci-infrastructure` with phase `prepare`.
    `scripts/provision.sh cloud` creates/reconciles only the VCN, Internet
    Gateway, public/restricted subnets, NSGs, and OCI Bastion.

--- a/infra/oci/scripts/prune-registry-generation.sh
+++ b/infra/oci/scripts/prune-registry-generation.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+TARGET_IMAGES_FILE="${TARGET_IMAGES_FILE:-}"
+PROTECTED_IMAGES_FILE="${PROTECTED_IMAGES_FILE:-}"
+TARGET_SOURCE_SHA="${TARGET_SOURCE_SHA:-}"
+CURRENT_SOURCE_SHA="${CURRENT_SOURCE_SHA:-}"
+OUTPUT_DIR="${OUTPUT_DIR:-artifacts/oci-registry-prune}"
+PRUNE_POLL_ATTEMPTS="${PRUNE_POLL_ATTEMPTS:-60}"
+PRUNE_POLL_SECONDS="${PRUNE_POLL_SECONDS:-10}"
+EXPECTED_SERVICES='auth backoffice bet client event gamemaster moderation resulting slip'
+EXPECTED_TARGET_IMAGES=9
+EXPECTED_PROTECTED_IMAGES=27
+EXPECTED_IMAGES_BEFORE=36
+
+oci_require_cli_version
+oci_require_command jq
+oci_require_vars \
+  OCI_COMPARTMENT_OCID OCI_IMAGE_PREFIX OCI_REGISTRY_HOST \
+  OCI_REGISTRY_NAMESPACE OCI_REGISTRY_MAX_BYTES
+oci_require_ocid OCI_COMPARTMENT_OCID
+
+[[ "$TARGET_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+  oci_die "TARGET_SOURCE_SHA must be a full commit SHA"
+[[ "$CURRENT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+  oci_die "CURRENT_SOURCE_SHA must be a full commit SHA"
+[[ "$TARGET_SOURCE_SHA" != "$CURRENT_SOURCE_SHA" ]] ||
+  oci_die "current master cannot be pruned"
+[[ "$PRUNE_POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] ||
+  oci_die "PRUNE_POLL_ATTEMPTS must be a positive integer"
+[[ "$PRUNE_POLL_SECONDS" =~ ^[0-9]+$ ]] ||
+  oci_die "PRUNE_POLL_SECONDS must be a nonnegative integer"
+[[ "$OCI_REGISTRY_MAX_BYTES" =~ ^[1-9][0-9]*$ ]] ||
+  oci_die "OCI_REGISTRY_MAX_BYTES must be a positive integer"
+[[ -f "$TARGET_IMAGES_FILE" ]] ||
+  oci_die "TARGET_IMAGES_FILE does not exist"
+[[ -f "$PROTECTED_IMAGES_FILE" ]] ||
+  oci_die "PROTECTED_IMAGES_FILE does not exist"
+
+mkdir -p "$OUTPUT_DIR"
+work_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+repository="${OCI_IMAGE_PREFIX}_images"
+provenance_repository="$OCI_REGISTRY_HOST/$OCI_REGISTRY_NAMESPACE/$repository"
+
+normalize_provenance() {
+  local source_file="$1"
+  local destination_file="$2"
+  local expected_rows="$3"
+  local expected_per_service="$4"
+
+  awk -F '\t' \
+    -v repository="$provenance_repository" \
+    -v expected_rows="$expected_rows" \
+    -v expected_per_service="$expected_per_service" \
+    -v expected_services="$EXPECTED_SERVICES" '
+      BEGIN {
+        split(expected_services, services, " ")
+        for (service_index in services) {
+          allowed[services[service_index]] = 1
+        }
+      }
+      function valid_digest(value) {
+        return length(value) == 71 &&
+          substr(value, 1, 7) == "sha256:" &&
+          substr(value, 8) ~ /^[0-9a-f]+$/
+      }
+      NF != 5 {
+        print "invalid image provenance column count" > "/dev/stderr"
+        exit 1
+      }
+      !($1 in allowed) {
+        print "unexpected image provenance service: " $1 > "/dev/stderr"
+        exit 1
+      }
+      $2 != repository {
+        print "unexpected image provenance repository" > "/dev/stderr"
+        exit 1
+      }
+      $3 != $2 "@" $4 || $4 != $5 || !valid_digest($4) {
+        print "invalid image provenance digest identity" > "/dev/stderr"
+        exit 1
+      }
+      {
+        rows++
+        service_count[$1]++
+        digest_count[$4]++
+        print $1 "\t" $4
+      }
+      END {
+        if (rows != expected_rows) {
+          print "unexpected image provenance row count" > "/dev/stderr"
+          exit 1
+        }
+        for (service in allowed) {
+          if (service_count[service] != expected_per_service) {
+            print "incomplete image provenance service set" > "/dev/stderr"
+            exit 1
+          }
+        }
+        for (digest in digest_count) {
+          if (digest_count[digest] != 1) {
+            print "duplicate image provenance digest" > "/dev/stderr"
+            exit 1
+          }
+        }
+      }
+    ' "$source_file" | LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
+      > "$destination_file" ||
+    oci_die "image provenance validation failed"
+}
+
+normalize_provenance \
+  "$TARGET_IMAGES_FILE" "$work_dir/target.tsv" \
+  "$EXPECTED_TARGET_IMAGES" 1
+normalize_provenance \
+  "$PROTECTED_IMAGES_FILE" "$work_dir/protected.tsv" \
+  "$EXPECTED_PROTECTED_IMAGES" 3
+
+cut -f2 "$work_dir/target.tsv" | LC_ALL=C sort -u > "$work_dir/target-digests.txt"
+cut -f2 "$work_dir/protected.tsv" | LC_ALL=C sort -u > "$work_dir/protected-digests.txt"
+if comm -12 "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
+    grep -q .; then
+  oci_die "obsolete generation overlaps a protected generation"
+fi
+cat "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
+  LC_ALL=C sort -u > "$work_dir/expected-before-digests.txt"
+[[ "$(wc -l < "$work_dir/expected-before-digests.txt" | tr -d ' ')" == \
+  "$EXPECTED_IMAGES_BEFORE" ]] ||
+  oci_die "expected registry generations are not pairwise disjoint"
+
+list_images() {
+  local destination="$1"
+  local raw="$work_dir/images-raw.json"
+
+  oci artifacts container image list \
+    --compartment-id "$OCI_COMPARTMENT_OCID" \
+    --repository-name "$repository" \
+    --all \
+    --output json > "$raw"
+  jq -e '
+    if (.data | type) == "array" then
+      {data: {items: .data}}
+    elif
+      (.data | type) == "object" and
+      (.data.items | type) == "array"
+    then
+      .
+    else
+      error("unexpected OCI container image list shape")
+    end
+  ' "$raw" > "$destination" ||
+    oci_die "unable to normalize OCI container image inventory"
+}
+
+validate_registry_rows() {
+  local inventory_file="$1"
+  local required_state="$2"
+
+  jq -e \
+    --arg repository "$repository" \
+    --arg required_state "$required_state" '
+      def parsed_tag:
+        (.version // "")
+        | try capture(
+            "^oci-(?<service>auth|backoffice|bet|client|event|gamemaster|moderation|resulting|slip)-(?<source_sha>[0-9a-f]{40})$"
+          ) catch null;
+      [
+        .data.items[]?
+        | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+        | . + {parsed_tag: parsed_tag}
+      ] as $rows
+      | ($rows | length) > 0
+      and all(
+        $rows[];
+        ."repository-name" == $repository and
+        (.digest // "" | test("^sha256:[0-9a-f]{64}$")) and
+        (.id // "" | startswith("ocid1.containerimage.")) and
+        .parsed_tag != null and
+        (
+          $required_state == "" or
+          (."lifecycle-state" // "" | ascii_upcase) == $required_state
+        )
+      )
+      and ([
+        ($rows | group_by(.digest))[]
+        | select(([.[].parsed_tag.service] | unique | length) != 1)
+      ] | length) == 0
+    ' "$inventory_file" >/dev/null ||
+    oci_die "OCI registry rows violate the exact tag, digest, or lifecycle contract"
+}
+
+registry_digest_set() {
+  local inventory_file="$1"
+  local destination="$2"
+
+  jq -r '
+    .data.items[]?
+    | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+    | .digest
+  ' "$inventory_file" | LC_ALL=C sort -u > "$destination"
+}
+
+registry_accounting() {
+  local destination="$1"
+  local raw="$work_dir/repositories-raw.json"
+
+  oci artifacts container repository list \
+    --compartment-id "$OCI_COMPARTMENT_OCID" \
+    --all \
+    --output json > "$raw"
+  jq -e \
+    --arg repository "$repository" '
+      (
+        if (.data | type) == "array" then
+          .data
+        elif
+          (.data | type) == "object" and
+          (.data.items | type) == "array"
+        then
+          .data.items
+        else
+          error("unexpected OCI container repository list shape")
+        end
+      )
+      | [.[] | select(."display-name" == $repository)]
+      | if length == 1 then
+          {
+            image_count: .[0]."image-count",
+            layers_size_bytes: .[0]."layers-size-in-bytes"
+          }
+        else
+          error("expected exactly one OCI container repository")
+        end
+      | select(
+          (.image_count | type) == "number" and
+          (.layers_size_bytes | type) == "number"
+        )
+    ' "$raw" > "$destination" ||
+    oci_die "unable to read exact OCI registry accounting"
+}
+
+list_images "$work_dir/before.json"
+validate_registry_rows "$work_dir/before.json" AVAILABLE
+registry_digest_set "$work_dir/before.json" "$work_dir/before-digests.txt"
+deletion_required=true
+if cmp -s "$work_dir/expected-before-digests.txt" "$work_dir/before-digests.txt"; then
+  before_image_count="$EXPECTED_IMAGES_BEFORE"
+elif cmp -s "$work_dir/protected-digests.txt" "$work_dir/before-digests.txt"; then
+  deletion_required=false
+  before_image_count="$EXPECTED_PROTECTED_IMAGES"
+else
+  oci_die "registry contains an unknown, missing, or unexpected image generation"
+fi
+
+: > "$OUTPUT_DIR/deletion-plan.tsv"
+if [[ "$deletion_required" == "true" ]]; then
+  while IFS=$'\t' read -r service digest; do
+    version="oci-${service}-${TARGET_SOURCE_SHA}"
+    image_ids="$(
+      jq -r \
+        --arg digest "$digest" \
+        --arg version "$version" '
+          [
+            .data.items[]?
+            | select(
+                .digest == $digest and
+                .version == $version and
+                (."lifecycle-state" // "" | ascii_upcase) == "AVAILABLE"
+              )
+            | .id
+          ]
+          | unique[]
+        ' "$work_dir/before.json"
+    )"
+    [[ "$(awk 'NF {count++} END {print count+0}' <<<"$image_ids")" == "1" ]] ||
+      oci_die "target digest does not map to one exact source-tagged image"
+    image_id="$(awk 'NF {print; exit}' <<<"$image_ids")"
+    printf '%s\t%s\t%s\n' "$service" "$digest" "$image_id" \
+      >> "$OUTPUT_DIR/deletion-plan.tsv"
+  done < "$work_dir/target.tsv"
+
+  [[ "$(wc -l < "$OUTPUT_DIR/deletion-plan.tsv" | tr -d ' ')" == \
+    "$EXPECTED_TARGET_IMAGES" ]] ||
+    oci_die "registry deletion plan is incomplete"
+  [[ "$(cut -f3 "$OUTPUT_DIR/deletion-plan.tsv" | LC_ALL=C sort -u | wc -l |
+    tr -d ' ')" == "$EXPECTED_TARGET_IMAGES" ]] ||
+    oci_die "registry deletion plan reuses an image OCID"
+fi
+
+target_sha256="$(oci_sha256 < "$work_dir/target.tsv")"
+protected_sha256="$(oci_sha256 < "$work_dir/protected.tsv")"
+jq -n \
+  --arg target_source_sha "$TARGET_SOURCE_SHA" \
+  --arg current_source_sha "$CURRENT_SOURCE_SHA" \
+  --arg target_sha256 "$target_sha256" \
+  --arg protected_sha256 "$protected_sha256" \
+  --arg deletion_required "$deletion_required" \
+  --argjson unique_images "$before_image_count" \
+  '{
+    target_source_sha: $target_source_sha,
+    current_source_sha: $current_source_sha,
+    target_generation_sha256: $target_sha256,
+    protected_generations_sha256: $protected_sha256,
+    unique_images: $unique_images,
+    deletion_required: ($deletion_required == "true")
+  }' > "$OUTPUT_DIR/before-summary.json"
+
+if [[ "$deletion_required" == "true" ]]; then
+  while IFS=$'\t' read -r _service _digest image_id; do
+    oci artifacts container image delete \
+      --image-id "$image_id" \
+      --force >/dev/null
+  done < "$OUTPUT_DIR/deletion-plan.tsv"
+fi
+
+pruned=false
+for ((attempt = 1; attempt <= PRUNE_POLL_ATTEMPTS; attempt++)); do
+  list_images "$work_dir/after.json"
+  registry_digest_set "$work_dir/after.json" "$work_dir/after-digests.txt"
+
+  if ! comm -23 \
+    "$work_dir/protected-digests.txt" "$work_dir/after-digests.txt" |
+      grep -q .; then
+    if cmp -s \
+      "$work_dir/protected-digests.txt" "$work_dir/after-digests.txt"; then
+      registry_accounting "$work_dir/accounting.json"
+      if jq -e \
+        --argjson expected_images "$EXPECTED_PROTECTED_IMAGES" \
+        --argjson max_bytes "$OCI_REGISTRY_MAX_BYTES" '
+          .image_count == $expected_images and
+          .layers_size_bytes <= $max_bytes
+        ' "$work_dir/accounting.json" >/dev/null; then
+        pruned=true
+        break
+      fi
+    fi
+  else
+    oci_die "a protected registry digest disappeared during pruning"
+  fi
+
+  if ((attempt < PRUNE_POLL_ATTEMPTS)); then
+    sleep "$PRUNE_POLL_SECONDS"
+  fi
+done
+[[ "$pruned" == "true" ]] ||
+  oci_die "OCI registry pruning did not reach the exact protected digest set"
+
+validate_registry_rows "$work_dir/after.json" AVAILABLE
+if comm -12 "$work_dir/target-digests.txt" "$work_dir/after-digests.txt" |
+    grep -q .; then
+  oci_die "obsolete registry digests remain after pruning"
+fi
+
+cp "$work_dir/target.tsv" "$OUTPUT_DIR/deleted-images.tsv"
+jq -e . "$work_dir/accounting.json" > "$OUTPUT_DIR/registry-accounting.json"
+jq -n \
+  --arg target_source_sha "$TARGET_SOURCE_SHA" \
+  --arg current_source_sha "$CURRENT_SOURCE_SHA" \
+  --arg protected_sha256 "$protected_sha256" \
+  --argjson unique_images "$EXPECTED_PROTECTED_IMAGES" \
+  '{
+    target_source_sha: $target_source_sha,
+    current_source_sha: $current_source_sha,
+    protected_generations_sha256: $protected_sha256,
+    unique_images: $unique_images,
+    terminal_status: "PRUNED"
+  }' > "$OUTPUT_DIR/after-summary.json"
+
+echo "registry_generation_pruned=$TARGET_SOURCE_SHA"

--- a/infra/oci/tests/run-contracts.sh
+++ b/infra/oci/tests/run-contracts.sh
@@ -14,6 +14,7 @@ suites=(
   "$TESTS_DIR/test-capacity-contract.sh"
   "$TESTS_DIR/test-image-reuse-contract.sh"
   "$TESTS_DIR/test-k3s-runtime-contract.sh"
+  "$TESTS_DIR/test-registry-prune-contract.sh"
   "$TESTS_DIR/test-migration-recovery-contract.sh"
   "$TESTS_DIR/test-mongo-upgrade.sh"
   "$ROOT_DIR/infra/oci/agents/test-health-contract-stan.sh"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -510,6 +510,7 @@ grep -Fq 'oci_(die|log|require_command|require_vars|prepare_private_dir)' \
 grep -Fq 'untracked helper dependency' "$compare_image_inputs" ||
   fail "OCI image input comparison does not enforce a closed helper dependency set"
 inventory="$OCI_DIR/scripts/inventory.sh"
+registry_pruner="$OCI_DIR/scripts/prune-registry-generation.sh"
 grep -Fq '[$prefix + "_images"]' "$inventory" ||
   fail "OCI inventory must allow only the shared image repository"
 grep -Fq 'REGISTRY_IMAGES_PER_GENERATION=9' "$inventory" ||
@@ -526,6 +527,20 @@ grep -Fq 'incomplete_tag_generation_count' "$inventory" ||
   fail "OCI inventory must reject incomplete service tag generations"
 grep -Fq 'digest_service_conflict_count' "$inventory" ||
   fail "OCI inventory must reject cross-service digest identities"
+grep -Fq 'EXPECTED_IMAGES_BEFORE=36' "$registry_pruner" ||
+  fail "registry pruning must require exactly four complete generations"
+grep -Fq 'EXPECTED_PROTECTED_IMAGES=27' "$registry_pruner" ||
+  fail "registry pruning must retain exactly three complete generations"
+grep -Fq 'obsolete generation overlaps a protected generation' "$registry_pruner" ||
+  fail "registry pruning does not reject protected digest overlap"
+grep -Fq 'registry contains an unknown, missing, or unexpected image generation' \
+  "$registry_pruner" ||
+  fail "registry pruning does not fail closed on unknown images"
+grep -Fq 'OCI registry pruning did not reach the exact protected digest set' \
+  "$registry_pruner" ||
+  fail "registry pruning does not wait for asynchronous deletion"
+grep -Fq '.layers_size_bytes <= $max_bytes' "$registry_pruner" ||
+  fail "registry pruning does not wait for bounded registry accounting"
 grep -Fq 'docker run -d --platform linux/arm64 --name "$container"' "$verify_images" ||
   fail "OCI application boot verification must run the ARM64 images"
 if grep -Eq -- '--platform linux/arm64 --name "\$(mongo|rabbit)"' "$verify_images"; then
@@ -693,6 +708,14 @@ migration_post_cloud_credentials="$(
   fail "post-commit browser validation receives cloud credentials"
 grep -Fq 'name: oci-infrastructure' "$infra_workflow"
 grep -Fq 'PROVISION OCI ZERO COST' "$infra_workflow"
+grep -Fq -- '- prune-registry' "$infra_workflow"
+grep -Fq 'PRUNE OBSOLETE OCI IMAGE GENERATION' "$infra_workflow"
+grep -Fq 'prune-registry-generation.sh' "$infra_workflow"
+grep -Fq 'oci-image-provenance-${OBSOLETE_SHA}-${OBSOLETE_BUILD_RUN_ID}-1' \
+  "$infra_workflow"
+grep -Fq 'oci-image-provenance-${FALLBACK_SHA}-${FALLBACK_BUILD_RUN_ID}-1' \
+  "$infra_workflow"
+grep -Fq 'oci-deploy-provenance-${DEPLOYED_RUN_ID}-1' "$infra_workflow"
 grep -Fq 'name: oci-migration' "$data_workflow"
 grep -Fq 'DRY RUN LIVE DATA EXACT SHA' "$data_workflow"
 grep -Fq 'APPLY LIVE BACKFILLS EXACT SHA' "$data_workflow"
@@ -1270,6 +1293,7 @@ if [[ "${BETSTAN_CONTRACT_ORCHESTRATED:-0}" != "1" ]]; then
   "$OCI_DIR/tests/test-capacity-contract.sh"
   "$OCI_DIR/tests/test-image-reuse-contract.sh"
   "$OCI_DIR/tests/test-k3s-runtime-contract.sh"
+  "$OCI_DIR/tests/test-registry-prune-contract.sh"
   "$OCI_DIR/tests/test-migration-recovery-contract.sh"
   "$OCI_DIR/tests/test-mongo-upgrade.sh"
   "$OCI_DIR/agents/test-health-contract-stan.sh"

--- a/infra/oci/tests/test-registry-prune-contract.sh
+++ b/infra/oci/tests/test-registry-prune-contract.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+OCI_DIR="$ROOT_DIR/infra/oci"
+WORK_DIR="$OCI_DIR/tests/.registry-prune-work"
+SERVICES=(auth backoffice bet client event gamemaster moderation resulting slip)
+TARGET_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+DEPLOYED_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+ROLLBACK_SHA="cccccccccccccccccccccccccccccccccccccccc"
+CURRENT_SHA="dddddddddddddddddddddddddddddddddddddddd"
+REPOSITORY="fra.ocir.io/example/betstan_images"
+
+fail() {
+  echo "OCI registry prune contract failure: $*" >&2
+  exit 1
+}
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR/bin" "$WORK_DIR/state"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+digest_for() {
+  local generation="$1"
+  local service_index="$2"
+  printf 'sha256:%064d' "$((generation * 9 + service_index + 1))"
+}
+
+write_generation() {
+  local source_sha="$1"
+  local generation="$2"
+  local output_file="$3"
+  local service_index service digest
+
+  : > "$output_file"
+  for service_index in "${!SERVICES[@]}"; do
+    service="${SERVICES[$service_index]}"
+    digest="$(digest_for "$generation" "$service_index")"
+    printf '%s\t%s\t%s@%s\t%s\t%s\n' \
+      "$service" "$REPOSITORY" "$REPOSITORY" "$digest" "$digest" "$digest" \
+      >> "$output_file"
+  done
+}
+
+write_generation "$TARGET_SHA" 0 "$WORK_DIR/target.tsv"
+write_generation "$DEPLOYED_SHA" 1 "$WORK_DIR/deployed.tsv"
+write_generation "$ROLLBACK_SHA" 2 "$WORK_DIR/rollback.tsv"
+write_generation "$CURRENT_SHA" 3 "$WORK_DIR/current.tsv"
+cat \
+  "$WORK_DIR/current.tsv" \
+  "$WORK_DIR/deployed.tsv" \
+  "$WORK_DIR/rollback.tsv" \
+  > "$WORK_DIR/protected.tsv"
+
+jq -n \
+  --arg target_sha "$TARGET_SHA" \
+  --arg deployed_sha "$DEPLOYED_SHA" \
+  --arg rollback_sha "$ROLLBACK_SHA" \
+  --arg current_sha "$CURRENT_SHA" '
+    def services: [
+      "auth", "backoffice", "bet", "client", "event", "gamemaster",
+      "moderation", "resulting", "slip"
+    ];
+    def pad($value; $width):
+      ($value | tostring) as $text
+      | ("0" * ($width - ($text | length))) + $text;
+    [
+      [$target_sha, 0],
+      [$deployed_sha, 1],
+      [$rollback_sha, 2],
+      [$current_sha, 3]
+    ] as $generations
+    | {
+        data: {
+          items: [
+            $generations[] as $generation
+            | range(0; 9) as $service_index
+            | {
+                id: (
+                  "ocid1.containerimage.oc1..fixture" +
+                  pad(($generation[1] * 9) + $service_index + 1; 3)
+                ),
+                "repository-name": "betstan_images",
+                version: (
+                  "oci-\(services[$service_index])-\($generation[0])"
+                ),
+                digest: (
+                  "sha256:" +
+                  pad(($generation[1] * 9) + $service_index + 1; 64)
+                ),
+                "lifecycle-state": "AVAILABLE"
+              }
+          ]
+        }
+      }
+  ' > "$WORK_DIR/state/images.json"
+
+cat > "$WORK_DIR/bin/oci" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "3.90.0"
+  exit 0
+fi
+printf '%s\n' "$*" >> "${MOCK_OCI_LOG:?}"
+case "$*" in
+  "artifacts container image list "*)
+    cat "${MOCK_OCI_STATE:?}/images.json"
+    ;;
+  "artifacts container repository list "*)
+    image_count="$(
+      jq '[.data.items[].digest] | unique | length' \
+        "${MOCK_OCI_STATE:?}/images.json"
+    )"
+    jq -n --argjson image_count "$image_count" '{
+      data: {
+        items: [{
+          "display-name": "betstan_images",
+          "image-count": $image_count,
+          "layers-size-in-bytes": 300000000
+        }]
+      }
+    }'
+    ;;
+  "artifacts container image delete "*)
+    image_id=""
+    while (($#)); do
+      if [[ "$1" == "--image-id" ]]; then
+        image_id="${2:-}"
+        break
+      fi
+      shift
+    done
+    [[ -n "$image_id" ]]
+    jq --arg image_id "$image_id" '
+      .data.items |= map(select(.id != $image_id))
+    ' "${MOCK_OCI_STATE:?}/images.json" > "${MOCK_OCI_STATE:?}/images.json.tmp"
+    mv "${MOCK_OCI_STATE:?}/images.json.tmp" "${MOCK_OCI_STATE:?}/images.json"
+    ;;
+  *)
+    echo "unexpected mock OCI command: $*" >&2
+    exit 1
+    ;;
+esac
+MOCK
+chmod +x "$WORK_DIR/bin/oci"
+
+run_prune() {
+  env \
+    PATH="$WORK_DIR/bin:$PATH" \
+    MOCK_OCI_LOG="$WORK_DIR/oci.log" \
+    MOCK_OCI_STATE="$WORK_DIR/state" \
+    OCI_CLI_VERSION=3.90.0 \
+    OCI_COMPARTMENT_OCID=ocid1.compartment.oc1..fixture \
+    OCI_REGISTRY_HOST=fra.ocir.io \
+    OCI_REGISTRY_NAMESPACE=example \
+    OCI_IMAGE_PREFIX=betstan \
+    OCI_REGISTRY_MAX_BYTES=500000000 \
+    TARGET_IMAGES_FILE="$WORK_DIR/target.tsv" \
+    PROTECTED_IMAGES_FILE="$WORK_DIR/protected.tsv" \
+    TARGET_SOURCE_SHA="$TARGET_SHA" \
+    CURRENT_SOURCE_SHA="$CURRENT_SHA" \
+    OUTPUT_DIR="$WORK_DIR/evidence" \
+    PRUNE_POLL_ATTEMPTS=1 \
+    PRUNE_POLL_SECONDS=0 \
+    "$OCI_DIR/scripts/prune-registry-generation.sh"
+}
+
+run_prune
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "9" ]] ||
+  fail "prune did not delete exactly one complete generation"
+jq -e '
+  .terminal_status == "PRUNED" and
+  .unique_images == 27
+' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
+  fail "prune did not emit terminal evidence"
+[[ "$(wc -l < "$WORK_DIR/evidence/deleted-images.tsv" | tr -d ' ')" == "9" ]] ||
+  fail "prune evidence does not contain nine deleted service images"
+[[ "$(
+  jq -c '[.data.items | length, ([.[] | .digest] | unique | length)]' \
+    "$WORK_DIR/state/images.json"
+)" == "[27,27]" ]] ||
+  fail "prune did not retain exactly three complete generations"
+
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+run_prune
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "an already-pruned generation was deleted again"
+jq -e '
+  .deletion_required == false and
+  .unique_images == 27
+' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
+  fail "an already-pruned generation was not resumed idempotently"
+
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+cp "$WORK_DIR/current.tsv" "$WORK_DIR/protected-overlap.tsv"
+cat \
+  "$WORK_DIR/deployed.tsv" \
+  "$WORK_DIR/target.tsv" \
+  >> "$WORK_DIR/protected-overlap.tsv"
+if env \
+  PATH="$WORK_DIR/bin:$PATH" \
+  MOCK_OCI_LOG="$WORK_DIR/oci.log" \
+  MOCK_OCI_STATE="$WORK_DIR/state" \
+  OCI_CLI_VERSION=3.90.0 \
+  OCI_COMPARTMENT_OCID=ocid1.compartment.oc1..fixture \
+  OCI_REGISTRY_HOST=fra.ocir.io \
+  OCI_REGISTRY_NAMESPACE=example \
+  OCI_IMAGE_PREFIX=betstan \
+  OCI_REGISTRY_MAX_BYTES=500000000 \
+  TARGET_IMAGES_FILE="$WORK_DIR/target.tsv" \
+  PROTECTED_IMAGES_FILE="$WORK_DIR/protected-overlap.tsv" \
+  TARGET_SOURCE_SHA="$TARGET_SHA" \
+  CURRENT_SOURCE_SHA="$CURRENT_SHA" \
+  OUTPUT_DIR="$WORK_DIR/evidence" \
+  PRUNE_POLL_ATTEMPTS=1 \
+  PRUNE_POLL_SECONDS=0 \
+  "$OCI_DIR/scripts/prune-registry-generation.sh" >/dev/null 2>&1; then
+  fail "overlapping protected and target generations were accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "overlap rejection happened after a delete"
+
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+jq '
+  .data.items += [{
+    id: "ocid1.containerimage.oc1..fixture999",
+    "repository-name": "betstan_images",
+    version: "oci-auth-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    digest: ("sha256:" + ("f" * 64)),
+    "lifecycle-state": "AVAILABLE"
+  }]
+' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+if run_prune >/dev/null 2>&1; then
+  fail "an unknown registry image was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "unknown-image rejection happened after a delete"
+
+echo "OCI registry prune contract tests passed"


### PR DESCRIPTION
## Summary
- promote the protected OCI registry pruning phase from `dev`
- retain exact candidate, deployed, and compatible fallback digest sets
- unblock current-master infrastructure finalization without weakening the three-generation Free Tier cap