### PR TITLE
fix(oci): avoid legacy alias event probes

### DIFF
--- a/infra/oci/scripts/baseline-capture-stan.sh
+++ b/infra/oci/scripts/baseline-capture-stan.sh
@@ -19,6 +19,7 @@ HTTP_RETRY_SECONDS="${HTTP_RETRY_SECONDS:-5}"
 SSE_TIMEOUT="${SSE_TIMEOUT:-5}"
 SSE_REQUIREMENT="${SSE_REQUIREMENT:-required}"
 SSE_REQUIRED=true
+ALIAS_PROBE_MODE=exhaustive
 BASELINE_RETENTION_DAYS="${BASELINE_RETENTION_DAYS:-30}"
 RABBIT_SELECTOR="${RABBIT_SELECTOR:-app=gaming-rabbitmq}"
 MIGRATION_STATE_CONFIGMAP="${MIGRATION_STATE_CONFIGMAP:-betstan-oci-migration-journal}"
@@ -36,6 +37,7 @@ API_CONTRACTS=(
   "/api/backoffice|array"
 )
 SSE_PATH="${SSE_PATH:-/api/event/stream}"
+REDIRECT_PATH="${REDIRECT_PATH:-/api/auth/currentuser?live-betting-redirect=1}"
 
 prepare_private_dir() {
   local directory="$1"
@@ -73,19 +75,26 @@ capture_http() {
   local body_file="$WORK_DIR/http-body"
   local headers_file="$WORK_DIR/http-headers"
   local summary_file="$WORK_DIR/http-summary.json"
-  local attempt curl_status meta status effective_url content_type shape
+  local attempt curl_status expected_status location meta status effective_url content_type shape
+  local -a curl_options=(--silent --show-error --max-time "$REQUEST_TIMEOUT")
 
+  expected_status=200
+  if [[ "$expected_kind" == "redirect" ]]; then
+    expected_status=308
+  else
+    curl_options+=(--location)
+  fi
   status=""
   for ((attempt = 1; attempt <= HTTP_ATTEMPTS; attempt++)); do
     if meta="$(
-      curl --location --silent --show-error --max-time "$REQUEST_TIMEOUT" \
+      curl "${curl_options[@]}" \
         --output "$body_file" --dump-header "$headers_file" \
         --write-out '%{http_code}\t%{url_effective}\t%{content_type}' \
         "${base_url}${path}"
     )"; then
       curl_status=0
       IFS=$'\t' read -r status effective_url content_type <<<"$meta"
-      [[ "$status" == "200" ]] && break
+      [[ "$status" == "$expected_status" ]] && break
     else
       curl_status=$?
       status=""
@@ -95,11 +104,11 @@ capture_http() {
       if [[ "$curl_status" != "0" ]]; then
         oci_die "HTTP probe failed for ${base_url}${path} after ${HTTP_ATTEMPTS} attempts"
       fi
-      oci_die "expected HTTP 200 for ${base_url}${path}, got ${status} after ${HTTP_ATTEMPTS} attempts"
+      oci_die "expected HTTP ${expected_status} for ${base_url}${path}, got ${status} after ${HTTP_ATTEMPTS} attempts"
     fi
     if [[ "$curl_status" == "0" &&
         ! "$status" =~ ^(429|500|502|503|504)$ ]]; then
-      oci_die "expected HTTP 200 for ${base_url}${path}, got ${status}"
+      oci_die "expected HTTP ${expected_status} for ${base_url}${path}, got ${status}"
     fi
     sleep "$HTTP_RETRY_SECONDS"
   done
@@ -162,6 +171,18 @@ if not isinstance(payload, dict):
 print('object')
 PY
 )" || oci_die "invalid object JSON for ${base_url}${path}"
+      ;;
+    redirect)
+      [[ "$content_type" == text/html* || "$content_type" == text/plain* ]] ||
+        oci_die "expected redirect response for ${base_url}${path}"
+      location="$(
+        tr -d '\r' <"$headers_file" |
+          sed -n 's/^[Ll]ocation:[[:space:]]*//p' |
+          tail -1
+      )"
+      [[ "$location" == "${OCI_PUBLIC_URL}${path}" ]] ||
+        oci_die "unexpected redirect target for ${base_url}${path}"
+      shape="redirect:${location}"
       ;;
     *)
       oci_die "unsupported HTTP expectation: $expected_kind"
