### PR TITLE
fix(oci): diagnose stalled data jobs

### DIFF
--- a/infra/oci/scripts/live-betting-data-rollout-stan.sh
+++ b/infra/oci/scripts/live-betting-data-rollout-stan.sh
@@ -227,7 +227,7 @@ wait_for_job_report() {
   local job_name="$1"
   local raw_file="$2"
   local deadline=$(( $(date +%s) + JOB_TIMEOUT_SECONDS ))
-  local job_json
+  local job_json pod_state pod_count pod_phase container_state container_reason
 
   while (( $(date +%s) < deadline )); do
     job_json="$(kubectl get job "$job_name" -n "$OCI_K8S_NAMESPACE" -o json)"
@@ -238,16 +238,109 @@ wait_for_job_report() {
         fail "unable to collect completed job report"
       return 0
     fi
+
+    pod_state="$(
+      kubectl get pods \
+        -n "$OCI_K8S_NAMESPACE" \
+        -l "job-name=$job_name" \
+        -o json |
+        jq -er '
+          def safe:
+            if type == "string" and
+               test("^[A-Za-z0-9_.:-]+$")
+            then .
+            else "Unknown"
+            end;
+
+          (.items // []) as $items |
+          if ($items | length) == 0 then
+            ["0", "Missing", "unknown", "PodNotCreated"]
+          elif ($items | length) > 1 then
+            [($items | length | tostring), "Ambiguous", "unknown", "MultiplePods"]
+          else
+            $items[0] as $pod |
+            ($pod.status.containerStatuses // []) as $statuses |
+            if ($statuses | length) == 0 then
+              (([
+                $pod.status.conditions[]? |
+                select(.type == "PodScheduled" and .status == "False")
+              ] | first) // {}) as $condition |
+              [
+                "1",
+                (($pod.status.phase // "Unknown") | safe),
+                "waiting",
+                (($condition.reason // "ContainerNotStarted") | safe)
+              ]
+            elif ($statuses | length) > 1 then
+              [
+                "1",
+                (($pod.status.phase // "Unknown") | safe),
+                "unknown",
+                "MultipleContainers"
+              ]
+            else
+              $statuses[0].state as $state |
+              if $state.waiting then
+                [
+                  "1",
+                  (($pod.status.phase // "Unknown") | safe),
+                  "waiting",
+                  (($state.waiting.reason // "Unknown") | safe)
+                ]
+              elif $state.running then
+                [
+                  "1",
+                  (($pod.status.phase // "Unknown") | safe),
+                  "running",
+                  "Running"
+                ]
+              elif $state.terminated then
+                [
+                  "1",
+                  (($pod.status.phase // "Unknown") | safe),
+                  "terminated",
+                  (($state.terminated.reason // "Unknown") | safe)
+                ]
+              else
+                [
+                  "1",
+                  (($pod.status.phase // "Unknown") | safe),
+                  "unknown",
+                  "StateMissing"
+                ]
+              end
+            end
+          end |
+          @tsv
+        '
+    )" || fail "unable to inspect sanitized pod state for $job_name"
+    IFS=$'\t' read -r \
+      pod_count pod_phase container_state container_reason <<<"$pod_state"
+
     if jq -e '(.status.failed // 0) > 0' <<<"$job_json" >/dev/null; then
       kubectl logs "job/$job_name" \
         -n "$OCI_K8S_NAMESPACE" \
         --container data-rollout >"$raw_file" 2>/dev/null || true
-      fail "data job failed for $job_name; raw logs were withheld"
+      fail "data job failed for $job_name; raw logs were withheld; pod_count=$pod_count pod_phase=$pod_phase container_state=$container_state reason=$container_reason"
+    fi
+    case "$container_reason" in
+      ErrImagePull|ImagePullBackOff|InvalidImageName|CreateContainerConfigError|\
+      CreateContainerError|RunContainerError|CrashLoopBackOff|\
+      PreCreateHookError|PostStartHookError|Unschedulable)
+        fail "data job startup failed for $job_name; pod_count=$pod_count pod_phase=$pod_phase container_state=$container_state reason=$container_reason"
+        ;;
+    esac
+    if [[ "$container_state" == "terminated" &&
+      "$container_reason" != "Completed" ]]; then
+      kubectl logs "job/$job_name" \
+        -n "$OCI_K8S_NAMESPACE" \
+        --container data-rollout >"$raw_file" 2>/dev/null || true
+      fail "data job terminated for $job_name; raw logs were withheld; pod_count=$pod_count pod_phase=$pod_phase container_state=$container_state reason=$container_reason"
     fi
     sleep 5
   done
 
-  fail "data job timed out for $job_name"
+  fail "data job timed out for $job_name; pod_count=$pod_count pod_phase=$pod_phase container_state=$container_state reason=$container_reason"
 }
 
 run_job() {

--- a/infra/oci/tests/test-live-betting-data-rollout-stan.sh
+++ b/infra/oci/tests/test-live-betting-data-rollout-stan.sh
@@ -58,7 +58,11 @@ if [[ "${1:-}" == "get" ]]; then
       exit 0
       ;;
     job)
-      printf '{"status":{"succeeded":1}}\n'
+      if [[ "$scenario" == "image-pull" ]]; then
+        printf '{"status":{}}\n'
+      else
+        printf '{"status":{"succeeded":1}}\n'
+      fi
       exit 0
       ;;
     deployment)
@@ -66,7 +70,10 @@ if [[ "${1:-}" == "get" ]]; then
       exit 0
       ;;
     pods)
-      if [[ "$*" == *"app=gaming-auth-mongo"* ]]; then
+      if [[ "$scenario" == "image-pull" && "$*" == *"job-name="* ]]; then
+        printf '%s\n' \
+          '{"items":[{"status":{"phase":"Pending","containerStatuses":[{"state":{"waiting":{"reason":"ImagePullBackOff","message":"secret registry detail"}}}]}}]}'
+      elif [[ "$*" == *"app=gaming-auth-mongo"* ]]; then
         printf 'mongo-0'
       elif [[ "$*" == *"app=gaming-rabbitmq"* ]]; then
         printf 'rabbitmq-0'
@@ -318,6 +325,19 @@ for manifest in "$stub_state"/jobs/*.yaml; do
     fail "job invoked TypeScript source instead of the compiled CLI"
   fi
 done
+
+image_pull_output="$work_dir/image-pull.out"
+if run_phase dry-run image-pull 4005 "$work_dir/image-pull" \
+    >"$image_pull_output" 2>&1; then
+  fail "image pull failure was accepted"
+fi
+grep -Fq \
+  'pod_count=1 pod_phase=Pending container_state=waiting reason=ImagePullBackOff' \
+  "$image_pull_output" ||
+  fail "image pull failure did not report sanitized pod state"
+if grep -Fq 'secret registry detail' "$image_pull_output"; then
+  fail "image pull diagnostics leaked the provider message"
+fi
 
 for literal in \
   'name: oci-migration' \


### PR DESCRIPTION
## Summary
- fail fast on terminal Kubernetes scheduling, image-pull, and container-start reasons
- report only allow-listed pod state fields while withholding raw migration logs
- retain pod state on the overall timeout to distinguish a running process from an infrastructure failure

## Validation
- `./infra/oci/tests/test-live-betting-data-rollout-stan.sh`
- `./infra/oci/tests/run-contracts.sh`