@@ -547,14 +568,23 @@ oci_rabbitmq_queue_rows <"$queue_raw" >"$OUTPUT_DIR/queues.tsv" ||
 
 : >"$OUTPUT_DIR/public-http.tsv"
 : >"$OUTPUT_DIR/sse.tsv"
-for entry in \
-  "canonical|$OCI_PUBLIC_URL" \
-  "redirect|$OCI_REDIRECT_URL" \
-  "diagnostic|$OCI_DIAGNOSTIC_URL"; do
-  IFS='|' read -r label base_url <<<"$entry"
-  capture_api_contracts "$base_url" "$label"
-  capture_sse "$base_url" "$label"
-done
+if [[ "$SSE_REQUIREMENT" == "deployed-source" && "$SSE_REQUIRED" == "false" ]]; then
+  ALIAS_PROBE_MODE=legacy-safe
+  capture_api_contracts "$OCI_PUBLIC_URL" canonical
+  capture_sse "$OCI_PUBLIC_URL" canonical
+  capture_http "$OCI_REDIRECT_URL" "$REDIRECT_PATH" redirect redirect
+  capture_http "$OCI_DIAGNOSTIC_URL" / html diagnostic
+  capture_http "$OCI_DIAGNOSTIC_URL" /api/auth/currentuser auth diagnostic
+else
+  for entry in \
+    "canonical|$OCI_PUBLIC_URL" \
+    "redirect|$OCI_REDIRECT_URL" \
+    "diagnostic|$OCI_DIAGNOSTIC_URL"; do
+    IFS='|' read -r label base_url <<<"$entry"
+    capture_api_contracts "$base_url" "$label"
+    capture_sse "$base_url" "$label"
+  done
+fi
 [[ -s "$OUTPUT_DIR/public-http.tsv" ]] || oci_die "public HTTP evidence was not captured"
 [[ -s "$OUTPUT_DIR/sse.tsv" ]] || oci_die "SSE evidence was not captured"
 
@@ -582,6 +612,7 @@ redirect_url=$OCI_REDIRECT_URL
 diagnostic_url=$OCI_DIAGNOSTIC_URL
 http_attempts=$HTTP_ATTEMPTS
 http_retry_seconds=$HTTP_RETRY_SECONDS
+alias_probe_mode=$ALIAS_PROBE_MODE
 sse_path=$SSE_PATH
 sse_requirement=$SSE_REQUIREMENT
 sse_required=$SSE_REQUIRED

--- a/infra/oci/scripts/baseline-capture-stan.sh
+++ b/infra/oci/scripts/baseline-capture-stan.sh
@@ -14,6 +14,8 @@ OCI_PUBLIC_URL="${OCI_PUBLIC_URL:-https://betstan.xyz}"
 OCI_REDIRECT_URL="${OCI_REDIRECT_URL:-https://www.betstan.xyz}"
 OCI_DIAGNOSTIC_URL="${OCI_DIAGNOSTIC_URL:-}"
 REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-20}"
+HTTP_ATTEMPTS="${HTTP_ATTEMPTS:-4}"
+HTTP_RETRY_SECONDS="${HTTP_RETRY_SECONDS:-5}"
 SSE_TIMEOUT="${SSE_TIMEOUT:-5}"
 SSE_REQUIREMENT="${SSE_REQUIREMENT:-required}"
 SSE_REQUIRED=true
@@ -71,16 +73,36 @@ capture_http() {
   local body_file="$WORK_DIR/http-body"
   local headers_file="$WORK_DIR/http-headers"
   local summary_file="$WORK_DIR/http-summary.json"
-  local meta status effective_url content_type shape
+  local attempt curl_status meta status effective_url content_type shape
 
-  meta="$({
-    curl --location --silent --show-error --max-time "$REQUEST_TIMEOUT" \
-      --output "$body_file" --dump-header "$headers_file" \
-      --write-out '%{http_code}\t%{url_effective}\t%{content_type}' \
-      "${base_url}${path}"
-  })" || oci_die "HTTP probe failed for ${base_url}${path}"
-  IFS=$'\t' read -r status effective_url content_type <<<"$meta"
-  [[ "$status" == "200" ]] || oci_die "expected HTTP 200 for ${base_url}${path}, got ${status}"
+  status=""
+  for ((attempt = 1; attempt <= HTTP_ATTEMPTS; attempt++)); do
+    if meta="$(
+      curl --location --silent --show-error --max-time "$REQUEST_TIMEOUT" \
+        --output "$body_file" --dump-header "$headers_file" \
+        --write-out '%{http_code}\t%{url_effective}\t%{content_type}' \
+        "${base_url}${path}"
+    )"; then
+      curl_status=0
+      IFS=$'\t' read -r status effective_url content_type <<<"$meta"
+      [[ "$status" == "200" ]] && break
+    else
+      curl_status=$?
+      status=""
+    fi
+
+    if ((attempt == HTTP_ATTEMPTS)); then
+      if [[ "$curl_status" != "0" ]]; then
+        oci_die "HTTP probe failed for ${base_url}${path} after ${HTTP_ATTEMPTS} attempts"
+      fi
+      oci_die "expected HTTP 200 for ${base_url}${path}, got ${status} after ${HTTP_ATTEMPTS} attempts"
+    fi
+    if [[ "$curl_status" == "0" &&
+        ! "$status" =~ ^(429|500|502|503|504)$ ]]; then
+      oci_die "expected HTTP 200 for ${base_url}${path}, got ${status}"
+    fi
+    sleep "$HTTP_RETRY_SECONDS"
+  done
   case "$expected_kind" in
     html)
       [[ "$content_type" == text/html* ]] || oci_die "expected HTML for ${base_url}${path}"
@@ -333,6 +355,9 @@ oci_require_command python3
 oci_require_command jq
 validate_positive_int "$BASELINE_RETENTION_DAYS" || oci_die "BASELINE_RETENTION_DAYS must be positive"
 validate_positive_int "$RUN_LOOKBACK" || oci_die "RUN_LOOKBACK must be positive"
+validate_positive_int "$HTTP_ATTEMPTS" || oci_die "HTTP_ATTEMPTS must be positive"
+[[ "$HTTP_RETRY_SECONDS" =~ ^[0-9]+$ ]] ||
+  oci_die "HTTP_RETRY_SECONDS must be a nonnegative integer"
 [[ "$OCI_PUBLIC_URL" == https://* ]] || oci_die "OCI_PUBLIC_URL must be https://"
 [[ "$OCI_REDIRECT_URL" == https://* ]] || oci_die "OCI_REDIRECT_URL must be https://"
 [[ "$OCI_DIAGNOSTIC_URL" == https://* ]] || oci_die "OCI_DIAGNOSTIC_URL must be https://"
@@ -555,6 +580,8 @@ namespace=$OCI_K8S_NAMESPACE
 public_url=$OCI_PUBLIC_URL
 redirect_url=$OCI_REDIRECT_URL
 diagnostic_url=$OCI_DIAGNOSTIC_URL
+http_attempts=$HTTP_ATTEMPTS
+http_retry_seconds=$HTTP_RETRY_SECONDS
 sse_path=$SSE_PATH
 sse_requirement=$SSE_REQUIREMENT
 sse_required=$SSE_REQUIRED

--- a/infra/oci/tests/rollback-contract.sh
+++ b/infra/oci/tests/rollback-contract.sh
@@ -1050,6 +1050,21 @@ elif [[ "$url" == *'/api/event' ]]; then
       body='[]'
       ;;
   esac
+  if [[ -n "${STUB_HTTP_PERSISTENT_FAILURE_MATCH:-}" &&
+      "$url" == *"$STUB_HTTP_PERSISTENT_FAILURE_MATCH"* ]]; then
+    status='503'
+    content_type='text/html'
+    body='<html>temporarily unavailable</html>'
+    header_block=$'HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/html\r\n\r\n'
+  elif [[ -n "${STUB_HTTP_TRANSIENT_FAILURE_MATCH:-}" &&
+      "$url" == *"$STUB_HTTP_TRANSIENT_FAILURE_MATCH"* &&
+      ! -f "$STUB_STATE_DIR/http-transient-seen" ]]; then
+    touch "$STUB_STATE_DIR/http-transient-seen"
+    status='503'
+    content_type='text/html'
+    body='<html>temporarily unavailable</html>'
+    header_block=$'HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/html\r\n\r\n'
+  fi
 elif [[ "$url" == *'/api/slip' ]]; then
   body='{}'
 elif [[ "$url" == *'/api/bet/stats' ]]; then
@@ -1223,6 +1238,24 @@ run_capture_expect_failure capture-legacy-sse-unexpected-status \
   SSE_REQUIREMENT=deployed-source \
   STUB_DEPLOYED_SOURCE_HAS_SSE=0 \
   STUB_SHORT_SSE_MODE=bad-status
+
+http_retry_capture_dir="$WORK_DIR/capture-http-transient-retry"
+if ! run_capture "$http_retry_capture_dir" \
+    HTTP_ATTEMPTS=2 \
+    HTTP_RETRY_SECONDS=0 \
+    STUB_HTTP_TRANSIENT_FAILURE_MATCH=www.betstan.xyz/api/event \
+    STUB_SHORT_SSE_MODE=quiet-timeout >"$WORK_DIR/capture-http-transient-retry.out" 2>&1; then
+  cat "$WORK_DIR/capture-http-transient-retry.out" >&2
+  fail "bounded HTTP retry did not recover a transient 503"
+fi
+assert_contains "$http_retry_capture_dir/baseline-provenance.env" 'http_attempts=2'
+assert_contains "$http_retry_capture_dir/baseline-provenance.env" 'http_retry_seconds=0'
+
+run_capture_expect_failure capture-http-persistent-failure \
+  HTTP_ATTEMPTS=2 \
+  HTTP_RETRY_SECONDS=0 \
+  STUB_HTTP_PERSISTENT_FAILURE_MATCH=www.betstan.xyz/api/event \
+  STUB_SHORT_SSE_MODE=quiet-timeout
 if ! run_capture "$repeat_capture_dir" STUB_SHORT_SSE_MODE=quiet-timeout >"$WORK_DIR/capture-repeat-safe-2.out" 2>&1; then
   cat "$WORK_DIR/capture-repeat-safe-2.out" >&2
   fail 'OCI repeat-safe quiet SSE capture unexpectedly failed on second run'

--- a/infra/oci/tests/rollback-contract.sh
+++ b/infra/oci/tests/rollback-contract.sh
@@ -1221,14 +1221,21 @@ legacy_capture_dir="$WORK_DIR/capture-legacy-sse-absence"
 if ! run_capture "$legacy_capture_dir" \
     SSE_REQUIREMENT=deployed-source \
     STUB_DEPLOYED_SOURCE_HAS_SSE=0 \
+    STUB_HTTP_PERSISTENT_FAILURE_MATCH=www.betstan.xyz/api/event \
     STUB_SHORT_SSE_MODE=legacy-absent >"$WORK_DIR/capture-legacy-sse-absence.out" 2>&1; then
   cat "$WORK_DIR/capture-legacy-sse-absence.out" >&2
   fail "trusted pre-SSE deployed source baseline was rejected"
 fi
 assert_contains "$legacy_capture_dir/baseline-provenance.env" 'sse_requirement=deployed-source'
 assert_contains "$legacy_capture_dir/baseline-provenance.env" 'sse_required=false'
-[[ "$(awk -F '\t' '$4 == "legacy-absent" { count++ } END { print count + 0 }' "$legacy_capture_dir/sse.tsv")" == "3" ]] ||
-  fail "legacy SSE absence was not recorded for all public endpoints"
+assert_contains "$legacy_capture_dir/baseline-provenance.env" 'alias_probe_mode=legacy-safe'
+[[ "$(awk -F '\t' '$4 == "legacy-absent" { count++ } END { print count + 0 }' "$legacy_capture_dir/sse.tsv")" == "1" ]] ||
+  fail "legacy SSE absence was not recorded for the canonical endpoint"
+[[ "$(awk -F '\t' '$1 != "canonical" && $2 == "/api/event" { count++ } END { print count + 0 }' "$legacy_capture_dir/public-http.tsv")" == "0" ]] ||
+  fail "legacy baseline repeated the side-effectful event API through an alias"
+grep -Fq $'redirect\t/api/auth/currentuser?live-betting-redirect=1\t308\t' \
+  "$legacy_capture_dir/public-http.tsv" ||
+  fail "legacy baseline did not prove the exact redirect"
 
 run_capture_expect_failure capture-declared-sse-absence \
   SSE_REQUIREMENT=deployed-source \


### PR DESCRIPTION
## Summary
- avoid repeated side-effectful `/api/event` calls through public aliases for trusted pre-SSE deployments
- prove the redirect host with an exact 308 target and use lightweight diagnostic probes
- retain exhaustive three-host API/SSE checks for SSE-capable deployments

## Validation
- `./infra/oci/tests/rollback-contract.sh`
- `BETSTAN_CONTRACT_ORCHESTRATED=1 ./infra/oci/tests/test-contract.sh`
- `./infra/oci/tests/run-contracts.sh`