### PR TITLE
Harden live betting production rollout

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -104,6 +104,12 @@ Required invariants:
 - Every prior blocking finding is resolved with evidence before approval.
 - `from_agent` never appears in `approvals`.
 - Feature flags remain dark until the approved activation gate.
+- Privileged access is revalidated against persisted auth state; JWT role
+  claims and client-side filtering are not authorization boundaries.
+- Synthetic acceptance data is offline and server-scoped to exact IDs.
+- A production activation remains leased until acceptance evidence and final
+  provenance revalidation succeed; failure and disable clear both flag and
+  lease.
 
 ## Status vocabulary
 

--- a/.github/agents/betstan-auth-security-reviewer.agent.md
+++ b/.github/agents/betstan-auth-security-reviewer.agent.md
@@ -48,6 +48,22 @@ Inspect the exact diff, target branch, and currently deployed contract assumptio
   retention/origin trust.
 - Cookie `Secure`, `HttpOnly`, `SameSite`, TLS, CSRF, JWT expiry, revocation, logout,
   and mixed-version token compatibility.
+- Persisted-role revalidation for every administrative mutation and
+  administrator-scoped read; test stale claims, demotion, deletion, legacy
+  no-`exp` tokens, and auth-service failure.
+- Server-side exclusion of offline/synthetic records from ordinary REST and
+  long-lived streams. Client filtering and possession of an event ID are not
+  authorization.
+- Privileged read routes as well as mutations, message-reordering defaults that
+  fail dark before metadata arrives, independent metadata/visibility ordering,
+  and client cache eviction after authorization revocation or visibility
+  removal.
+- Missing-row visibility messages must create only a fail-dark pending
+  placeholder; they must not be acknowledged and discarded or published before
+  metadata arrives.
+- Review duplicate-key convergence for every competing placeholder upsert; a
+  losing consumer must retry its pending decision rather than crash or ACK it
+  away.
 - Public response DTOs, logs, DOM attributes, screenshots, and CI artifact leakage.
 - Authorization enforcement on authenticated and administrative routes.
 

--- a/.github/agents/betstan-backend-developer.agent.md
+++ b/.github/agents/betstan-backend-developer.agent.md
@@ -52,6 +52,13 @@ instead of crossing the boundary.
   required.
 - Make message handlers idempotent and explicit about cross-queue ordering.
 - Use database-enforced invariants for concurrency-sensitive uniqueness.
+- Treat JWT roles as non-authoritative for privileged operations. Revalidate
+  current persisted roles through the owning auth service and fail closed.
+- Keep synthetic acceptance records excluded by default in every public read
+  path, including long-lived streams, and authorize exact scoped IDs
+  server-side.
+- Generate private simulation randomness independently of public identifiers,
+  persist it before publication, and never include it in public DTOs.
 - Reuse existing helpers and patterns; avoid broad catches and silent failures.
 - Keep publisher instances singleton-scoped as documented in `LEARNINGS.md`.
 - Run the smallest existing tests that prove the slice.

--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -17,7 +17,11 @@ Before changing or assessing deployment behavior, read:
 - `.github/workflows/branch-policy.yml`
 - `.github/workflows/production-deploy.yml`
 - `.github/workflows/oci-live-data-rollout.yml`
+- `.github/workflows/oci-live-betting-activate.yml`
+- `.github/workflows/oci-live-betting-disable.yml`
 - `.github/workflows/oci-production-deploy.yml`
+- `infra/oci/scripts/live-betting-control-stan.sh`
+- `infra/oci/scripts/revalidate-live-activation-stan.sh`
 - `infra/azure/LESSONS_LEARNED.md`
 - `infra/oci/LESSONS_LEARNED.md`
 - `infra/azure/agents/README.md`
@@ -54,7 +58,7 @@ Inspect the current git graph and remote default branch. Do not infer that a mer
   evidence that Azure data cutover or retirement is complete. The governed set includes `production-build`,
   `production-deploy`, `oci-production-build`, `oci-production-deploy`,
   `oci-infrastructure`, `oci-capacity-acquire`, `oci-live-data-rollout`,
-  `oci-migrate`, and the
+  `oci-live-betting-activate`, `oci-live-betting-disable`, `oci-migrate`, and the
   stop-only `oci-migration-recovery`; use the checked-in inventory as
   authority when it changes.
 - Before promotion, evaluate workflow branch and path filters against the exact diff and list every production-capable workflow that will run. If approval does not cover that complete trigger set, return `NO_GO`.
@@ -119,6 +123,12 @@ After deployment:
 - on an incomplete OCI data-bound deployment, reapply the write fence, quiesce
   all six data writers, and retain or reacquire the exact handoff lock before
   permitting a retry.
+- enable live kickoffs only through a bounded worker-enforced activation lease;
+  permit the same run/SHA to remove that lease only after complete acceptance,
+  protected evidence upload, and final current-master/provenance revalidation;
+- on disable or any ambiguous activation/commit write, set the kickoff flag
+  false and remove the lease together. Never treat signal cleanup alone as
+  protection from hard runner termination.
 
 ## Ingress safety
 

--- a/.github/agents/betstan-final-validator.agent.md
+++ b/.github/agents/betstan-final-validator.agent.md
@@ -34,6 +34,19 @@ Read:
   deployment specialists were invoked when their triggers apply.
 - Verify historical-data, mixed-version, feature-flag, rollout, rollback, and
   exact-SHA evidence is complete.
+- Verify production acceptance fixtures are offline and excluded server-side
+  from ordinary REST/SSE, with persisted-administrator checks on scoped reads
+  and offline selections.
+- Verify anonymous privileged catalog reads disclose no fixture metadata,
+  live-update-first ordering fails dark without coupling metadata to visibility,
+  and clients evict hidden records after authorization loss or visibility
+  changes.
+- Verify visibility-before-row ordering persists a pending decision on an
+  offline placeholder and applies it only after event metadata is initialized.
+- Verify temporary activation has an unexpired worker-enforced lease and that
+  permanent commit occurs only after acceptance evidence upload plus final
+  current-master/provenance revalidation. Require disable/failure paths to
+  clear both flag and lease.
 - Run only existing read-only/local validation needed to confirm the evidence.
 - Treat stale, skipped, neutral, unrelated, or branch-name-only CI as missing.
 

--- a/.github/agents/betstan-frontend-developer.agent.md
+++ b/.github/agents/betstan-frontend-developer.agent.md
@@ -47,6 +47,10 @@ instead of crossing the boundary.
 - Keep server state, local input state, and asynchronous status state separate;
   never use remount keys as a refresh mechanism.
 - Apply realtime and REST state through one monotonic reducer invariant.
+- Treat privileged-stream failure as revocation: remove cached scoped records
+  immediately, reconcile without waiting for polling, and refresh auth state.
+- Keep a bounded authoritative reconcile active even while SSE is healthy when
+  the stream protocol cannot represent pre-match removals or visibility changes.
 - Surface actionable errors; do not add empty catches or success-shaped
   fallbacks.
 - Preserve independent form/wager state across sibling component updates.

--- a/.github/agents/betstan-test-engineer.agent.md
+++ b/.github/agents/betstan-test-engineer.agent.md
@@ -32,6 +32,11 @@ Read:
 5. Classify assertion failures separately from missing binaries, browser
    downloads, network dependencies, or privileged-install requirements.
 
+For privileged live acceptance, include negative ordinary-user REST/SSE
+coverage, stale/demoted administrator checks, auth-unavailable failure, private
+seed invariants, activation lease expiry, same-run/SHA commit ownership,
+ambiguous writes, and automatic flag-plus-lease disable.
+
 Use `npm ci`, not `npm install`. Do not rewrite lockfiles. Respect documented
 Mongo-memory, publisher-mock, timestamp, and coverage traps.
 

--- a/.github/agents/betstan-validation-critic.agent.md
+++ b/.github/agents/betstan-validation-critic.agent.md
@@ -28,6 +28,11 @@ Read:
 - Historical-data and old/new producer-consumer compatibility.
 - Duplicate, out-of-order, retry, restart, and concurrent execution paths.
 - Authorization, ownership, input trust, and silent-failure behavior.
+- Long-lived stream and synthetic-fixture isolation after stale-role,
+  demotion, unavailable-auth, malformed-scope, and ordinary-public requests.
+- Fail-dark control behavior under cancellation, hard process termination,
+  expired leases, ambiguous writes, stale master, and mismatched run/SHA
+  ownership.
 - Missing negative, boundary, integration, and regression tests.
 - Unrelated scope or path-ownership violations.
 

--- a/.github/workflows/oci-live-betting-activate.yml
+++ b/.github/workflows/oci-live-betting-activate.yml
@@ -1,0 +1,688 @@
+name: oci-live-betting-activate
+run-name: oci-live-activate ${{ inputs.approved_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      approved_sha:
+        description: Exact currently deployed master SHA to activate
+        required: true
+        type: string
+      build_run_id:
+        description: Successful first-attempt OCI build run ID
+        required: true
+        type: string
+      infrastructure_run_id:
+        description: Successful first-attempt OCI infrastructure run ID
+        required: true
+        type: string
+      deployment_run_id:
+        description: Successful first-attempt dark OCI deployment run ID
+        required: true
+        type: string
+      confirmation:
+        description: Type ACTIVATE OCI LIVE BETTING
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: oci-control-plane
+  cancel-in-progress: false
+
+jobs:
+  activate-and-validate:
+    if: github.run_attempt == 1
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    environment:
+      name: oci-production
+    env:
+      SOURCE_SHA: ${{ inputs.approved_sha }}
+      BUILD_RUN_ID: ${{ inputs.build_run_id }}
+      INFRASTRUCTURE_RUN_ID: ${{ inputs.infrastructure_run_id }}
+      DEPLOYMENT_RUN_ID: ${{ inputs.deployment_run_id }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      OCI_RUNTIME_MODE: ${{ vars.OCI_RUNTIME_MODE }}
+      OCI_CLI_VERSION: "3.90.0"
+      OCI_REGION: ${{ vars.OCI_REGION }}
+      OCI_TENANCY_OCID: ${{ vars.OCI_TENANCY_OCID }}
+      OCI_CI_USER_OCID: ${{ vars.OCI_CI_USER_OCID }}
+      OCI_CI_KEY_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+      OCI_K8S_NAMESPACE: ${{ vars.OCI_K8S_NAMESPACE }}
+      OCI_BASTION_DEFAULT_CLIENT_CIDR: 192.0.2.1/32
+      LIVE_ACTIVATION_LEASE_SECONDS: "1800"
+
+    steps:
+      - name: Initialize isolated OCI paths
+        run: |
+          {
+            echo "HOME=$RUNNER_TEMP/oci-live-control-home"
+            echo "KUBECONFIG=$RUNNER_TEMP/oci-live-control-home/.kube/config"
+          } >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/oci-live-control-home/.local/bin" >> "$GITHUB_PATH"
+          mkdir -p \
+            "$RUNNER_TEMP/oci-live-control-home/.kube" \
+            artifacts/build \
+            artifacts/infrastructure \
+            artifacts/deploy \
+            artifacts/dark-readiness \
+            artifacts/live-control
+          chmod 700 \
+            "$RUNNER_TEMP/oci-live-control-home" \
+            "$RUNNER_TEMP/oci-live-control-home/.kube"
+
+      - name: Checkout exact current master
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.approved_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate exact SHA and release provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [ "$GITHUB_RUN_ATTEMPT" = "1" ]
+          [ "$CONFIRMATION" = "ACTIVATE OCI LIVE BETTING" ]
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          for run_id in \
+            "$BUILD_RUN_ID" "$INFRASTRUCTURE_RUN_ID" "$DEPLOYMENT_RUN_ID"; do
+            [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
+          done
+          [ "$SOURCE_SHA" = "$GITHUB_SHA" ]
+          git fetch --quiet origin master:refs/remotes/origin/master
+          [ "$SOURCE_SHA" = "$(git rev-parse origin/master)" ]
+
+          verify_run() {
+            local run_id="$1"
+            local workflow_file="$2"
+            local expected_event="$3"
+            local workflow_id actual_id path event head_sha head_branch repository
+            local status conclusion attempt
+            workflow_id="$(
+              gh api "repos/$REPOSITORY/actions/workflows/$workflow_file" --jq '.id'
+            )"
+            read -r actual_id path event head_sha head_branch repository \
+              status conclusion attempt <<<"$(
+              gh api "repos/$REPOSITORY/actions/runs/$run_id/attempts/1" \
+                --jq '[.workflow_id,.path,.event,.head_sha,.head_branch,.head_repository.full_name,.status,.conclusion,.run_attempt] | @tsv'
+            )"
+            [ "$actual_id" = "$workflow_id" ]
+            [ "$path" = ".github/workflows/$workflow_file" ]
+            [ "$event" = "$expected_event" ]
+            [ "$head_sha" = "$SOURCE_SHA" ]
+            [ "$head_branch" = "master" ]
+            [ "$repository" = "$REPOSITORY" ]
+            [ "$status" = "completed" ]
+            [ "$conclusion" = "success" ]
+            [ "$attempt" = "1" ]
+          }
+
+          verify_run "$BUILD_RUN_ID" oci-production-build.yml workflow_run
+          verify_run "$INFRASTRUCTURE_RUN_ID" oci-infrastructure.yml workflow_dispatch
+          verify_run "$DEPLOYMENT_RUN_ID" oci-production-deploy.yml workflow_dispatch
+
+      - name: Download exact OCI image provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-image-provenance-${{ inputs.approved_sha }}-${{ inputs.build_run_id }}-1
+          path: artifacts/build
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.build_run_id }}
+
+      - name: Download exact OCI infrastructure provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-infrastructure-provenance-${{ inputs.infrastructure_run_id }}-1
+          path: artifacts/infrastructure
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.infrastructure_run_id }}
+
+      - name: Download exact dark deployment provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-deploy-provenance-${{ inputs.deployment_run_id }}-1
+          path: artifacts/deploy
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.deployment_run_id }}
+
+      - name: Download exact dark readiness evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-live-readiness-${{ inputs.deployment_run_id }}-1
+          path: artifacts/dark-readiness
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.deployment_run_id }}
+
+      - name: Verify downloaded provenance
+        id: provenance
+        run: |
+          set -euo pipefail
+          PROVENANCE_DIR=artifacts/build \
+          SOURCE_SHA="$SOURCE_SHA" \
+          EXPECTED_BUILD_RUN_ID="$BUILD_RUN_ID" \
+          EXPECTED_BUILD_RUN_ATTEMPT=1 \
+          OUTPUT_FILE=artifacts/live-control/images.tsv \
+          VERIFY_REMOTE=0 BOOT_IMAGES=0 \
+            ./infra/oci/scripts/verify-images.sh
+
+          source artifacts/infrastructure/provenance.env
+          [ "$source_sha" = "$SOURCE_SHA" ]
+          [ "$infrastructure_run_id" = "$INFRASTRUCTURE_RUN_ID" ]
+          [ "$infrastructure_run_attempt" = "1" ]
+          [ "$infrastructure_finalized" = "true" ]
+          [ "$runtime_mode" = "$OCI_RUNTIME_MODE" ]
+          [ "$namespace" = "$OCI_K8S_NAMESPACE" ]
+          selected_runtime_mode="$runtime_mode"
+          selected_infrastructure_sha256="$(
+            sha256sum artifacts/infrastructure/provenance.env |
+              awk '{print $1}'
+          )"
+          if [ "$selected_runtime_mode" = "oke" ]; then
+            selected_runtime_fingerprint="$cluster_fingerprint"
+          else
+            [ "$selected_runtime_mode" = "k3s" ]
+            selected_runtime_fingerprint="$instance_fingerprint"
+          fi
+
+          source artifacts/deploy/provenance.txt
+          [ "$source_sha" = "$SOURCE_SHA" ]
+          [ "$deployment_run_id" = "$DEPLOYMENT_RUN_ID" ]
+          [ "$deployment_run_attempt" = "1" ]
+          [ "$runtime_mode" = "$selected_runtime_mode" ]
+          [ "$runtime_fingerprint" = "$selected_runtime_fingerprint" ]
+          [ "$infrastructure_run_id" = "$INFRASTRUCTURE_RUN_ID" ]
+          [ "$infrastructure_run_attempt" = "1" ]
+          [ "$infrastructure_provenance_sha256" = "$selected_infrastructure_sha256" ]
+          [ "$public_host" = "$canonical_host" ]
+
+          mapfile -t dark_summaries < <(
+            find artifacts/dark-readiness -type f -name summary.env
+          )
+          [ "${#dark_summaries[@]}" = "1" ]
+          dark_summary="${dark_summaries[0]}"
+          [ "$(awk -F= '$1 == "mode" {print $2}' "$dark_summary")" = "dark" ]
+          [ "$(awk -F= '$1 == "live_betting_readiness" {print $2}' "$dark_summary")" = "GO" ]
+          [ "$(awk -F= '$1 == "actual_live_kickoffs_enabled" {print $2}' "$dark_summary")" = "false" ]
+          [ "$(awk -F= '$1 == "active_matches" {print $2}' "$dark_summary")" = "0" ]
+          [ "$(awk -F= '$1 == "submitted_live_slips" {print $2}' "$dark_summary")" = "0" ]
+          printf 'DARK_READINESS_FILE=%s\n' "$dark_summary" >> "$GITHUB_ENV"
+
+          printf 'public_url=https://%s\n' "$canonical_host" >> "$GITHUB_OUTPUT"
+          printf 'redirect_url=https://%s\n' "$redirect_host" >> "$GITHUB_OUTPUT"
+          printf 'diagnostic_url=https://%s\n' "$diagnostic_host" >> "$GITHUB_OUTPUT"
+          if [ "$runtime_mode" = "oke" ]; then
+            echo "::add-mask::$cluster_ocid"
+            echo "::add-mask::$endpoint_nsg_ocid"
+            printf 'cluster_ocid=%s\n' "$cluster_ocid" >> "$GITHUB_OUTPUT"
+            printf 'endpoint_nsg_ocid=%s\n' "$endpoint_nsg_ocid" >> "$GITHUB_OUTPUT"
+          else
+            echo "::add-mask::$instance_ocid"
+            echo "::add-mask::$bastion_ocid"
+            printf 'instance_ocid=%s\n' "$instance_ocid" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install pinned OCI CLI
+        run: ./infra/oci/scripts/install-cli.sh
+
+      - name: Verify OKE identity
+        if: env.OCI_RUNTIME_MODE == 'oke'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_CLUSTER_OCID: ${{ steps.provenance.outputs.cluster_ocid }}
+        run: |
+          oci ce cluster get \
+            --cluster-id "$OCI_CLUSTER_OCID" \
+            --query 'data.{type:type,state:"lifecycle-state"}' >/dev/null
+
+      - name: Verify k3s identity
+        if: env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_INSTANCE_OCID: ${{ steps.provenance.outputs.instance_ocid }}
+        run: |
+          oci compute instance get \
+            --instance-id "$OCI_INSTANCE_OCID" \
+            --query 'data.{shape:shape,state:"lifecycle-state"}' >/dev/null
+
+      - name: Authorize current OKE runner
+        if: env.OCI_RUNTIME_MODE == 'oke'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_ENDPOINT_NSG_OCID: ${{ steps.provenance.outputs.endpoint_nsg_ocid }}
+          RULE_STATE_FILE: ${{ runner.temp }}/live-control-runner-rule.env
+        run: |
+          set -euo pipefail
+          ./infra/oci/scripts/authorize-github-runner.sh cleanup-stale
+          RUNNER_PUBLIC_IPV4="$(
+            curl --fail --silent --show-error --max-time 15 https://api.ipify.org
+          )"
+          export RUNNER_PUBLIC_IPV4
+          ./infra/oci/scripts/authorize-github-runner.sh authorize
+
+      - name: Configure kubectl from exact OKE cluster
+        if: env.OCI_RUNTIME_MODE == 'oke'
+        uses: oracle-actions/configure-kubectl-oke@77a733d79446dabe7bf0e58eb56197d33ce4dc58 # v1.5.0
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+        with:
+          cluster: ${{ steps.provenance.outputs.cluster_ocid }}
+
+      - name: Open ephemeral OCI Bastion access to k3s
+        if: env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_K3S_SSH_PRIVATE_KEY: ${{ secrets.OCI_K3S_SSH_PRIVATE_KEY }}
+          INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env
+          SESSION_STATE_FILE: ${{ runner.temp }}/live-control-k3s-access.env
+          WORK_DIR: ${{ runner.temp }}/betstan-k3s-live-control
+        run: |
+          set -euo pipefail
+          RUNNER_PUBLIC_IPV4="$(
+            curl --fail --silent --show-error --max-time 15 https://api.ipify.org
+          )"
+          export RUNNER_PUBLIC_IPV4
+          ./infra/oci/scripts/configure-k3s-access.sh open
+
+      - name: Install browser acceptance dependencies
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "18"
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install locked client and Chromium
+        run: |
+          npm ci --prefix client --no-audit --no-fund
+          ./client/node_modules/.bin/playwright install --with-deps chromium
+
+      - name: Capture pre-activation pod restart baseline
+        run: |
+          kubectl get pods -n "$OCI_K8S_NAMESPACE" -o json |
+            jq '[
+              .items[] as $pod |
+              $pod.status.containerStatuses[]? |
+              {
+                pod: $pod.metadata.name,
+                name: .name,
+                restarts: .restartCount
+              }
+            ]' > artifacts/live-control/restarts-before.json
+
+      - name: Verify dark activation preconditions
+        env:
+          MODE: dark
+          BASE_URL: ${{ steps.provenance.outputs.public_url }}
+          SECONDARY_PUBLIC_URL: ${{ steps.provenance.outputs.redirect_url }}
+          DIAGNOSTIC_URL: ${{ steps.provenance.outputs.diagnostic_url }}
+          NAMESPACE: ${{ env.OCI_K8S_NAMESPACE }}
+          IMAGE_PROVENANCE_FILE: artifacts/live-control/images.tsv
+          EXACT_MASTER_PROVENANCE_FILE: artifacts/deploy/provenance.txt
+          LIVE_SCHEMA_EVIDENCE_FILE: artifacts/deploy/live-schema.env
+          OUTPUT_DIR: artifacts/live-control/readiness-before
+        run: ./infra/oci/agents/live-betting-readiness-stan.sh
+
+      - name: Revalidate current master before live mutation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: ./infra/oci/scripts/revalidate-live-activation-stan.sh
+
+      - name: Activate new live kickoffs
+        id: activate
+        env:
+          ACTION: activate
+          SOURCE_SHA: ${{ env.SOURCE_SHA }}
+          CONTROL_RUN_ID: ${{ github.run_id }}
+          CONFIRMATION: ACTIVATE OCI LIVE BETTING
+          NAMESPACE: ${{ env.OCI_K8S_NAMESPACE }}
+          LEASE_DURATION_SECONDS: ${{ env.LIVE_ACTIVATION_LEASE_SECONDS }}
+          OUTPUT_DIR: artifacts/live-control/activate
+        run: ./infra/oci/scripts/live-betting-control-stan.sh
+
+      - name: Verify activated runtime
+        env:
+          MODE: activate
+          BASE_URL: ${{ steps.provenance.outputs.public_url }}
+          SECONDARY_PUBLIC_URL: ${{ steps.provenance.outputs.redirect_url }}
+          DIAGNOSTIC_URL: ${{ steps.provenance.outputs.diagnostic_url }}
+          NAMESPACE: ${{ env.OCI_K8S_NAMESPACE }}
+          IMAGE_PROVENANCE_FILE: artifacts/live-control/images.tsv
+          EXACT_MASTER_PROVENANCE_FILE: artifacts/deploy/provenance.txt
+          LIVE_SCHEMA_EVIDENCE_FILE: artifacts/deploy/live-schema.env
+          ROLLBACK_BASELINE_FILE: ${{ env.DARK_READINESS_FILE }}
+          OUTPUT_DIR: artifacts/live-control/readiness-activated
+        run: ./infra/oci/agents/live-betting-readiness-stan.sh
+
+      - name: Create disposable validation account
+        id: account
+        env:
+          BASE_URL: ${{ steps.provenance.outputs.public_url }}
+        run: |
+          set -euo pipefail
+          umask 077
+          username="live-e2e-${GITHUB_RUN_ID}"
+          password="Lv1-$(openssl rand -hex 7)"
+          echo "::add-mask::$password"
+          response_file="$RUNNER_TEMP/live-acceptance-signup.json"
+          status="$(
+            jq -n --arg email "$username" --arg password "$password" \
+              '{email:$email,password:$password}' |
+              curl --fail-with-body --silent --show-error \
+                --output "$response_file" \
+                --write-out '%{http_code}' \
+                --header 'Content-Type: application/json' \
+                --data-binary @- \
+                "$BASE_URL/api/auth/new"
+          )"
+          [ "$status" = "201" ]
+          user_id="$(jq -er '.id | select(test("^[0-9a-f]{24}$"))' "$response_file")"
+          cookie_jar="$RUNNER_TEMP/live-acceptance.cookies"
+          {
+            echo "LIVE_ACCEPTANCE_USERNAME=$username"
+            echo "LIVE_ACCEPTANCE_PASSWORD=$password"
+            echo "LIVE_ACCEPTANCE_USER_ID=$user_id"
+            echo "LIVE_ACCEPTANCE_COOKIE_JAR=$cookie_jar"
+          } >> "$GITHUB_ENV"
+          printf 'user_id=%s\n' "$user_id" >> "$GITHUB_OUTPUT"
+          rm -f "$response_file"
+
+      - name: Grant and verify disposable administrator role
+        env:
+          BASE_URL: ${{ steps.provenance.outputs.public_url }}
+        run: |
+          set -euo pipefail
+          kubectl exec -n "$OCI_K8S_NAMESPACE" \
+            deployment/gaming-auth-depl \
+            -c gaming-auth -- \
+            env \
+              "USER_ID=$LIVE_ACCEPTANCE_USER_ID" \
+              USER_ROLE=ADMIN \
+              "USER_ROLE_CHANGE_CONFIRMATION=SET_ROLE:$LIVE_ACCEPTANCE_USER_ID:ADMIN" \
+              npm run role:set
+          status="$(
+            jq -n \
+              --arg email "$LIVE_ACCEPTANCE_USERNAME" \
+              --arg password "$LIVE_ACCEPTANCE_PASSWORD" \
+              '{email:$email,password:$password}' |
+              curl --fail-with-body --silent --show-error \
+                --output /dev/null \
+                --write-out '%{http_code}' \
+                --cookie-jar "$LIVE_ACCEPTANCE_COOKIE_JAR" \
+                --header 'Content-Type: application/json' \
+                --data-binary @- \
+                "$BASE_URL/api/auth/login"
+          )"
+          [ "$status" = "200" ]
+
+      - name: Exercise complete production live journey
+        env:
+          E2E_BASE_URL: ${{ steps.provenance.outputs.public_url }}
+          LIVE_ACCEPTANCE_RUN_ID: ${{ github.run_id }}
+          LIVE_ACCEPTANCE_EVIDENCE_FILE: ${{ github.workspace }}/artifacts/live-control/acceptance/evidence.json
+          OCI_E2E_OUTPUT_DIR: ${{ github.workspace }}/artifacts/live-control/playwright
+        run: |
+          NODE_PATH="$GITHUB_WORKSPACE/client/node_modules" \
+            ./client/node_modules/.bin/playwright test \
+              --config infra/oci/agents/playwright-live-acceptance.config.js
+
+      - name: Revoke disposable administrator role
+        if: always() && steps.account.outcome == 'success'
+        env:
+          BASE_URL: ${{ steps.provenance.outputs.public_url }}
+        run: |
+          set -euo pipefail
+          kubectl exec -n "$OCI_K8S_NAMESPACE" \
+            deployment/gaming-auth-depl \
+            -c gaming-auth -- \
+            env \
+              "USER_ID=$LIVE_ACCEPTANCE_USER_ID" \
+              USER_ROLE=USER \
+              "USER_ROLE_CHANGE_CONFIRMATION=SET_ROLE:$LIVE_ACCEPTANCE_USER_ID:USER" \
+              npm run role:set
+          if [ -s "$LIVE_ACCEPTANCE_COOKIE_JAR" ]; then
+            status="$(
+              curl --silent --show-error \
+                --output /dev/null \
+                --write-out '%{http_code}' \
+                --cookie "$LIVE_ACCEPTANCE_COOKIE_JAR" \
+                --header 'Content-Type: application/json' \
+                --data '{"eventId":"revoked-admin-check","homeResult":1,"awayResult":0}' \
+                "$BASE_URL/api/backoffice/result"
+            )"
+            [ "$status" = "403" ]
+          fi
+          rm -f "$LIVE_ACCEPTANCE_COOKIE_JAR"
+
+      - name: Verify settled queues and runtime
+        env:
+          MODE: monitor
+          BASE_URL: ${{ steps.provenance.outputs.public_url }}
+          SECONDARY_PUBLIC_URL: ${{ steps.provenance.outputs.redirect_url }}
+          DIAGNOSTIC_URL: ${{ steps.provenance.outputs.diagnostic_url }}
+          NAMESPACE: ${{ env.OCI_K8S_NAMESPACE }}
+          IMAGE_PROVENANCE_FILE: artifacts/live-control/images.tsv
+          EXACT_MASTER_PROVENANCE_FILE: artifacts/deploy/provenance.txt
+          LIVE_SCHEMA_EVIDENCE_FILE: artifacts/deploy/live-schema.env
+          OUTPUT_DIR: artifacts/live-control/readiness-final
+        run: ./infra/oci/agents/live-betting-readiness-stan.sh
+
+      - name: Verify no runtime errors or pod restarts
+        env:
+          INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env
+          SINCE: 20m
+        run: |
+          set -euo pipefail
+          kubectl get pods -n "$OCI_K8S_NAMESPACE" -o json |
+            jq '[
+              .items[] as $pod |
+              $pod.status.containerStatuses[]? |
+              {
+                pod: $pod.metadata.name,
+                name: .name,
+                restarts: .restartCount
+              }
+            ]' > artifacts/live-control/restarts-after.json
+          jq -e \
+            --slurpfile before artifacts/live-control/restarts-before.json '
+              all(.[];
+                . as $after |
+                (
+                  $before[0]
+                  | map(select(
+                      .pod == $after.pod
+                      and .name == $after.name
+                    ))
+                  | if length == 0
+                    then $after.restarts == 0
+                    else $after.restarts <= .[0].restarts
+                    end
+                )
+              )
+            ' artifacts/live-control/restarts-after.json >/dev/null
+          ./infra/oci/agents/service-ops-stan.sh \
+            > artifacts/live-control/service-ops.txt
+          if grep -Eq '^pod=' artifacts/live-control/service-ops.txt; then
+            echo "redacted runtime error logs were detected" >&2
+            exit 1
+          fi
+
+      - name: Revalidate release head before acceptance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: ./infra/oci/scripts/revalidate-live-activation-stan.sh
+
+      - name: Write activation provenance
+        id: accepted
+        run: |
+          set -euo pipefail
+          acceptance_sha256="$(
+            sha256sum artifacts/live-control/acceptance/evidence.json |
+              awk '{print $1}'
+          )"
+          control_sha256="$(
+            sha256sum artifacts/live-control/activate/control.env |
+              awk '{print $1}'
+          )"
+          activation_lease_until_epoch="$(
+            awk -F= \
+              '$1 == "after_lease_until_epoch" {print $2}' \
+              artifacts/live-control/activate/control.env
+          )"
+          [[ "$activation_lease_until_epoch" =~ ^[1-9][0-9]*$ ]]
+          [ "$activation_lease_until_epoch" -gt "$(date +%s)" ]
+          printf '%s\n' \
+            "source_sha=$SOURCE_SHA" \
+            "build_run_id=$BUILD_RUN_ID" \
+            "infrastructure_run_id=$INFRASTRUCTURE_RUN_ID" \
+            "deployment_run_id=$DEPLOYMENT_RUN_ID" \
+            "activation_run_id=$GITHUB_RUN_ID" \
+            "activation_run_attempt=$GITHUB_RUN_ATTEMPT" \
+            "control_sha256=$control_sha256" \
+            "acceptance_sha256=$acceptance_sha256" \
+            "live_kickoffs_enabled=true" \
+            "activation_state=leased" \
+            "activation_lease_until_epoch=$activation_lease_until_epoch" \
+            > artifacts/live-control/provenance.env
+
+      - name: Disable new kickoffs after any failed activation gate
+        if: always() && steps.accepted.outcome != 'success'
+        env:
+          ACTION: disable
+          SOURCE_SHA: ${{ env.SOURCE_SHA }}
+          CONTROL_RUN_ID: ${{ github.run_id }}
+          CONFIRMATION: DISABLE OCI LIVE BETTING
+          NAMESPACE: ${{ env.OCI_K8S_NAMESPACE }}
+          OUTPUT_DIR: artifacts/live-control/failure-disable
+        run: ./infra/oci/scripts/live-betting-control-stan.sh
+
+      - name: Capture sanitized failure diagnostics
+        if: failure()
+        env:
+          INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env
+          SINCE: 20m
+        run: |
+          ./infra/oci/agents/service-ops-stan.sh \
+            > artifacts/live-control/failure-service-ops.txt 2>&1 || true
+          ./infra/oci/agents/node-logs-stan.sh \
+            > artifacts/live-control/failure-node-logs.txt 2>&1 || true
+
+      - name: Upload protected activation evidence
+        id: evidence_upload
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: oci-live-activation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/live-control
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Revalidate release head before permanent activation
+        id: commit_preflight
+        if: >-
+          always() &&
+          steps.accepted.outcome == 'success' &&
+          steps.evidence_upload.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: ./infra/oci/scripts/revalidate-live-activation-stan.sh
+
+      - name: Commit accepted live activation
+        id: commit
+        if: >-
+          always() &&
+          steps.commit_preflight.outcome == 'success'
+        env:
+          ACTION: commit
+          SOURCE_SHA: ${{ env.SOURCE_SHA }}
+          CONTROL_RUN_ID: ${{ github.run_id }}
+          CONFIRMATION: COMMIT OCI LIVE BETTING
+          NAMESPACE: ${{ env.OCI_K8S_NAMESPACE }}
+          OUTPUT_DIR: artifacts/live-control/commit
+        run: ./infra/oci/scripts/live-betting-control-stan.sh
+
+      - name: Enforce dark mode unless activation committed
+        if: >-
+          always() &&
+          (steps.accepted.outcome != 'success' ||
+            steps.evidence_upload.outcome != 'success' ||
+            steps.commit_preflight.outcome != 'success' ||
+            steps.commit.outcome != 'success')
+        env:
+          ACTION: disable
+          SOURCE_SHA: ${{ env.SOURCE_SHA }}
+          CONTROL_RUN_ID: ${{ github.run_id }}
+          CONFIRMATION: DISABLE OCI LIVE BETTING
+          NAMESPACE: ${{ env.OCI_K8S_NAMESPACE }}
+          OUTPUT_DIR: artifacts/live-control/final-failure-disable
+        run: ./infra/oci/scripts/live-betting-control-stan.sh
+
+      - name: Revoke exact OKE runner rule
+        if: always() && env.OCI_RUNTIME_MODE == 'oke'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          RULE_STATE_FILE: ${{ runner.temp }}/live-control-runner-rule.env
+        run: |
+          if [ -f "$RULE_STATE_FILE" ]; then
+            ./infra/oci/scripts/revoke-github-runner.sh "$RULE_STATE_FILE"
+          fi
+
+      - name: Close ephemeral OCI Bastion access
+        if: always() && env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          SESSION_STATE_FILE: ${{ runner.temp }}/live-control-k3s-access.env
+          WORK_DIR: ${{ runner.temp }}/betstan-k3s-live-control
+        run: ./infra/oci/scripts/configure-k3s-access.sh cleanup
+
+      - name: Remove isolated client state
+        if: always()
+        run: |
+          rm -rf "$RUNNER_TEMP/oci-live-control-home"
+          rm -rf "$RUNNER_TEMP/betstan-k3s-live-control"
+          rm -f \
+            "$RUNNER_TEMP/live-acceptance.cookies" \
+            "$RUNNER_TEMP/live-acceptance-signup.json" \
+            "$RUNNER_TEMP/live-control-runner-rule.env" \
+            "$RUNNER_TEMP/live-control-k3s-access.env"

--- a/.github/workflows/oci-live-betting-disable.yml
+++ b/.github/workflows/oci-live-betting-disable.yml
@@ -1,0 +1,411 @@
+name: oci-live-betting-disable
+run-name: oci-live-betting-disable ${{ inputs.approved_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      approved_sha:
+        description: Exact deployed master SHA whose live betting will be disabled
+        required: true
+        type: string
+      deployment_run_id:
+        description: Successful first-attempt OCI deployment run for the exact SHA
+        required: true
+        type: string
+      infrastructure_run_id:
+        description: Successful first-attempt OCI infrastructure run used by the deployment
+        required: true
+        type: string
+      confirmation:
+        description: Type DISABLE OCI LIVE BETTING
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: oci-control-plane
+  cancel-in-progress: false
+
+jobs:
+  disable-and-drain:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment:
+      name: oci-production
+    env:
+      SOURCE_SHA: ${{ inputs.approved_sha }}
+      DEPLOYMENT_RUN_ID: ${{ inputs.deployment_run_id }}
+      INFRASTRUCTURE_RUN_ID: ${{ inputs.infrastructure_run_id }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      OCI_RUNTIME_MODE: ${{ vars.OCI_RUNTIME_MODE }}
+      OCI_CLI_VERSION: "3.90.0"
+      OCI_REGION: ${{ vars.OCI_REGION }}
+      OCI_TENANCY_OCID: ${{ vars.OCI_TENANCY_OCID }}
+      OCI_CI_USER_OCID: ${{ vars.OCI_CI_USER_OCID }}
+      OCI_CI_KEY_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+      OCI_K8S_NAMESPACE: ${{ vars.OCI_K8S_NAMESPACE || 'default' }}
+      OCI_PUBLIC_URL: ${{ vars.OCI_PUBLIC_URL }}
+      OCI_REDIRECT_URL: ${{ vars.OCI_REDIRECT_URL }}
+      OCI_DIAGNOSTIC_URL: ${{ vars.OCI_DIAGNOSTIC_URL }}
+      OCI_BASTION_DEFAULT_CLIENT_CIDR: 192.0.2.1/32
+      OUTPUT_DIR: artifacts/oci-live-betting-disable
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Initialize isolated OCI paths
+        run: |
+          {
+            echo "HOME=$RUNNER_TEMP/oci-live-disable-home"
+            echo "KUBECONFIG=$RUNNER_TEMP/oci-live-disable-home/.kube/config"
+          } >> "$GITHUB_ENV"
+          echo "$RUNNER_TEMP/oci-live-disable-home/.local/bin" >> "$GITHUB_PATH"
+          mkdir -p \
+            "$RUNNER_TEMP/oci-live-disable-home/.kube" \
+            "$OUTPUT_DIR" \
+            artifacts/deployment \
+            artifacts/infrastructure
+          chmod 700 \
+            "$RUNNER_TEMP/oci-live-disable-home" \
+            "$RUNNER_TEMP/oci-live-disable-home/.kube"
+
+      - name: Check out exact approved source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.approved_sha }}
+          persist-credentials: false
+
+      - name: Validate exact master and deployment provenance
+        env:
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]
+          [ "$GITHUB_REF_NAME" = "master" ]
+          [ "$GITHUB_RUN_ATTEMPT" = "1" ]
+          [ "$CONFIRMATION" = "DISABLE OCI LIVE BETTING" ]
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$DEPLOYMENT_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$INFRASTRUCTURE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          git fetch origin master:refs/remotes/origin/master
+          [ "$(git rev-parse HEAD)" = "$SOURCE_SHA" ]
+          git merge-base --is-ancestor "$SOURCE_SHA" origin/master
+
+          deployment_json="$(gh api "repos/$GH_REPO/actions/runs/$DEPLOYMENT_RUN_ID")"
+          [ "$(jq -r .path <<<"$deployment_json")" = ".github/workflows/oci-production-deploy.yml" ]
+          [ "$(jq -r .event <<<"$deployment_json")" = "workflow_dispatch" ]
+          [ "$(jq -r .head_sha <<<"$deployment_json")" = "$SOURCE_SHA" ]
+          [ "$(jq -r .head_branch <<<"$deployment_json")" = "master" ]
+          [ "$(jq -r .head_repository.full_name <<<"$deployment_json")" = "$GITHUB_REPOSITORY" ]
+          [ "$(jq -r .status <<<"$deployment_json")" = "completed" ]
+          [ "$(jq -r .conclusion <<<"$deployment_json")" = "success" ]
+          [ "$(jq -r .run_attempt <<<"$deployment_json")" = "1" ]
+
+          infrastructure_json="$(gh api "repos/$GH_REPO/actions/runs/$INFRASTRUCTURE_RUN_ID")"
+          [ "$(jq -r .path <<<"$infrastructure_json")" = ".github/workflows/oci-infrastructure.yml" ]
+          [ "$(jq -r .event <<<"$infrastructure_json")" = "workflow_dispatch" ]
+          [ "$(jq -r .head_sha <<<"$infrastructure_json")" = "$SOURCE_SHA" ]
+          [ "$(jq -r .head_branch <<<"$infrastructure_json")" = "master" ]
+          [ "$(jq -r .head_repository.full_name <<<"$infrastructure_json")" = "$GITHUB_REPOSITORY" ]
+          [ "$(jq -r .status <<<"$infrastructure_json")" = "completed" ]
+          [ "$(jq -r .conclusion <<<"$infrastructure_json")" = "success" ]
+          [ "$(jq -r .run_attempt <<<"$infrastructure_json")" = "1" ]
+
+      - name: Download exact deployment provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-deploy-provenance-${{ inputs.deployment_run_id }}-1
+          path: artifacts/deployment
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.deployment_run_id }}
+
+      - name: Validate deployment artifact binding
+        run: |
+          set -euo pipefail
+          provenance=artifacts/deployment/provenance.txt
+          images=artifacts/deployment/images.tsv
+          [ -s "$provenance" ]
+          [ -s "$images" ]
+          source_sha="$(sed -n 's/^source_sha=//p' "$provenance")"
+          deployment_run_id="$(sed -n 's/^deployment_run_id=//p' "$provenance")"
+          deployment_run_attempt="$(sed -n 's/^deployment_run_attempt=//p' "$provenance")"
+          deployed_infrastructure_run_id="$(
+            sed -n 's/^infrastructure_run_id=//p' "$provenance"
+          )"
+          deployed_infrastructure_run_attempt="$(
+            sed -n 's/^infrastructure_run_attempt=//p' "$provenance"
+          )"
+          deployed_infrastructure_sha256="$(
+            sed -n 's/^infrastructure_provenance_sha256=//p' "$provenance"
+          )"
+          runtime_mode="$(sed -n 's/^runtime_mode=//p' "$provenance")"
+          runtime_fingerprint="$(sed -n 's/^runtime_fingerprint=//p' "$provenance")"
+          public_host="$(sed -n 's/^public_host=//p' "$provenance")"
+          canonical_host="$(sed -n 's/^canonical_host=//p' "$provenance")"
+          redirect_host="$(sed -n 's/^redirect_host=//p' "$provenance")"
+          diagnostic_host="$(sed -n 's/^diagnostic_host=//p' "$provenance")"
+          [ "$source_sha" = "$SOURCE_SHA" ]
+          [ "$deployment_run_id" = "$DEPLOYMENT_RUN_ID" ]
+          [ "$deployment_run_attempt" = "1" ]
+          [ "$deployed_infrastructure_run_id" = "$INFRASTRUCTURE_RUN_ID" ]
+          [ "$deployed_infrastructure_run_attempt" = "1" ]
+          [[ "$deployed_infrastructure_sha256" =~ ^[0-9a-f]{64}$ ]]
+          [ "$runtime_mode" = "$OCI_RUNTIME_MODE" ]
+          [ "$runtime_mode" = "oke" ] || [ "$runtime_mode" = "k3s" ]
+          [ -n "$runtime_fingerprint" ]
+          [ "$public_host" = "$canonical_host" ]
+          for host in "$canonical_host" "$redirect_host" "$diagnostic_host"; do
+            [[ "$host" =~ ^[A-Za-z0-9.-]+$ ]]
+          done
+          [ "$(wc -l < "$images" | tr -d ' ')" = "9" ]
+          awk -F '\t' '
+            NF != 4 { exit 1 }
+            $3 !~ /@sha256:[0-9a-f]{64}$/ { exit 1 }
+            $4 !~ /^sha256:[0-9a-f]{64}$/ { exit 1 }
+            END { exit NR == 9 ? 0 : 1 }
+          ' "$images"
+          {
+            printf 'OCI_PUBLIC_URL=https://%s\n' "$canonical_host"
+            printf 'OCI_REDIRECT_URL=https://%s\n' "$redirect_host"
+            printf 'OCI_DIAGNOSTIC_URL=https://%s\n' "$diagnostic_host"
+            printf 'DEPLOYED_RUNTIME_MODE=%s\n' "$runtime_mode"
+            printf 'DEPLOYED_RUNTIME_FINGERPRINT=%s\n' "$runtime_fingerprint"
+            printf 'DEPLOYED_INFRASTRUCTURE_SHA256=%s\n' "$deployed_infrastructure_sha256"
+          } >> "$GITHUB_ENV"
+
+      - name: Download exact infrastructure provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: oci-infrastructure-provenance-${{ inputs.infrastructure_run_id }}-1
+          path: artifacts/infrastructure
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.infrastructure_run_id }}
+
+      - name: Bind exact runtime identity
+        id: infrastructure
+        run: |
+          set -euo pipefail
+          source artifacts/infrastructure/provenance.env
+          [ "$source_sha" = "$SOURCE_SHA" ]
+          [ "$infrastructure_run_id" = "$INFRASTRUCTURE_RUN_ID" ]
+          [ "$infrastructure_run_attempt" = "1" ]
+          [ "$infrastructure_finalized" = "true" ]
+          [ "$runtime_mode" = "$DEPLOYED_RUNTIME_MODE" ]
+          [ "$(
+            sha256sum artifacts/infrastructure/provenance.env |
+              awk '{print $1}'
+          )" = "$DEPLOYED_INFRASTRUCTURE_SHA256" ]
+          [ "$namespace" = "$OCI_K8S_NAMESPACE" ]
+          if [ "$runtime_mode" = "oke" ]; then
+            [ "$cluster_fingerprint" = "$DEPLOYED_RUNTIME_FINGERPRINT" ]
+            echo "::add-mask::$cluster_ocid"
+            echo "::add-mask::$endpoint_nsg_ocid"
+            printf 'cluster_ocid=%s\n' "$cluster_ocid" >> "$GITHUB_OUTPUT"
+            printf 'endpoint_nsg_ocid=%s\n' "$endpoint_nsg_ocid" >> "$GITHUB_OUTPUT"
+          else
+            [ "$runtime_mode" = "k3s" ]
+            [ "$instance_fingerprint" = "$DEPLOYED_RUNTIME_FINGERPRINT" ]
+            echo "::add-mask::$instance_ocid"
+            echo "::add-mask::$bastion_ocid"
+            printf 'instance_ocid=%s\n' "$instance_ocid" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install pinned OCI CLI
+        run: ./infra/oci/scripts/install-cli.sh
+
+      - name: Verify OKE identity
+        if: env.OCI_RUNTIME_MODE == 'oke'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_CLUSTER_OCID: ${{ steps.infrastructure.outputs.cluster_ocid }}
+        run: |
+          set -euo pipefail
+          oci ce cluster get \
+            --cluster-id "$OCI_CLUSTER_OCID" \
+            --query 'data.{type:type,state:"lifecycle-state"}' >/dev/null
+
+      - name: Verify k3s identity
+        if: env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_INSTANCE_OCID: ${{ steps.infrastructure.outputs.instance_ocid }}
+        run: |
+          set -euo pipefail
+          oci compute instance get \
+            --instance-id "$OCI_INSTANCE_OCID" \
+            --query 'data.{shape:shape,state:"lifecycle-state"}' >/dev/null
+
+      - name: Authorize exact runner
+        if: env.OCI_RUNTIME_MODE == 'oke'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_ENDPOINT_NSG_OCID: ${{ steps.infrastructure.outputs.endpoint_nsg_ocid }}
+          RULE_STATE_FILE: ${{ runner.temp }}/live-disable-runner-rule.env
+        run: |
+          set -euo pipefail
+          ./infra/oci/scripts/authorize-github-runner.sh cleanup-stale
+          RUNNER_PUBLIC_IPV4="$(
+            curl --fail --silent --show-error --max-time 15 https://api.ipify.org
+          )"
+          export RUNNER_PUBLIC_IPV4
+          ./infra/oci/scripts/authorize-github-runner.sh authorize
+
+      - name: Configure kubectl for OKE
+        if: env.OCI_RUNTIME_MODE == 'oke'
+        uses: oracle-actions/configure-kubectl-oke@77a733d79446dabe7bf0e58eb56197d33ce4dc58 # v1.5.0
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+        with:
+          cluster: ${{ steps.infrastructure.outputs.cluster_ocid }}
+
+      - name: Open ephemeral OCI Bastion access to k3s
+        if: env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          OCI_K3S_SSH_PRIVATE_KEY: ${{ secrets.OCI_K3S_SSH_PRIVATE_KEY }}
+          INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env
+          SESSION_STATE_FILE: ${{ runner.temp }}/live-disable-k3s-access.env
+          WORK_DIR: ${{ runner.temp }}/betstan-k3s-live-disable
+        run: |
+          set -euo pipefail
+          RUNNER_PUBLIC_IPV4="$(
+            curl --fail --silent --show-error --max-time 15 https://api.ipify.org
+          )"
+          export RUNNER_PUBLIC_IPV4
+          ./infra/oci/scripts/configure-k3s-access.sh open
+
+      - name: Disable new live kickoffs
+        id: disable
+        env:
+          ACTION: disable
+          CONTROL_RUN_ID: ${{ github.run_id }}
+          CONFIRMATION: DISABLE OCI LIVE BETTING
+          NAMESPACE: ${{ env.OCI_K8S_NAMESPACE }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$OUTPUT_DIR"
+          ./infra/oci/scripts/live-betting-control-stan.sh |
+            tee "$OUTPUT_DIR/control.txt"
+
+      - name: Wait for live work to drain
+        id: drain
+        env:
+          IMAGE_PROVENANCE_FILE: artifacts/deployment/images.tsv
+          INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 1200 ))
+          attempt=0
+          while true; do
+            attempt=$((attempt + 1))
+            attempt_dir="$OUTPUT_DIR/drain-attempt-$attempt"
+            mkdir -p "$attempt_dir"
+            if MODE=rollback-drain \
+              BASE_URL="$OCI_PUBLIC_URL" \
+              SECONDARY_PUBLIC_URL="$OCI_REDIRECT_URL" \
+              DIAGNOSTIC_URL="$OCI_DIAGNOSTIC_URL" \
+              OUTPUT_DIR="$attempt_dir" \
+              ./infra/oci/agents/live-betting-readiness-stan.sh \
+              >"$attempt_dir/run.txt" 2>&1; then
+              cp "$attempt_dir/summary.env" "$OUTPUT_DIR/drain-summary.env"
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "live betting did not drain within 20 minutes" >&2
+              exit 1
+            fi
+            sleep 30
+          done
+
+      - name: Capture sanitized service diagnostics
+        if: always()
+        env:
+          INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env
+        run: |
+          mkdir -p "$OUTPUT_DIR/final"
+          ./infra/oci/agents/service-ops-stan.sh \
+            >"$OUTPUT_DIR/final/service-ops.txt" 2>&1 || true
+          ./infra/oci/agents/node-logs-stan.sh \
+            >"$OUTPUT_DIR/final/node-logs.txt" 2>&1 || true
+
+      - name: Upload disable and drain evidence
+        id: evidence_upload
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: oci-live-betting-disable-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/oci-live-betting-disable
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Reassert dark mode after any disable workflow failure
+        if: >-
+          always() &&
+          (steps.disable.outcome != 'success' ||
+            steps.drain.outcome != 'success' ||
+            steps.evidence_upload.outcome != 'success')
+        env:
+          ACTION: disable
+          CONTROL_RUN_ID: ${{ github.run_id }}
+          CONFIRMATION: DISABLE OCI LIVE BETTING
+          NAMESPACE: ${{ env.OCI_K8S_NAMESPACE }}
+          OUTPUT_DIR: artifacts/oci-live-betting-disable/final-dark-reassertion
+        run: ./infra/oci/scripts/live-betting-control-stan.sh
+
+      - name: Revoke exact runner rule
+        if: always() && env.OCI_RUNTIME_MODE == 'oke'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          RULE_STATE_FILE: ${{ runner.temp }}/live-disable-runner-rule.env
+        run: |
+          if [ -f "$RULE_STATE_FILE" ]; then
+            ./infra/oci/scripts/revoke-github-runner.sh "$RULE_STATE_FILE"
+          fi
+
+      - name: Close ephemeral OCI Bastion access
+        if: always() && env.OCI_RUNTIME_MODE == 'k3s'
+        env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
+          SESSION_STATE_FILE: ${{ runner.temp }}/live-disable-k3s-access.env
+          WORK_DIR: ${{ runner.temp }}/betstan-k3s-live-disable
+        run: ./infra/oci/scripts/configure-k3s-access.sh cleanup
+
+      - name: Remove isolated runner state
+        if: always()
+        run: |
+          rm -rf "$RUNNER_TEMP/oci-live-disable-home"
+          rm -rf "$RUNNER_TEMP/betstan-k3s-live-disable"
+          rm -f \
+            "$RUNNER_TEMP/live-disable-runner-rule.env" \
+            "$RUNNER_TEMP/live-disable-k3s-access.env"

--- a/.github/workflows/oci-live-betting-disable.yml
+++ b/.github/workflows/oci-live-betting-disable.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   disable-and-drain:
+    if: github.run_attempt == 1
     runs-on: ubuntu-latest
     timeout-minutes: 35
     environment:

--- a/.github/workflows/oci-production-deploy.yml
+++ b/.github/workflows/oci-production-deploy.yml
@@ -403,6 +403,12 @@ jobs:
             printf 'data_run_id=%s\n' "$DATA_RUN_ID"
             printf 'data_run_attempt=1\n'
             printf 'data_evidence_sha256=%s\n' "$(sha256sum artifacts/data/SHA256SUMS | awk '{print $1}')"
+            printf 'infrastructure_run_id=%s\n' "$INFRASTRUCTURE_RUN_ID"
+            printf 'infrastructure_run_attempt=1\n'
+            printf 'infrastructure_provenance_sha256=%s\n' "$(
+              sha256sum artifacts/infrastructure/provenance.env |
+                awk '{print $1}'
+            )"
           } >> artifacts/oci-deploy/provenance.txt
           cp artifacts/data/schema.env artifacts/oci-deploy/live-schema.env
 

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -129,11 +129,15 @@ jobs:
           bash -n infra/oci/agents/live-betting-readiness-stan.sh
           bash -n infra/oci/scripts/deploy.sh
           bash -n infra/oci/scripts/live-data-maintenance-stan.sh
+          bash -n infra/oci/scripts/live-betting-control-stan.sh
+          bash -n infra/oci/scripts/revalidate-live-activation-stan.sh
           bash -n infra/oci/scripts/live-betting-data-rollout-stan.sh
           bash -n infra/oci/scripts/shared-mongo-operation-lock-stan.sh
           bash -n infra/oci/scripts/verify-live-betting-data-evidence-stan.sh
           bash -n infra/oci/tests/test-deploy-validation-loop-stan.sh
           bash -n infra/oci/tests/test-live-data-maintenance-stan.sh
+          bash -n infra/oci/tests/test-live-betting-control-stan.sh
+          bash -n infra/oci/tests/test-revalidate-live-activation-stan.sh
           bash -n infra/oci/tests/test-live-betting-data-rollout-stan.sh
           bash -n infra/oci/tests/test-live-betting-readiness-stan.sh
           bash -n infra/oci/tests/rollback-live-readiness-contract.sh
@@ -143,6 +147,8 @@ jobs:
               .github/workflows/production-build.yml
               .github/workflows/production-deploy.yml
               .github/workflows/oci-live-data-rollout.yml
+              .github/workflows/oci-live-betting-activate.yml
+              .github/workflows/oci-live-betting-disable.yml
               .github/workflows/oci-production-deploy.yml
             ].each { |file| YAML.load_stream(File.read(file)) }
           '
@@ -154,6 +160,8 @@ jobs:
           ./infra/azure/agents/test-production-rollback-stan.sh
           ./infra/oci/tests/test-deploy-validation-loop-stan.sh
           ./infra/oci/tests/test-live-data-maintenance-stan.sh
+          ./infra/oci/tests/test-live-betting-control-stan.sh
+          ./infra/oci/tests/test-revalidate-live-activation-stan.sh
           ./infra/oci/tests/test-live-betting-data-rollout-stan.sh
           ./infra/oci/tests/test-live-betting-readiness-stan.sh
           ./infra/oci/tests/rollback-live-readiness-contract.sh

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -40,8 +40,26 @@
 ### Live simulation engine
 - `gamemaster/src/simulation/` is pure and clock-independent: it uses named seeded RNG streams and emits integer offsets, never wall-clock timestamps.
 - The persisted engine version and generated transitions are authoritative for an in-progress match; never regenerate them after an engine change.
+- New simulations use an independent 256-bit lowercase hexadecimal seed. Treat a missing, malformed, short, uppercase, or public-ID-derived seed as unsafe and replace it before persisting the timeline; never expose seeds in public event payloads.
 - Only `GOAL` transitions change the score. Penalty awards resolve later in the same half, and a scored penalty emits a linked goal.
 - Live settlement identity is `marketId + marketVersion`; quote versions track price changes only, and remaining next-event markets settle explicitly to `NONE` at full-time.
+
+### Privileged authorization and synthetic fixtures
+- A signed JWT role is only a request hint. Every privileged mutation and every server-side acceptance-fixture scope must revalidate the current persisted role through auth and fail closed when auth is unavailable.
+- Signup never accepts an administrator role. Persisted demotion or deletion revokes privileged mutations immediately, and `/currentuser` invalidates expired, deleted, or role-mismatched sessions, including bounded legacy tokens without `exp`.
+- Synthetic production-acceptance events remain `OFFLINE`. Ordinary REST and SSE queries exclude them server-side; an acceptance view may request at most ten exact lowercase ObjectIDs and only a currently persisted administrator may receive them.
+- Offline-event odds requests repeat authoritative administrator verification. Client filtering and a stale JWT claim are never security boundaries.
+- Administrative catalog reads are privileged too: `/api/backoffice` revalidates the persisted role and must not return fixture metadata in an unauthorized error.
+- A live update received before `NEW_EVENT` creates an `OFFLINE` projection. Metadata and visibility initialize independently so `NEW_EVENT` can repair legacy/event-visibility-first placeholders without undoing a newer visibility change.
+- A visibility message may arrive before any event row. Persist it as pending on an `OFFLINE` placeholder, then apply it only after authoritative metadata arrives; ambiguous legacy hidden placeholders stay hidden.
+- Competing `NEW_EVENT` and visibility placeholder upserts can race on the unique event ID. Both paths must treat duplicate-key as convergence and retry the pending decision against the winning row before acknowledging.
+- Scoped clients immediately purge cached offline events and refresh authentication when REST or SSE access fails. A bounded authoritative REST reconcile continues while SSE is healthy because visibility removals and pre-match changes may not produce live snapshots.
+
+### Fail-dark live activation
+- `LIVE_KICKOFFS_ENABLED=true` is permanent only when no activation lease is present. A temporary activation also carries `LIVE_KICKOFFS_LEASE_UNTIL_EPOCH`; malformed or expired leases fail dark inside Gamemaster while already-started matches continue.
+- The protected activation workflow first uses a bounded lease. Only the same run and source SHA may remove it, and only after production acceptance, protected evidence upload, and a final current-master/provenance revalidation.
+- Disable and every ambiguous control failure set the flag false and remove the lease together. The lease remains the independent safety boundary if the workflow runner is hard-killed before its cleanup trap can execute.
+- Deployment provenance must bind source SHA, build/deploy attempts, infrastructure artifact digest, runtime mode, and runtime fingerprint. Rechecking current `master` immediately before mutation and commit closes the preflight-to-mutation race.
 
 ---
 
@@ -96,6 +114,7 @@ cd resulting && npm ci && npm run test:ci
 - Skipped, stale, pending, neutral, or unrelated runs are not green gates.
 - A squash promotion breaks shared ancestry until the new `master` commit is merged back into `dev`; perform that synchronization immediately.
 - Manual central production workflow dispatches and reruns are emergency operations requiring an exact full master SHA and `production-emergency` approval. Old central and per-service workflow identities stay disabled so historical definitions cannot be rerun.
+- Live activation and disable are separate protected OCI control-plane workflows. Activation is leased until its complete acceptance evidence is committed; disable may target an older deployed SHA only while that SHA remains an ancestor of current `master`.
 
 ## Resolved failures and durable rules
 

--- a/auth/package.json
+++ b/auth/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "ts-node-dev src/index",
     "dev": "ts-node-dev src/index",
+    "role:set": "ts-node src/scripts/SetUserRole.ts",
     "test": "jest --watchAll --no-cache",
     "test:ci": "jest"
   },

--- a/auth/src/app.ts
+++ b/auth/src/app.ts
@@ -6,6 +6,7 @@ import { currentUserRouter } from "./route/CurrentUser";
 import { loginRouter } from "./route/LogIn";
 import { logoutRouter } from "./route/LogOut";
 import { newUser } from "./route/NewUser";
+import { verifyAdminRouter } from "./route/VerifyAdmin";
 import { errorHandler } from "@betstan/common";
 
 const app = express();
@@ -23,6 +24,7 @@ app.use(currentUserRouter);
 app.use(loginRouter);
 app.use(logoutRouter);
 app.use(newUser);
+app.use(verifyAdminRouter);
 
 app.all("*", async (req, res, next) => {
   //next(new NotFoundError());

--- a/auth/src/middleware/CurrentUser.ts
+++ b/auth/src/middleware/CurrentUser.ts
@@ -1,10 +1,12 @@
 import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 
-interface UserPayload {
+export interface UserPayload {
   id: string;
   email: string;
-  timestamp: Date;
+  role?: "USER" | "ADMIN";
+  timestamp: Date | string;
+  exp?: number;
 }
 
 declare global {

--- a/auth/src/model/User.ts
+++ b/auth/src/model/User.ts
@@ -1,6 +1,11 @@
 import { Schema, model } from "mongoose";
 import { Password } from "../service/Password";
 
+enum UserRole {
+  USER = "USER",
+  ADMIN = "ADMIN",
+}
+
 const userSchema = new Schema({
   email: {
     type: String,
@@ -13,6 +18,12 @@ const userSchema = new Schema({
   password: {
     type: String,
     required: true,
+  },
+  role: {
+    type: String,
+    enum: Object.values(UserRole),
+    required: true,
+    default: UserRole.USER,
   },
   timestamp: {
     type: String,
@@ -39,6 +50,7 @@ userSchema.set("toJSON", {
     return {
       _id: returnedObject._id,
       email: returnedObject.email,
+      role: returnedObject.role,
       timestamp: returnedObject.timestamp,
       lastLogin: returnedObject.lastLogin,
     };
@@ -57,4 +69,4 @@ userSchema.pre("save", async function (done) {
 
 const User = model("User", userSchema);
 
-export { User };
+export { User, UserRole };

--- a/auth/src/route/CurrentUser.ts
+++ b/auth/src/route/CurrentUser.ts
@@ -1,6 +1,10 @@
 import express from "express";
-import { currentUser } from "../middleware/CurrentUser";
+import { currentUser, UserPayload } from "../middleware/CurrentUser";
 import { User } from "../model/User";
+import {
+  isSessionTimestampFresh,
+  normalizeUserRole,
+} from "../service/Session";
 
 const router = express.Router();
 
@@ -9,19 +13,23 @@ router.get("/api/auth/currentuser", currentUser, async (req, res) => {
 
   if (currentUser) {
     const user = await User.findById(currentUser.id);
+    const signedRole = normalizeUserRole(currentUser.role);
+    const persistedRole = normalizeUserRole(user?.role);
 
-    // session token expires evert 12 hours
-    const dateToExpire = currentUser.timestamp
-      ? new Date(
-          new Date(currentUser.timestamp).getTime() + 12 * 60 * 60 * 1000
-        )
-      : new Date().getTime() - 1 * 60 * 60 * 1000;
-
-    if (!user || new Date() > dateToExpire) {
-      console.log("user not found or expired", user, currentUser.email);
-
+    if (
+      !user
+      || !isSessionTimestampFresh(currentUser.timestamp)
+      || signedRole !== persistedRole
+    ) {
       req.session = null;
       currentUser = undefined;
+    } else {
+      currentUser = {
+        id: currentUser.id,
+        email: currentUser.email,
+        role: signedRole,
+        timestamp: currentUser.timestamp,
+      } satisfies UserPayload;
     }
   }
 

--- a/auth/src/route/LogIn.ts
+++ b/auth/src/route/LogIn.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from "express";
 import { body, oneOf } from "express-validator";
-import { User } from "../model/User";
+import { User, UserRole } from "../model/User";
 import { Password } from "../service/Password";
 import jwt from "jsonwebtoken";
 import { BadRequestError, validateRequest } from "@betstan/common";
@@ -76,16 +76,21 @@ router.post(
       {
         id: existingUser.id,
         email: existingUser.email,
+        role: existingUser.role ?? UserRole.USER,
         timestamp: new Date(),
       },
-      process.env.JWT_KEY!
+      process.env.JWT_KEY!,
+      { expiresIn: "12h" }
     );
 
     req.session = {
       jwt: userJwt,
     };
 
-    existingUser.set({ lastLogin: new Date().toISOString() });
+    existingUser.set({
+      lastLogin: new Date().toISOString(),
+      role: existingUser.role ?? UserRole.USER,
+    });
     await existingUser.save();
 
     res.status(200).send(toPublicUser(existingUser));

--- a/auth/src/route/NewUser.ts
+++ b/auth/src/route/NewUser.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from "express";
 import { body, oneOf } from "express-validator";
-import { User } from "../model/User";
+import { User, UserRole } from "../model/User";
 import jwt from "jsonwebtoken";
 import { validateRequest, BadRequestError } from "@betstan/common";
 import {
@@ -62,6 +62,7 @@ router.post(
         email: identifier,
         identifierNormalized,
         password,
+        role: UserRole.USER,
         timestamp: new Date().toISOString(),
         lastLogin: new Date().toISOString(),
       });
@@ -70,9 +71,11 @@ router.post(
         {
           id: user.id,
           email: user.email,
+          role: user.role,
           timestamp: new Date(),
         },
-        process.env.JWT_KEY!
+        process.env.JWT_KEY!,
+        { expiresIn: "12h" }
       );
 
       req.session = {

--- a/auth/src/route/VerifyAdmin.ts
+++ b/auth/src/route/VerifyAdmin.ts
@@ -1,0 +1,43 @@
+import express, { Request, Response } from "express";
+import { currentUser } from "../middleware/CurrentUser";
+import { User, UserRole } from "../model/User";
+import {
+  isSessionTimestampFresh,
+  normalizeUserRole,
+} from "../service/Session";
+
+const router = express.Router();
+
+router.get(
+  "/api/auth/admin/verify",
+  currentUser,
+  async (req: Request, res: Response) => {
+    if (!req.currentUser) {
+      return res.status(401).send();
+    }
+
+    if (!isSessionTimestampFresh(req.currentUser.timestamp)) {
+      req.session = null;
+      return res.status(401).send();
+    }
+
+    if (normalizeUserRole(req.currentUser.role) !== UserRole.ADMIN) {
+      return res.status(403).send();
+    }
+
+    const user = await User.findById(req.currentUser.id).select("role");
+    if (!user) {
+      req.session = null;
+      return res.status(401).send();
+    }
+
+    if (normalizeUserRole(user.role) !== UserRole.ADMIN) {
+      req.session = null;
+      return res.status(403).send();
+    }
+
+    return res.status(204).send();
+  }
+);
+
+export { router as verifyAdminRouter };

--- a/auth/src/route/__test__/CurrentUser.test.ts
+++ b/auth/src/route/__test__/CurrentUser.test.ts
@@ -1,5 +1,7 @@
 import request from "supertest";
 import { app } from "../../app";
+import { User, UserRole } from "../../model/User";
+import { buildSessionCookie } from "../../test/session";
 
 it("returns null if not authenticated", async () => {
   const response = await request(app)
@@ -26,4 +28,78 @@ it("returns current user info when authenticated", async () => {
 
   expect(response.body.currentUser).not.toBeNull();
   expect(response.body.currentUser.email).toEqual("test@test.com");
+  expect(response.body.currentUser.role).toEqual("USER");
+});
+
+it("normalizes a legacy role-free session to USER", async () => {
+  const user = await User.create({
+    email: "legacy-session",
+    identifierNormalized: "legacy-session",
+    password: "password",
+  });
+  await User.collection.updateOne(
+    { _id: user._id },
+    { $unset: { role: "" } }
+  );
+
+  const response = await request(app)
+    .get("/api/auth/currentuser")
+    .set(
+      "Cookie",
+      buildSessionCookie({
+        id: user.id,
+        email: user.email,
+        timestamp: new Date(),
+      })
+    )
+    .expect(200);
+
+  expect(response.body.currentUser.role).toEqual("USER");
+});
+
+it("clears an existing session when the persisted role changes", async () => {
+  const user = await User.create({
+    email: "demoted-session",
+    identifierNormalized: "demoted-session",
+    password: "password",
+    role: UserRole.ADMIN,
+  });
+  const cookie = buildSessionCookie({
+    id: user.id,
+    email: user.email,
+    role: UserRole.ADMIN,
+    timestamp: new Date(),
+  });
+  await User.updateOne({ _id: user._id }, { $set: { role: UserRole.USER } });
+
+  const response = await request(app)
+    .get("/api/auth/currentuser")
+    .set("Cookie", cookie)
+    .expect(200);
+
+  expect(response.body.currentUser).toBeNull();
+});
+
+it("expires legacy tokens without exp from their signed timestamp", async () => {
+  const user = await User.create({
+    email: "expired-session",
+    identifierNormalized: "expired-session",
+    password: "password",
+    role: UserRole.USER,
+  });
+
+  const response = await request(app)
+    .get("/api/auth/currentuser")
+    .set(
+      "Cookie",
+      buildSessionCookie({
+        id: user.id,
+        email: user.email,
+        role: UserRole.USER,
+        timestamp: new Date(Date.now() - 13 * 60 * 60 * 1000),
+      })
+    )
+    .expect(200);
+
+  expect(response.body.currentUser).toBeNull();
 });

--- a/auth/src/route/__test__/LogIn.test.ts
+++ b/auth/src/route/__test__/LogIn.test.ts
@@ -1,12 +1,25 @@
 import request from "supertest";
+import jwt from "jsonwebtoken";
 import { app } from "../../app";
-import { User } from "../../model/User";
+import { User, UserRole } from "../../model/User";
 
 const createUser = async (identifier = "test@test.com") => {
   await request(app)
     .post("/api/auth/new")
     .send({ email: identifier, password: "password" })
     .expect(201);
+};
+
+const sessionPayload = (setCookie: string[]) => {
+  const encodedSession = /^session=([^;]+)/.exec(setCookie[0])?.[1];
+  if (!encodedSession) {
+    throw new Error("Session cookie was not set");
+  }
+
+  const session = JSON.parse(
+    Buffer.from(decodeURIComponent(encodedSession), "base64").toString("utf8")
+  );
+  return jwt.verify(session.jwt, process.env.JWT_KEY!) as jwt.JwtPayload;
 };
 
 it("logs in with a non-email username regardless of case", async () => {
@@ -20,10 +33,31 @@ it("logs in with a non-email username regardless of case", async () => {
   expect(response.body).toEqual({
     id: expect.any(String),
     email: "Stan_1",
+    role: "USER",
   });
   expect(response.body.password).toBeUndefined();
   expect(response.body.identifierNormalized).toBeUndefined();
   expect(response.get("Set-Cookie")).toBeDefined();
+  const payload = sessionPayload(response.get("Set-Cookie")!);
+  expect(payload.role).toEqual("USER");
+  expect(Number(payload.exp) - Number(payload.iat)).toEqual(12 * 60 * 60);
+});
+
+it("signs the persisted administrator role after login", async () => {
+  const user = await User.create({
+    email: "admin-user",
+    identifierNormalized: "admin-user",
+    password: "password",
+    role: UserRole.ADMIN,
+  });
+
+  const response = await request(app)
+    .post("/api/auth/login")
+    .send({ email: user.email, password: "password" })
+    .expect(200);
+
+  expect(response.body.role).toEqual("ADMIN");
+  expect(sessionPayload(response.get("Set-Cookie")!).role).toEqual("ADMIN");
 });
 
 it("continues to log in a legacy email record", async () => {
@@ -38,6 +72,28 @@ it("continues to log in a legacy email record", async () => {
     .post("/api/auth/login")
     .send({ email: "Legacy@Test.com", password: "password" })
     .expect(200);
+});
+
+it("normalizes a legacy user without a role to USER", async () => {
+  const user = await User.create({
+    email: "legacy-role-user",
+    identifierNormalized: "legacy-role-user",
+    password: "password",
+  });
+  await User.collection.updateOne(
+    { _id: user._id },
+    { $unset: { role: "" } }
+  );
+
+  const response = await request(app)
+    .post("/api/auth/login")
+    .send({ email: "legacy-role-user", password: "password" })
+    .expect(200);
+
+  expect(response.body.role).toEqual("USER");
+  expect((await User.collection.findOne({ _id: user._id }))?.role).toEqual(
+    "USER"
+  );
 });
 
 it.each(["Pelé@example.com", '"quoted local"@example.com'])(

--- a/auth/src/route/__test__/NewUser.test.ts
+++ b/auth/src/route/__test__/NewUser.test.ts
@@ -1,6 +1,19 @@
 import request from "supertest";
+import jwt from "jsonwebtoken";
 import { app } from "../../app";
 import { User } from "../../model/User";
+
+const sessionPayload = (setCookie: string[]) => {
+  const encodedSession = /^session=([^;]+)/.exec(setCookie[0])?.[1];
+  if (!encodedSession) {
+    throw new Error("Session cookie was not set");
+  }
+
+  const session = JSON.parse(
+    Buffer.from(decodeURIComponent(encodedSession), "base64").toString("utf8")
+  );
+  return jwt.verify(session.jwt, process.env.JWT_KEY!) as jwt.JwtPayload;
+};
 
 it("creates an account with a non-email username", async () => {
   const response = await request(app)
@@ -11,12 +24,24 @@ it("creates an account with a non-email username", async () => {
   expect(response.body).toEqual({
     id: expect.any(String),
     email: "stan_1",
+    role: "USER",
   });
   expect(response.body.password).toBeUndefined();
   expect(response.body.identifierNormalized).toBeUndefined();
 
   const user = await User.findOne({ email: "stan_1" });
   expect(user?.identifierNormalized).toEqual("stan_1");
+  expect(user?.role).toEqual("USER");
+});
+
+it("ignores attempts to self-register as an administrator", async () => {
+  const response = await request(app)
+    .post("/api/auth/new")
+    .send({ email: "not-an-admin", password: "password", role: "ADMIN" })
+    .expect(201);
+
+  expect(response.body.role).toEqual("USER");
+  expect((await User.findById(response.body.id))?.role).toEqual("USER");
 });
 
 it.each([
@@ -114,4 +139,7 @@ it("sets a cookie after successful signup", async () => {
     .expect(201);
 
   expect(response.get("Set-Cookie")).toBeDefined();
+  const payload = sessionPayload(response.get("Set-Cookie")!);
+  expect(payload.role).toEqual("USER");
+  expect(Number(payload.exp) - Number(payload.iat)).toEqual(12 * 60 * 60);
 });

--- a/auth/src/route/__test__/VerifyAdmin.test.ts
+++ b/auth/src/route/__test__/VerifyAdmin.test.ts
@@ -1,0 +1,89 @@
+import request from "supertest";
+import { app } from "../../app";
+import { User, UserRole } from "../../model/User";
+import { buildSessionCookie } from "../../test/session";
+
+async function loginAsAdmin() {
+  const user = await User.create({
+    email: "admin-user",
+    identifierNormalized: "admin-user",
+    password: "password",
+    role: UserRole.ADMIN,
+  });
+  const response = await request(app)
+    .post("/api/auth/login")
+    .send({ email: user.email, password: "password" })
+    .expect(200);
+
+  return {
+    cookie: response.get("Set-Cookie")!,
+    user,
+  };
+}
+
+it("rejects a missing session", async () => {
+  await request(app).get("/api/auth/admin/verify").expect(401);
+});
+
+it("rejects an authenticated non-admin user", async () => {
+  const signup = await request(app)
+    .post("/api/auth/new")
+    .send({ email: "standard-user", password: "password" })
+    .expect(201);
+
+  await request(app)
+    .get("/api/auth/admin/verify")
+    .set("Cookie", signup.get("Set-Cookie")!)
+    .expect(403);
+});
+
+it("accepts a signed token whose persisted user remains an administrator", async () => {
+  const { cookie } = await loginAsAdmin();
+
+  await request(app)
+    .get("/api/auth/admin/verify")
+    .set("Cookie", cookie)
+    .expect(204);
+});
+
+it("revokes an existing admin token after the persisted role is demoted", async () => {
+  const { cookie, user } = await loginAsAdmin();
+  await User.updateOne({ _id: user._id }, { $set: { role: UserRole.USER } });
+
+  await request(app)
+    .get("/api/auth/admin/verify")
+    .set("Cookie", cookie)
+    .expect(403);
+});
+
+it("revokes an existing admin token after the user is deleted", async () => {
+  const { cookie, user } = await loginAsAdmin();
+  await User.deleteOne({ _id: user._id });
+
+  await request(app)
+    .get("/api/auth/admin/verify")
+    .set("Cookie", cookie)
+    .expect(401);
+});
+
+it("rejects an expired legacy administrator token without exp", async () => {
+  const user = await User.create({
+    email: "expired-admin",
+    identifierNormalized: "expired-admin",
+    password: "password",
+    role: UserRole.ADMIN,
+  });
+
+  await request(app)
+    .get("/api/auth/admin/verify")
+    .set(
+      "Cookie",
+      buildSessionCookie({
+        id: user.id,
+        email: user.email,
+        role: UserRole.ADMIN,
+        timestamp: new Date(Date.now() - 13 * 60 * 60 * 1000),
+      })
+    )
+    .expect(401);
+});

--- a/auth/src/scripts/SetUserRole.ts
+++ b/auth/src/scripts/SetUserRole.ts
@@ -1,0 +1,54 @@
+import mongoose from "mongoose";
+import { User, UserRole } from "../model/User";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} must be set`);
+  }
+
+  return value;
+}
+
+async function setUserRole() {
+  const mongoUri = requiredEnv("MONGO_URI");
+  const userId = requiredEnv("USER_ID");
+  const roleValue = requiredEnv("USER_ROLE");
+  const confirmation = requiredEnv("USER_ROLE_CHANGE_CONFIRMATION");
+
+  if (!mongoose.isValidObjectId(userId)) {
+    throw new Error("USER_ID must be a valid MongoDB object ID");
+  }
+
+  if (!Object.values(UserRole).includes(roleValue as UserRole)) {
+    throw new Error("USER_ROLE must be USER or ADMIN");
+  }
+
+  if (confirmation !== `SET_ROLE:${userId}:${roleValue}`) {
+    throw new Error(
+      "USER_ROLE_CHANGE_CONFIRMATION does not match the requested change"
+    );
+  }
+
+  await mongoose.connect(mongoUri);
+  const result = await User.updateOne(
+    { _id: userId },
+    { $set: { role: roleValue as UserRole } }
+  );
+
+  if (result.matchedCount !== 1) {
+    throw new Error("User was not found");
+  }
+
+  console.log(`Updated role for user ${userId}`);
+}
+
+setUserRole()
+  .then(async () => {
+    await mongoose.disconnect();
+  })
+  .catch(async (error) => {
+    console.error(error instanceof Error ? error.message : "Role update failed");
+    await mongoose.disconnect();
+    process.exitCode = 1;
+  });

--- a/auth/src/service/Identifier.ts
+++ b/auth/src/service/Identifier.ts
@@ -1,6 +1,7 @@
 type PublicUserSource = {
   _id: unknown;
   email: string;
+  role?: string;
 };
 
 export const usernamePattern = /^[A-Za-z0-9][A-Za-z0-9._%+@-]*$/;
@@ -11,6 +12,7 @@ export const normalizeIdentifier = (identifier: string) =>
 export const toPublicUser = (user: PublicUserSource) => ({
   id: String(user._id),
   email: user.email,
+  role: user.role ?? "USER",
 });
 
 export const isDuplicateKeyError = (error: unknown) =>

--- a/auth/src/service/Session.ts
+++ b/auth/src/service/Session.ts
@@ -1,0 +1,23 @@
+import { UserRole } from "../model/User";
+
+const SESSION_MAX_AGE_MS = 12 * 60 * 60 * 1000;
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+export const normalizeUserRole = (role: unknown): UserRole =>
+  role === UserRole.ADMIN ? UserRole.ADMIN : UserRole.USER;
+
+export const isSessionTimestampFresh = (
+  timestamp: Date | string | undefined,
+  nowMs = Date.now()
+): boolean => {
+  if (!timestamp) {
+    return false;
+  }
+
+  const timestampMs = new Date(timestamp).getTime();
+  return (
+    Number.isFinite(timestampMs)
+    && timestampMs <= nowMs + MAX_CLOCK_SKEW_MS
+    && nowMs <= timestampMs + SESSION_MAX_AGE_MS
+  );
+};

--- a/auth/src/test/session.ts
+++ b/auth/src/test/session.ts
@@ -1,0 +1,19 @@
+import jwt from "jsonwebtoken";
+
+type TestSessionPayload = {
+  id: string;
+  email: string;
+  role?: "USER" | "ADMIN";
+  timestamp: Date | string;
+};
+
+export const buildSessionCookie = (
+  payload: TestSessionPayload
+): string[] => {
+  const token = jwt.sign(payload, process.env.JWT_KEY!);
+  const session = Buffer.from(JSON.stringify({ jwt: token })).toString(
+    "base64"
+  );
+
+  return [`session=${encodeURIComponent(session)}`];
+};

--- a/backoffice/src/index.ts
+++ b/backoffice/src/index.ts
@@ -12,6 +12,9 @@ const startUp = async () => {
   if (!process.env.MONGO_URI) {
     throw new Error("Missing MONGO_URI variable");
   }
+  if (!process.env.AUTH_SERVICE_URL) {
+    throw new Error("Missing AUTH_SERVICE_URL variable");
+  }
 
   try {
     console.log("Connecting to: ", process.env.RABBITMQ_URI);

--- a/backoffice/src/middleware/RequireAdmin.ts
+++ b/backoffice/src/middleware/RequireAdmin.ts
@@ -1,0 +1,56 @@
+import { NextFunction, Request, Response } from "express";
+import {
+  AdminSessionVerifier,
+  verifyAdminSession,
+} from "../service/VerifyAdminSession";
+
+let sessionVerifier: AdminSessionVerifier = verifyAdminSession;
+
+export const setAdminSessionVerifierForTests = (
+  verifier: AdminSessionVerifier
+) => {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error("Admin session verifier can only be replaced in tests");
+  }
+
+  sessionVerifier = verifier;
+};
+
+export const requireAdmin = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (!req.currentUser) {
+    return res.status(401).send({
+      errors: [{ message: "Authentication required" }],
+    });
+  }
+
+  const role = (req.currentUser as typeof req.currentUser & { role?: string })
+    .role;
+  if (role !== "ADMIN") {
+    return res.status(403).send({
+      errors: [{ message: "Administrator role required" }],
+    });
+  }
+
+  try {
+    const status = await sessionVerifier(req.headers.cookie ?? "");
+    if (status === 204) {
+      next();
+      return;
+    }
+
+    const message =
+      status === 401
+        ? "Authentication required"
+        : "Administrator role required";
+    res.status(status).send({ errors: [{ message }] });
+  } catch (_error) {
+    console.error("Administrator session verification failed");
+    res.status(503).send({
+      errors: [{ message: "Authorization service unavailable" }],
+    });
+  }
+};

--- a/backoffice/src/route/EventVisibility.ts
+++ b/backoffice/src/route/EventVisibility.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express";
 import { Event } from "../model/Event";
 import { EventVisibility, messengerWrapper } from "@betstan/common";
 import EventVisibilityPublisher from "../event/publisher/EventVisibilityPublisher";
+import { requireAdmin } from "../middleware/RequireAdmin";
 
 const router = express.Router();
 
@@ -16,6 +17,7 @@ const getPublisher = async (): Promise<EventVisibilityPublisher> => {
 
 router.post(
   "/api/backoffice/event_visibility",
+  requireAdmin,
   async (req: Request, res: Response) => {
     const { eventId } = req.body;
     const event = await Event.findOne({ eventId: eventId });

--- a/backoffice/src/route/NewEvent.ts
+++ b/backoffice/src/route/NewEvent.ts
@@ -1,8 +1,13 @@
 import express, { Request, Response } from "express";
 import { Event } from "../model/Event";
 import NewEventPublisher from "../event/publisher/NewEventPublisher";
-import { EventStatus, messengerWrapper } from "@betstan/common";
+import {
+  EventStatus,
+  EventVisibility,
+  messengerWrapper,
+} from "@betstan/common";
 import mongoose from "mongoose";
+import { requireAdmin } from "../middleware/RequireAdmin";
 
 const router = express.Router();
 
@@ -17,16 +22,33 @@ const getPublisher = async (): Promise<NewEventPublisher> => {
 
 router.post(
   "/api/backoffice/new_event",
+  requireAdmin,
   async (req: Request, res: Response) => {
-    const { home, away } = req.body;
+    const { home, away, kickoffDelaySeconds } = req.body;
+    const visibility = req.body.visibility ?? EventVisibility.ONLINE;
 
     if (!home || !away) {
       res.send({});
       return;
     }
 
-    // all custom events will "run" in 30 minutes
-    const eventTime = new Date(new Date().getTime() + 30 * 60 * 1000);
+    const delaySeconds = kickoffDelaySeconds ?? 30 * 60;
+    if (
+      !Number.isInteger(delaySeconds)
+      || delaySeconds < 15
+      || delaySeconds > 24 * 60 * 60
+    ) {
+      res.status(400).send({
+        message: "Kickoff delay must be between 15 seconds and 24 hours",
+      });
+      return;
+    }
+    if (!Object.values(EventVisibility).includes(visibility)) {
+      res.status(400).send({ message: "Event visibility is invalid" });
+      return;
+    }
+
+    const eventTime = new Date(Date.now() + delaySeconds * 1000);
 
     const event = new Event({
       eventId: new mongoose.Types.ObjectId().toHexString(),
@@ -35,21 +57,24 @@ router.post(
       home: home,
       away: away,
       status: EventStatus.NO_RESULT,
+      visibility,
     });
 
     await event.save();
 
     const publisher = await getPublisher();
 
-    publisher.publish({
+    const newEventMessage = {
       data: {
         id: event.eventId,
         name: event.name,
         time: event.time,
         home: event.home,
         away: event.away,
+        visibility,
       },
-    });
+    };
+    publisher.publish(newEventMessage);
 
     res.send({ event });
   }

--- a/backoffice/src/route/SetResult.ts
+++ b/backoffice/src/route/SetResult.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express";
 import { Event } from "../model/Event";
 import ResultSetPublisher from "../event/publisher/ResultSetPublisher";
 import { EventStatus, messengerWrapper } from "@betstan/common";
+import { requireAdmin } from "../middleware/RequireAdmin";
 
 const router = express.Router();
 
@@ -14,7 +15,7 @@ const getPublisher = async (): Promise<ResultSetPublisher> => {
   return _publisher;
 };
 
-router.post("/api/backoffice/result", async (req: Request, res: Response) => {
+router.post("/api/backoffice/result", requireAdmin, async (req: Request, res: Response) => {
   let { eventId, homeResult, awayResult } = req.body;
 
   const event = await Event.findOne({ eventId: eventId });

--- a/backoffice/src/route/ShowEvents.ts
+++ b/backoffice/src/route/ShowEvents.ts
@@ -1,12 +1,17 @@
 import express, { Request, Response } from "express";
 import { Event } from "../model/Event";
+import { requireAdmin } from "../middleware/RequireAdmin";
 
 const router = express.Router();
 
-router.get("/api/backoffice", async (req: Request, res: Response) => {
-  const events = await Event.find().sort({ status: 1, time: 1 });
+router.get(
+  "/api/backoffice",
+  requireAdmin,
+  async (req: Request, res: Response) => {
+    const events = await Event.find().sort({ status: 1, time: 1 });
 
-  res.send(events);
-});
+    res.send(events);
+  }
+);
 
 export { router as ShowEvents };

--- a/backoffice/src/route/__test__/Authorization.test.ts
+++ b/backoffice/src/route/__test__/Authorization.test.ts
@@ -1,0 +1,120 @@
+import request from "supertest";
+import { app } from "../../app";
+import { buildSessionCookie } from "../../test/session";
+import { setAdminSessionVerifierForTests } from "../../middleware/RequireAdmin";
+import { Event } from "../../model/Event";
+import { EventStatus, EventVisibility } from "@betstan/common";
+
+const mutations = [
+  {
+    path: "/api/backoffice/new_event",
+    body: { home: "Team A", away: "Team B" },
+  },
+  {
+    path: "/api/backoffice/result",
+    body: { eventId: "event-id", homeResult: 1, awayResult: 0 },
+  },
+  {
+    path: "/api/backoffice/event_visibility",
+    body: { eventId: "event-id" },
+  },
+];
+
+it("does not disclose offline fixtures to anonymous reads", async () => {
+  await Event.create({
+    eventId: "offline-secret",
+    name: "Private acceptance fixture",
+    time: new Date(),
+    home: "Private",
+    away: "Fixture",
+    status: EventStatus.NO_RESULT,
+    visibility: EventVisibility.OFFLINE,
+  });
+
+  const response = await request(app).get("/api/backoffice").expect(401);
+
+  expect(JSON.stringify(response.body)).not.toContain(
+    "Private acceptance fixture"
+  );
+});
+
+it.each([
+  { name: "ordinary users", role: "USER" as const },
+  { name: "legacy sessions", role: undefined },
+])("rejects backoffice reads from $name", async ({ role }) => {
+  await request(app)
+    .get("/api/backoffice")
+    .set("Cookie", buildSessionCookie(role))
+    .expect(403);
+});
+
+it("rejects backoffice reads after persisted-role revocation", async () => {
+  setAdminSessionVerifierForTests(async () => 403);
+
+  await request(app)
+    .get("/api/backoffice")
+    .set("Cookie", buildSessionCookie("ADMIN"))
+    .expect(403);
+});
+
+it("fails backoffice reads closed when persisted-role verification is unavailable", async () => {
+  setAdminSessionVerifierForTests(async () => {
+    throw new Error("auth unavailable");
+  });
+
+  await request(app)
+    .get("/api/backoffice")
+    .set("Cookie", buildSessionCookie("ADMIN"))
+    .expect(503);
+});
+
+it.each(mutations)(
+  "rejects unauthenticated $path mutations",
+  async ({ path, body }) => {
+    await request(app).post(path).send(body).expect(401);
+  }
+);
+
+it("rejects a locally valid admin token after auth revokes it", async () => {
+  setAdminSessionVerifierForTests(async () => 403);
+
+  await request(app)
+    .post("/api/backoffice/new_event")
+    .set("Cookie", buildSessionCookie("ADMIN"))
+    .send({ home: "Team A", away: "Team B" })
+    .expect(403);
+});
+
+it("fails closed when persisted-role verification is unavailable", async () => {
+  setAdminSessionVerifierForTests(async () => {
+    throw new Error("auth unavailable");
+  });
+
+  await request(app)
+    .post("/api/backoffice/new_event")
+    .set("Cookie", buildSessionCookie("ADMIN"))
+    .send({ home: "Team A", away: "Team B" })
+    .expect(503);
+});
+
+it.each(mutations)(
+  "rejects non-admin $path mutations",
+  async ({ path, body }) => {
+    await request(app)
+      .post(path)
+      .set("Cookie", buildSessionCookie("USER"))
+      .send(body)
+      .expect(403);
+  }
+);
+
+it.each(mutations)(
+  "rejects legacy no-role $path mutations",
+  async ({ path, body }) => {
+    await request(app)
+      .post(path)
+      .set("Cookie", buildSessionCookie())
+      .send(body)
+      .expect(403);
+  }
+);

--- a/backoffice/src/route/__test__/EventVisibility.test.ts
+++ b/backoffice/src/route/__test__/EventVisibility.test.ts
@@ -3,6 +3,9 @@ import { app } from "../../app";
 import { Event } from "../../model/Event";
 import { EventStatus, EventVisibility as EventVisibilityStatus } from "@betstan/common";
 import EventVisibilityPublisher from "../../event/publisher/EventVisibilityPublisher";
+import { buildSessionCookie } from "../../test/session";
+
+const adminCookie = () => buildSessionCookie("ADMIN");
 
 const createEvent = async (eventId: string, visibility = EventVisibilityStatus.ONLINE) => {
   return Event.create({
@@ -19,6 +22,7 @@ const createEvent = async (eventId: string, visibility = EventVisibilityStatus.O
 it("returns message when event not found", async () => {
   const response = await request(app)
     .post("/api/backoffice/event_visibility")
+    .set("Cookie", adminCookie())
     .send({ eventId: "nonexistent" })
     .expect(200);
 
@@ -30,6 +34,7 @@ it("flips event visibility from ONLINE to OFFLINE", async () => {
 
   const response = await request(app)
     .post("/api/backoffice/event_visibility")
+    .set("Cookie", adminCookie())
     .send({ eventId: "evt-1" })
     .expect(200);
 
@@ -42,6 +47,7 @@ it("flips event visibility from OFFLINE to ONLINE", async () => {
 
   const response = await request(app)
     .post("/api/backoffice/event_visibility")
+    .set("Cookie", adminCookie())
     .send({ eventId: "evt-2" })
     .expect(200);
 
@@ -54,6 +60,7 @@ it("defaults corrupted visibility to OFFLINE before publishing", async () => {
 
   const response = await request(app)
     .post("/api/backoffice/event_visibility")
+    .set("Cookie", adminCookie())
     .send({ eventId: "evt-3" })
     .expect(200);
 

--- a/backoffice/src/route/__test__/NewEvent.test.ts
+++ b/backoffice/src/route/__test__/NewEvent.test.ts
@@ -1,12 +1,16 @@
 import request from "supertest";
 import { app } from "../../app";
 import { Event } from "../../model/Event";
-import { EventStatus } from "@betstan/common";
+import { EventStatus, EventVisibility } from "@betstan/common";
 import NewEventPublisher from "../../event/publisher/NewEventPublisher";
+import { buildSessionCookie } from "../../test/session";
+
+const adminCookie = () => buildSessionCookie("ADMIN");
 
 it("returns empty object when home or away is missing", async () => {
   const response = await request(app)
     .post("/api/backoffice/new_event")
+    .set("Cookie", adminCookie())
     .send({ home: "Team A" })
     .expect(200);
 
@@ -14,8 +18,10 @@ it("returns empty object when home or away is missing", async () => {
 });
 
 it("creates a new event and publishes it", async () => {
+  const beforeRequest = Date.now();
   const response = await request(app)
     .post("/api/backoffice/new_event")
+    .set("Cookie", adminCookie())
     .send({ home: "Team A", away: "Team B" })
     .expect(200);
 
@@ -23,9 +29,76 @@ it("creates a new event and publishes it", async () => {
   expect(response.body.event.home).toEqual("Team A");
   expect(response.body.event.away).toEqual("Team B");
   expect(response.body.event.status).toEqual(EventStatus.NO_RESULT);
+  expect(new Date(response.body.event.time).getTime()).toBeGreaterThanOrEqual(
+    beforeRequest + 30 * 60 * 1000
+  );
 
   const storedEvent = await Event.findOne({ eventId: response.body.event.eventId });
   expect(storedEvent).not.toBeNull();
 
   expect(NewEventPublisher.prototype.publish).toHaveBeenCalledTimes(1);
 });
+
+it("allows an administrator to schedule a bounded near-term kickoff", async () => {
+  const beforeRequest = Date.now();
+  const response = await request(app)
+    .post("/api/backoffice/new_event")
+    .set("Cookie", adminCookie())
+    .send({
+      home: "Team A",
+      away: "Team B",
+      kickoffDelaySeconds: 15,
+    })
+    .expect(200);
+
+  const kickoffTime = new Date(response.body.event.time).getTime();
+  expect(kickoffTime).toBeGreaterThanOrEqual(beforeRequest + 15 * 1000);
+  expect(kickoffTime).toBeLessThan(beforeRequest + 16 * 1000);
+});
+
+it("creates an offline event without exposing it during acceptance setup", async () => {
+  const response = await request(app)
+    .post("/api/backoffice/new_event")
+    .set("Cookie", adminCookie())
+    .send({
+      home: "Hidden A",
+      away: "Hidden B",
+      visibility: EventVisibility.OFFLINE,
+    })
+    .expect(200);
+
+  expect(response.body.event.visibility).toEqual(EventVisibility.OFFLINE);
+  expect(NewEventPublisher.prototype.publish).toHaveBeenCalledWith({
+    data: expect.objectContaining({
+      id: response.body.event.eventId,
+      visibility: EventVisibility.OFFLINE,
+    }),
+  });
+});
+
+it("rejects an invalid event visibility", async () => {
+  await request(app)
+    .post("/api/backoffice/new_event")
+    .set("Cookie", adminCookie())
+    .send({
+      home: "Team A",
+      away: "Team B",
+      visibility: "PRIVATE",
+    })
+    .expect(400);
+
+  expect(NewEventPublisher.prototype.publish).not.toHaveBeenCalled();
+});
+
+it.each([14, 86401, 15.5, "15"])(
+  "rejects an invalid kickoff delay of %s",
+  async (kickoffDelaySeconds) => {
+    await request(app)
+      .post("/api/backoffice/new_event")
+      .set("Cookie", adminCookie())
+      .send({ home: "Team A", away: "Team B", kickoffDelaySeconds })
+      .expect(400);
+
+    expect(NewEventPublisher.prototype.publish).not.toHaveBeenCalled();
+  }
+);

--- a/backoffice/src/route/__test__/SetResult.test.ts
+++ b/backoffice/src/route/__test__/SetResult.test.ts
@@ -3,6 +3,9 @@ import { app } from "../../app";
 import { Event } from "../../model/Event";
 import { EventStatus } from "@betstan/common";
 import ResultSetPublisher from "../../event/publisher/ResultSetPublisher";
+import { buildSessionCookie } from "../../test/session";
+
+const adminCookie = () => buildSessionCookie("ADMIN");
 
 const createEvent = async (eventId: string, status = EventStatus.NO_RESULT) => {
   return Event.create({
@@ -18,6 +21,7 @@ const createEvent = async (eventId: string, status = EventStatus.NO_RESULT) => {
 it("returns 400 when event not found", async () => {
   const response = await request(app)
     .post("/api/backoffice/result")
+    .set("Cookie", adminCookie())
     .send({ eventId: "nonexistent", homeResult: 2, awayResult: 1 })
     .expect(400);
 
@@ -29,6 +33,7 @@ it("sets result and publishes event", async () => {
 
   const response = await request(app)
     .post("/api/backoffice/result")
+    .set("Cookie", adminCookie())
     .send({ eventId: "evt-1", homeResult: 3, awayResult: 1 })
     .expect(200);
 
@@ -44,6 +49,7 @@ it("returns event without change if already resulted", async () => {
 
   const response = await request(app)
     .post("/api/backoffice/result")
+    .set("Cookie", adminCookie())
     .send({ eventId: "evt-2", homeResult: 1, awayResult: 0 })
     .expect(200);
 
@@ -56,6 +62,7 @@ it("defaults invalid scores to 0", async () => {
 
   const response = await request(app)
     .post("/api/backoffice/result")
+    .set("Cookie", adminCookie())
     .send({ eventId: "evt-3" })
     .expect(200);
 

--- a/backoffice/src/route/__test__/ShowEvents.test.ts
+++ b/backoffice/src/route/__test__/ShowEvents.test.ts
@@ -2,10 +2,12 @@ import request from "supertest";
 import { app } from "../../app";
 import { Event } from "../../model/Event";
 import { EventStatus } from "@betstan/common";
+import { buildSessionCookie } from "../../test/session";
 
 it("returns empty array when no events exist", async () => {
   const response = await request(app)
     .get("/api/backoffice")
+    .set("Cookie", buildSessionCookie("ADMIN"))
     .send()
     .expect(200);
 
@@ -34,6 +36,7 @@ it("returns all events sorted by status and time", async () => {
 
   const response = await request(app)
     .get("/api/backoffice")
+    .set("Cookie", buildSessionCookie("ADMIN"))
     .send()
     .expect(200);
 

--- a/backoffice/src/service/VerifyAdminSession.ts
+++ b/backoffice/src/service/VerifyAdminSession.ts
@@ -1,0 +1,52 @@
+import http from "http";
+import https from "https";
+
+const VERIFICATION_TIMEOUT_MS = 3000;
+
+export type AdminVerificationStatus = 204 | 401 | 403;
+export type AdminSessionVerifier = (
+  cookieHeader: string
+) => Promise<AdminVerificationStatus>;
+
+export const verifyAdminSession: AdminSessionVerifier = (cookieHeader) => {
+  const serviceUrl = process.env.AUTH_SERVICE_URL;
+  if (!serviceUrl) {
+    return Promise.reject(new Error("AUTH_SERVICE_URL is not configured"));
+  }
+
+  const url = new URL("/api/auth/admin/verify", serviceUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return Promise.reject(new Error("AUTH_SERVICE_URL must use HTTP or HTTPS"));
+  }
+
+  const transport = url.protocol === "https:" ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const request = transport.request(
+      url,
+      {
+        method: "GET",
+        headers: {
+          Cookie: cookieHeader,
+        },
+        timeout: VERIFICATION_TIMEOUT_MS,
+      },
+      (response) => {
+        response.resume();
+        const status = response.statusCode;
+        if (status === 204 || status === 401 || status === 403) {
+          resolve(status);
+          return;
+        }
+
+        reject(new Error(`Unexpected auth verification status ${status}`));
+      }
+    );
+
+    request.on("timeout", () => {
+      request.destroy(new Error("Auth verification timed out"));
+    });
+    request.on("error", reject);
+    request.end();
+  });
+};

--- a/backoffice/src/service/__test__/VerifyAdminSession.test.ts
+++ b/backoffice/src/service/__test__/VerifyAdminSession.test.ts
@@ -1,0 +1,60 @@
+import http from "http";
+import { AddressInfo } from "net";
+import { verifyAdminSession } from "../VerifyAdminSession";
+
+let server: http.Server | undefined;
+
+afterEach(async () => {
+  delete process.env.AUTH_SERVICE_URL;
+  if (server) {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => (error ? reject(error) : resolve()));
+    });
+    server = undefined;
+  }
+});
+
+async function startAuthStub(status: number) {
+  let receivedCookie: string | undefined;
+  server = http.createServer((request, response) => {
+    receivedCookie = request.headers.cookie;
+    response.statusCode = status;
+    response.end();
+  });
+  await new Promise<void>((resolve) => {
+    server?.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  process.env.AUTH_SERVICE_URL = `http://127.0.0.1:${address.port}`;
+
+  return () => receivedCookie;
+}
+
+it.each([204, 401, 403] as const)(
+  "returns the supported auth verification status %s",
+  async (status) => {
+    const receivedCookie = await startAuthStub(status);
+
+    await expect(verifyAdminSession("session=signed")).resolves.toBe(status);
+    expect(receivedCookie()).toBe("session=signed");
+  }
+);
+
+it("rejects an unexpected auth response", async () => {
+  await startAuthStub(500);
+
+  await expect(verifyAdminSession("session=signed")).rejects.toThrow(
+    "Unexpected auth verification status 500"
+  );
+});
+
+it("rejects a missing or unsupported auth service URL", async () => {
+  await expect(verifyAdminSession("session=signed")).rejects.toThrow(
+    "AUTH_SERVICE_URL is not configured"
+  );
+
+  process.env.AUTH_SERVICE_URL = "file:///tmp/auth";
+  await expect(verifyAdminSession("session=signed")).rejects.toThrow(
+    "AUTH_SERVICE_URL must use HTTP or HTTPS"
+  );
+});

--- a/backoffice/src/test/session.ts
+++ b/backoffice/src/test/session.ts
@@ -1,0 +1,15 @@
+import jwt from "jsonwebtoken";
+
+export function buildSessionCookie(role?: "USER" | "ADMIN"): string[] {
+  const token = jwt.sign(
+    {
+      id: "test-user-id",
+      email: "test@example.com",
+      ...(role ? { role } : {}),
+    },
+    process.env.JWT_KEY as string
+  );
+  const session = Buffer.from(JSON.stringify({ jwt: token })).toString("base64");
+
+  return [`session=${session}`];
+}

--- a/backoffice/src/test/setup.ts
+++ b/backoffice/src/test/setup.ts
@@ -1,5 +1,6 @@
 import { MongoMemoryServer } from "mongodb-memory-server";
 import mongoose from "mongoose";
+import { setAdminSessionVerifierForTests } from "../middleware/RequireAdmin";
 
 jest.mock("@betstan/common", () => {
   const actual = jest.requireActual("@betstan/common");
@@ -55,6 +56,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   jest.clearAllMocks();
+  setAdminSessionVerifierForTests(async () => 204);
   const collections = await mongoose.connection.db.collections();
 
   for (let collection of collections) {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -32,6 +32,17 @@ const App = () => {
   const [slipRefreshSignal, setSlipRefreshSignal] = useState(0);
   const [statsRefreshToken, setStatsRefreshToken] = useState(0);
   const [backofficeRefreshToken, setBackofficeRefreshToken] = useState(0);
+  const visibleOfflineEventIds = useMemo(() => {
+    if (currentUser?.role !== 'ADMIN') {
+      return new Set();
+    }
+
+    const rawIds = new URLSearchParams(location.search)
+      .get('acceptanceEventIds')
+      ?.split(',')
+      .slice(0, 10) ?? [];
+    return new Set(rawIds.filter((eventId) => /^[a-f0-9]{24}$/.test(eventId)));
+  }, [currentUser, location.search]);
 
   const fetchData = useCallback(async () => {
     try {
@@ -86,12 +97,25 @@ const App = () => {
                   onSelectionPlaced={requestSlipRefresh}
                   selectedSelectionKeys={selectedSelectionKeys}
                   uiVariant={uiVariant}
+                  visibleOfflineEventIds={visibleOfflineEventIds}
+                  onScopedAccessFailure={fetchData}
                 />}
               />
               <Route path="/signup" element={<NewUser callback={handleAuthChange} />} />
               <Route path="/logout" element={<LogOut callback={handleAuthChange} />} />
               <Route path="/login" element={<LogIn callback={handleAuthChange} />} />
-              <Route path="/backoffice" element={<Backoffice onChanged={refreshBackoffice} refreshToken={backofficeRefreshToken} />} />
+              <Route
+                path="/backoffice"
+                element={currentUser?.role === 'ADMIN'
+                  ? <Backoffice onChanged={refreshBackoffice} refreshToken={backofficeRefreshToken} />
+                  : <EventList
+                      onSelectionPlaced={requestSlipRefresh}
+                      selectedSelectionKeys={selectedSelectionKeys}
+                      uiVariant={uiVariant}
+                      visibleOfflineEventIds={visibleOfflineEventIds}
+                      onScopedAccessFailure={fetchData}
+                    />}
+              />
               <Route path="/bets" element={<MyBets />} />
               <Route
                 path="*"
@@ -99,6 +123,8 @@ const App = () => {
                   onSelectionPlaced={requestSlipRefresh}
                   selectedSelectionKeys={selectedSelectionKeys}
                   uiVariant={uiVariant}
+                  visibleOfflineEventIds={visibleOfflineEventIds}
+                  onScopedAccessFailure={fetchData}
                 />}
               />
             </Routes>

--- a/client/src/Header.js
+++ b/client/src/Header.js
@@ -7,7 +7,7 @@ const Header = ({ currentUser, uiVariant, theme }) => {
     const isV2 = uiVariant === 'v2';
 
     const links = [
-       currentUser && { label: 'Backoffice', href: '/backoffice', icon: '/icons/backoffice.svg' },
+       currentUser?.role === 'ADMIN' && { label: 'Backoffice', href: '/backoffice', icon: '/icons/backoffice.svg' },
        !currentUser && { label: 'Create account', href: '/signup', icon: '/icons/signup.svg' },
        !currentUser && { label: 'Log in', href: '/login', icon: '/icons/login.svg', kind: 'login' },
        currentUser && { label: 'My bets', href: '/bets', icon: '/icons/bets.svg' },

--- a/client/src/Header.test.js
+++ b/client/src/Header.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Header from './Header';
+
+const renderHeader = (currentUser) => render(
+  <MemoryRouter initialEntries={['/?ui=v2&theme=light']}>
+    <Header currentUser={currentUser} uiVariant="v2" theme="light" />
+  </MemoryRouter>
+);
+
+it('shows Backoffice only to administrators', () => {
+  const { unmount } = renderHeader({
+    email: 'admin@example.com',
+    role: 'ADMIN',
+  });
+
+  expect(screen.getByRole('link', { name: 'Backoffice' })).toHaveAttribute(
+    'href',
+    '/backoffice?ui=v2&theme=light'
+  );
+
+  unmount();
+  renderHeader({ email: 'user@example.com', role: 'USER' });
+  expect(
+    screen.queryByRole('link', { name: 'Backoffice' })
+  ).not.toBeInTheDocument();
+});
+
+it('keeps Backoffice hidden for legacy users without a role', () => {
+  renderHeader({ email: 'legacy@example.com' });
+
+  expect(
+    screen.queryByRole('link', { name: 'Backoffice' })
+  ).not.toBeInTheDocument();
+});

--- a/client/src/pages/event/EventList.js
+++ b/client/src/pages/event/EventList.js
@@ -34,6 +34,7 @@ const formatQuoteValidity = (value) => {
 };
 
 const buildCardClass = (uiVariant) => (uiVariant === 'v3' ? 'col-12' : 'col-12 col-md-6 col-xl-4');
+const EMPTY_EVENT_IDS = new Set();
 
 const FeedStatus = ({ feedState }) => {
   if (feedState === 'open') {
@@ -216,12 +217,24 @@ const EventSection = ({ children, title, uiVariant }) => <section className={`ev
   <div className="row g-3 justify-content-center">{children}</div>
 </section>;
 
-const HandleEventList = ({ onSelectionPlaced, selectedSelectionKeys, uiVariant }) => {
-  const { events, feedState, isLoading } = useLiveEvents();
+const HandleEventList = ({
+  onSelectionPlaced,
+  selectedSelectionKeys,
+  uiVariant,
+  visibleOfflineEventIds = EMPTY_EVENT_IDS,
+  onScopedAccessFailure,
+}) => {
+  const { events, feedState, isLoading } = useLiveEvents(
+    visibleOfflineEventIds,
+    onScopedAccessFailure,
+  );
 
   const eventItems = useMemo(() => sortEvents(
-    (events ?? []).filter((event) => event.visibility !== 'OFFLINE'),
-  ), [events]);
+    (events ?? []).filter((event) => (
+      event.visibility !== 'OFFLINE'
+      || visibleOfflineEventIds.has(event.eventId)
+    )),
+  ), [events, visibleOfflineEventIds]);
 
   const liveEvents = eventItems.filter(isLiveEvent);
   const preMatchEvents = eventItems.filter((event) => !isLiveEvent(event));

--- a/client/src/pages/event/EventList.test.js
+++ b/client/src/pages/event/EventList.test.js
@@ -151,4 +151,31 @@ describe('EventList', () => {
     }));
     await waitFor(() => expect(onSelectionPlaced).toHaveBeenCalledTimes(1));
   });
+
+  it('shows an explicitly scoped offline event only to the acceptance view', () => {
+    useLiveEvents.mockReturnValue({
+      events: [{ ...preMatchEvent, visibility: 'OFFLINE' }],
+      feedState: 'open',
+      isLoading: false,
+    });
+
+    const { rerender } = render(
+      <EventList
+        selectedSelectionKeys={new Set()}
+        uiVariant="v2"
+      />,
+    );
+    expect(screen.queryByRole('article', { name: preMatchEvent.name })).toBeNull();
+
+    rerender(
+      <EventList
+        selectedSelectionKeys={new Set()}
+        uiVariant="v2"
+        visibleOfflineEventIds={new Set([preMatchEvent.eventId])}
+      />,
+    );
+    expect(
+      screen.getByRole('article', { name: preMatchEvent.name }),
+    ).toBeInTheDocument();
+  });
 });

--- a/client/src/pages/event/useLiveEvents.js
+++ b/client/src/pages/event/useLiveEvents.js
@@ -25,7 +25,17 @@ const clearScheduledInterval = (taskRef) => {
 
 const normalizeEventList = (payload) => (Array.isArray(payload) ? payload : []);
 
-const useLiveEvents = () => {
+const buildAcceptanceQuery = (visibleOfflineEventIds) => {
+  const eventIds = [...(visibleOfflineEventIds ?? [])]
+    .filter((eventId) => /^[a-f0-9]{24}$/.test(eventId))
+    .slice(0, 10)
+    .sort();
+  return eventIds.length > 0
+    ? `?acceptanceEventIds=${encodeURIComponent(eventIds.join(','))}`
+    : '';
+};
+
+const useLiveEvents = (visibleOfflineEventIds, onScopedAccessFailure) => {
   const [events, setEvents] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [feedState, setFeedState] = useState('connecting');
@@ -39,6 +49,21 @@ const useLiveEvents = () => {
   const hasConnectedRef = useRef(false);
   const restRequestIdRef = useRef(0);
   const lastAppliedRestRequestIdRef = useRef(0);
+  const scopedAccessGenerationRef = useRef(0);
+  const acceptanceQuery = buildAcceptanceQuery(visibleOfflineEventIds);
+  const eventApiUrl = `/api/event${acceptanceQuery}`;
+  const eventStreamUrl = `/api/event/stream${acceptanceQuery}`;
+  const revokeScopedEvents = useCallback(() => {
+    if (!acceptanceQuery) {
+      return;
+    }
+
+    scopedAccessGenerationRef.current += 1;
+    setEvents((currentEvents) => currentEvents.filter(
+      (event) => event.visibility !== 'OFFLINE',
+    ));
+    onScopedAccessFailure?.();
+  }, [acceptanceQuery, onScopedAccessFailure]);
 
   const closeSource = useCallback(() => {
     if (eventSourceRef.current) {
@@ -49,12 +74,17 @@ const useLiveEvents = () => {
 
   const fetchAuthoritativeEvents = useCallback(async () => {
     const requestId = restRequestIdRef.current + 1;
+    const scopedAccessGeneration = scopedAccessGenerationRef.current;
     restRequestIdRef.current = requestId;
 
     try {
-      const response = await axios.get('/api/event');
+      const response = await axios.get(eventApiUrl);
 
-      if (!mountedRef.current || requestId < lastAppliedRestRequestIdRef.current) {
+      if (
+        !mountedRef.current
+        || requestId < lastAppliedRestRequestIdRef.current
+        || scopedAccessGeneration !== scopedAccessGenerationRef.current
+      ) {
         return;
       }
 
@@ -66,21 +96,22 @@ const useLiveEvents = () => {
       setIsLoading(false);
     } catch (error) {
       if (mountedRef.current) {
+        revokeScopedEvents();
         setIsLoading(false);
       }
     }
-  }, []);
+  }, [eventApiUrl, revokeScopedEvents]);
 
   const stopPollingFallback = useCallback(() => {
     clearScheduledInterval(pollTimerRef);
   }, []);
 
   const startPollingFallback = useCallback(() => {
+    setFeedState('polling');
     if (pollTimerRef.current) {
       return;
     }
 
-    setFeedState('polling');
     pollTimerRef.current = setInterval(() => {
       fetchAuthoritativeEvents();
     }, POLL_FALLBACK_MS);
@@ -111,10 +142,14 @@ const useLiveEvents = () => {
 
     setFeedState(isReconnect ? 'reconnecting' : 'connecting');
 
-    const source = new EventSource('/api/event/stream');
+    const source = new EventSource(eventStreamUrl);
     eventSourceRef.current = source;
 
     source.addEventListener('snapshot', (message) => {
+      if (eventSourceRef.current !== source || !mountedRef.current) {
+        return;
+      }
+
       try {
         const snapshot = JSON.parse(message.data);
         setEvents((currentEvents) => {
@@ -136,7 +171,6 @@ const useLiveEvents = () => {
 
       reconnectAttemptsRef.current = 0;
       clearScheduledTask(reconnectTimerRef);
-      stopPollingFallback();
       setFeedState('open');
       setIsLoading(false);
 
@@ -152,7 +186,9 @@ const useLiveEvents = () => {
         return;
       }
 
+      revokeScopedEvents();
       closeSource();
+      fetchAuthoritativeEvents();
       startPollingFallback();
 
       if (reconnectTimerRef.current) {
@@ -171,11 +207,23 @@ const useLiveEvents = () => {
         connect(true);
       }, reconnectDelay);
     };
-  }, [closeSource, scheduleReconcile, startPollingFallback, stopPollingFallback]);
+  }, [
+    closeSource,
+    eventStreamUrl,
+    fetchAuthoritativeEvents,
+    revokeScopedEvents,
+    scheduleReconcile,
+    startPollingFallback,
+  ]);
 
   useEffect(() => {
     mountedRef.current = true;
     fetchAuthoritativeEvents();
+    if (!pollTimerRef.current) {
+      pollTimerRef.current = setInterval(() => {
+        fetchAuthoritativeEvents();
+      }, POLL_FALLBACK_MS);
+    }
     connect(false);
 
     return () => {
@@ -199,4 +247,5 @@ export {
   MAX_RECONNECT_DELAY_MS,
   POLL_FALLBACK_MS,
   RECONCILE_DEBOUNCE_MS,
+  buildAcceptanceQuery,
 };

--- a/client/src/pages/event/useLiveEvents.test.js
+++ b/client/src/pages/event/useLiveEvents.test.js
@@ -63,11 +63,15 @@ const buildLiveEvent = (sequence) => ({
   },
 });
 
-const Harness = () => {
-  const { events, feedState, isLoading } = useLiveEvents();
+const Harness = ({ visibleOfflineEventIds, onScopedAccessFailure }) => {
+  const { events, feedState, isLoading } = useLiveEvents(
+    visibleOfflineEventIds,
+    onScopedAccessFailure,
+  );
 
   return <div>
     <div data-testid="sequence">{events[0]?.live?.sequence ?? 'none'}</div>
+    <div data-testid="event-count">{events.length}</div>
     <div data-testid="feed-state">{feedState}</div>
     <div data-testid="loading-state">{String(isLoading)}</div>
   </div>;
@@ -79,6 +83,7 @@ describe('useLiveEvents', () => {
     createdSources.length = 0;
     axios.get.mockReset();
     global.EventSource = jest.fn((url) => new MockEventSource(url));
+    window.history.replaceState({}, '', '/');
   });
 
   afterEach(() => {
@@ -90,6 +95,7 @@ describe('useLiveEvents', () => {
       .mockResolvedValueOnce({ data: [buildLiveEvent(1)] })
       .mockResolvedValueOnce({ data: [buildLiveEvent(4)] })
       .mockResolvedValueOnce({ data: [buildLiveEvent(4)] })
+      .mockResolvedValueOnce({ data: [buildLiveEvent(5)] })
       .mockResolvedValueOnce({ data: [buildLiveEvent(5)] });
 
     const { unmount } = render(<Harness />);
@@ -132,11 +138,12 @@ describe('useLiveEvents', () => {
 
     expect(firstSource.close).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('feed-state')).toHaveTextContent('polling');
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(3));
 
     await act(async () => {
       jest.advanceTimersByTime(POLL_FALLBACK_MS);
     });
-    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(4));
 
     await act(async () => {
       jest.advanceTimersByTime(1000);
@@ -152,7 +159,7 @@ describe('useLiveEvents', () => {
     await act(async () => {
       jest.advanceTimersByTime(RECONCILE_DEBOUNCE_MS);
     });
-    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(5));
 
     unmount();
 
@@ -162,6 +169,90 @@ describe('useLiveEvents', () => {
       jest.advanceTimersByTime(POLL_FALLBACK_MS + 1000 + RECONCILE_DEBOUNCE_MS);
     });
 
-    expect(axios.get).toHaveBeenCalledTimes(4);
+    expect(axios.get).toHaveBeenCalledTimes(5);
+  });
+
+  it('scopes both REST and SSE requests to authorized acceptance event IDs', async () => {
+    const eventIds = `${'a'.repeat(24)},${'b'.repeat(24)}`;
+    axios.get.mockResolvedValue({ data: [] });
+
+    const { unmount } = render(
+      <Harness visibleOfflineEventIds={new Set(eventIds.split(','))} />,
+    );
+    const encodedScope = encodeURIComponent(eventIds);
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith(
+        `/api/event?acceptanceEventIds=${encodedScope}`,
+      );
+    });
+    expect(createdSources[0].url).toBe(
+      `/api/event/stream?acceptanceEventIds=${encodedScope}`,
+    );
+
+    unmount();
+  });
+
+  it('authoritatively removes events hidden while SSE remains healthy', async () => {
+    axios.get
+      .mockResolvedValueOnce({ data: [buildLiveEvent(1)] })
+      .mockResolvedValueOnce({ data: [] });
+
+    const { unmount } = render(<Harness />);
+    await waitFor(() => expect(screen.getByTestId('event-count')).toHaveTextContent('1'));
+
+    act(() => {
+      createdSources[0].emitOpen();
+    });
+    expect(screen.getByTestId('feed-state')).toHaveTextContent('open');
+
+    await act(async () => {
+      jest.advanceTimersByTime(POLL_FALLBACK_MS);
+    });
+
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId('event-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('feed-state')).toHaveTextContent('open');
+
+    unmount();
+  });
+
+  it('immediately removes scoped offline events when stream authorization is lost', async () => {
+    const eventId = 'a'.repeat(24);
+    const offlineEvent = {
+      ...buildLiveEvent(1),
+      eventId,
+      visibility: 'OFFLINE',
+    };
+    const onScopedAccessFailure = jest.fn();
+    axios.get
+      .mockResolvedValueOnce({ data: [offlineEvent] })
+      .mockRejectedValueOnce({ response: { status: 403 } });
+
+    const { unmount } = render(
+      <Harness
+        visibleOfflineEventIds={new Set([eventId])}
+        onScopedAccessFailure={onScopedAccessFailure}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('sequence')).toHaveTextContent('1'));
+
+    act(() => {
+      createdSources[0].emitError();
+    });
+
+    expect(screen.getByTestId('sequence')).toHaveTextContent('none');
+    expect(onScopedAccessFailure).toHaveBeenCalled();
+    act(() => {
+      createdSources[0].emitSnapshot({ ...offlineEvent, live: {
+        ...offlineEvent.live,
+        sequence: 2,
+      } });
+    });
+    expect(screen.getByTestId('sequence')).toHaveTextContent('none');
+    await waitFor(() => expect(axios.get).toHaveBeenCalledTimes(2));
+
+    unmount();
   });
 });

--- a/event/src/index.ts
+++ b/event/src/index.ts
@@ -68,6 +68,9 @@ const startUp = async () => {
   if (!process.env.MONGO_URI) {
     throw new Error("Missing MONGO_URI variable");
   }
+  if (!process.env.AUTH_SERVICE_URL) {
+    throw new Error("Missing AUTH_SERVICE_URL variable");
+  }
 
   try {
     console.log("Connecting to: ", process.env.RABBITMQ_URI);

--- a/event/src/live/LiveEventReadModel.ts
+++ b/event/src/live/LiveEventReadModel.ts
@@ -498,7 +498,9 @@ const buildLiveUpdateOperations = (
   const setOnInsertOperations: UnknownRecord = {
     eventId: data.eventId,
     status: EventStatus.NO_RESULT,
-    visibility: EventVisibility.ONLINE,
+    visibility: EventVisibility.OFFLINE,
+    visibilityInitialized: false,
+    eventMetadataInitialized: false,
     products: [],
     source: "EXTERNAL",
     newEventPublishedAt: null,
@@ -649,7 +651,7 @@ export const createPublicEventSnapshotFromLiveUpdate = (
     name: eventName,
     time: kickoffAt,
     status: seedSnapshot?.status ?? EventStatus.NO_RESULT,
-    visibility: seedSnapshot?.visibility ?? EventVisibility.ONLINE,
+    visibility: seedSnapshot?.visibility ?? EventVisibility.OFFLINE,
     products: cloneProducts(seedSnapshot?.products ?? []),
     live: liveSnapshot,
   };
@@ -679,14 +681,25 @@ const compareEventTimes = (left: PublicEventSnapshot, right: PublicEventSnapshot
   Date.parse(left.time) - Date.parse(right.time);
 
 export const listPublicEvents = async (
-  now: Date = new Date()
+  now: Date = new Date(),
+  visibleOfflineEventIds: string[] = []
 ): Promise<PublicEventSnapshot[]> => {
   const { historyMinutes, horizonMinutes } = getPublicEventConfig();
   const lowerBound = new Date(now.getTime() - historyMinutes * 60 * 1000);
   const upperBound = new Date(now.getTime() + horizonMinutes * 60 * 1000);
 
+  const visibilityFilter =
+    visibleOfflineEventIds.length > 0
+      ? {
+          $or: [
+            { visibility: { $ne: EventVisibility.OFFLINE } },
+            { eventId: { $in: visibleOfflineEventIds } },
+          ],
+        }
+      : { visibility: { $ne: EventVisibility.OFFLINE } };
   const events = await Event.find({
     time: { $gte: lowerBound, $lte: upperBound },
+    ...visibilityFilter,
   }).lean();
 
   return events

--- a/event/src/live/__test__/LiveEventReadModel.test.ts
+++ b/event/src/live/__test__/LiveEventReadModel.test.ts
@@ -502,7 +502,7 @@ it("builds sparse live updates with defaults, deduplicated incidents, and filter
     name: "generated-event",
     time: "2030-02-01T00:00:00.000Z",
     status: EventStatus.NO_RESULT,
-    visibility: EventVisibility.ONLINE,
+    visibility: EventVisibility.OFFLINE,
     products: [],
     live: {
       sequence: 1,

--- a/event/src/messaging/listener/EventVisibilityListener.ts
+++ b/event/src/messaging/listener/EventVisibilityListener.ts
@@ -1,6 +1,7 @@
 import { ConsumeMessage } from "amqplib";
 import {
   AListener,
+  EventStatus,
   EventVisibility,
   IEventVibibilityEvent,
   QueueNames,
@@ -14,21 +15,75 @@ class EventVisibilityListener extends AListener<IEventVibibilityEvent> {
   async onMessage(event: IEventVibibilityEvent, msg: ConsumeMessage) {
     const { data } = event;
 
-    const storedEvent = await Event.findOne({ eventId: data.eventId });
+    try {
+      await Event.updateOne(
+        { eventId: data.eventId },
+        {
+          $set: { pendingVisibility: data.visibility },
+          $setOnInsert: {
+            eventId: data.eventId,
+            name: data.eventId,
+            time: new Date(),
+            status: EventStatus.NO_RESULT,
+            visibility: EventVisibility.OFFLINE,
+            visibilityInitialized: false,
+            eventMetadataInitialized: false,
+            products: [],
+            source: "EXTERNAL",
+          },
+        },
+        { upsert: true }
+      );
+    } catch (err: any) {
+      if (err?.code !== 11000) {
+        throw err;
+      }
 
-    if (!storedEvent) {
-      console.log("event not found", event);
-      this.channel.ack(msg);
-      return;
+      await Event.updateOne(
+        { eventId: data.eventId },
+        { $set: { pendingVisibility: data.visibility } }
+      );
     }
 
-    if (data.visibility === EventVisibility.ONLINE) {
-      storedEvent.visibility = EventVisibility.ONLINE;
-    } else {
-      storedEvent.visibility = EventVisibility.OFFLINE;
-    }
+    await Event.updateOne(
+      {
+        eventId: data.eventId,
+        $or: [
+          { eventMetadataInitialized: false },
+          {
+            eventMetadataInitialized: { $exists: false },
+            source: "EXTERNAL",
+            "live.sequence": { $exists: true },
+            "products.0": { $exists: false },
+          },
+        ],
+      },
+      {
+        $set: {
+          visibility: EventVisibility.OFFLINE,
+          eventMetadataInitialized: false,
+        },
+      }
+    );
 
-    await storedEvent.save();
+    await Event.updateOne(
+      {
+        eventId: data.eventId,
+        pendingVisibility: data.visibility,
+        $or: [
+          { eventMetadataInitialized: true },
+          { "products.0": { $exists: true } },
+        ],
+      },
+      {
+        $set: {
+          visibility: data.visibility,
+          visibilityInitialized: true,
+          eventMetadataInitialized: true,
+        },
+        $unset: { pendingVisibility: 1 },
+      }
+    );
 
     this.channel.ack(msg);
   }

--- a/event/src/messaging/listener/LiveEventUpdateListener.ts
+++ b/event/src/messaging/listener/LiveEventUpdateListener.ts
@@ -59,9 +59,12 @@ class LiveEventUpdateListener extends AListener<ILiveEventUpdateEvent> {
   }
 
   async onMessage(event: ILiveEventUpdateEvent, msg: ConsumeMessage) {
+    const localSnapshot = this.hub.getSnapshot(event.data.eventId);
+    const storedSnapshot = await getStoredPublicEventSnapshot(event.data.eventId);
     const seedSnapshot =
-      this.hub.getSnapshot(event.data.eventId) ??
-      (await getStoredPublicEventSnapshot(event.data.eventId));
+      localSnapshot && storedSnapshot
+        ? { ...localSnapshot, visibility: storedSnapshot.visibility }
+        : localSnapshot ?? storedSnapshot;
     const snapshot = createPublicEventSnapshotFromLiveUpdate(
       event,
       seedSnapshot

--- a/event/src/messaging/listener/NewEventListener.ts
+++ b/event/src/messaging/listener/NewEventListener.ts
@@ -1,5 +1,10 @@
 import { ConsumeMessage } from "amqplib";
-import { AListener, INewEventEvent, QueueNames } from "@betstan/common";
+import {
+  AListener,
+  EventVisibility,
+  INewEventEvent,
+  QueueNames,
+} from "@betstan/common";
 import EventTemplate from "../../data/EventTemplate";
 import { Event } from "../../model/Event";
 
@@ -9,6 +14,13 @@ class NewEventListener extends AListener<INewEventEvent> {
 
   async onMessage(event: INewEventEvent, msg: ConsumeMessage) {
     const { data } = event;
+    const requestedVisibility = (
+      data as typeof data & { visibility?: EventVisibility }
+    ).visibility;
+    const visibility =
+      requestedVisibility === EventVisibility.OFFLINE
+        ? EventVisibility.OFFLINE
+        : EventVisibility.ONLINE;
 
     if (event.sender === this.serviceName) {
       // ignoring selfinflicted message
@@ -23,18 +35,25 @@ class NewEventListener extends AListener<INewEventEvent> {
       data.away,
       data.time
     );
+    const eventMetadata = {
+      name: newEvent.name,
+      time: newEvent.time,
+      home: newEvent.home,
+      away: newEvent.away,
+      products: newEvent.products,
+    };
+
     try {
       await Event.updateOne(
         { eventId: data.id },
         {
           $setOnInsert: {
             eventId: newEvent.eventId,
-            name: newEvent.name,
-            time: newEvent.time,
-            home: newEvent.home,
-            away: newEvent.away,
-            products: newEvent.products,
             source: "EXTERNAL",
+            ...eventMetadata,
+            visibility,
+            visibilityInitialized: true,
+            eventMetadataInitialized: true,
           },
         },
         { upsert: true }
@@ -44,6 +63,76 @@ class NewEventListener extends AListener<INewEventEvent> {
         throw err;
       }
     }
+
+    await Event.updateOne(
+      {
+        eventId: data.id,
+        $or: [
+          { eventMetadataInitialized: false },
+          { visibilityInitialized: false },
+          {
+            eventMetadataInitialized: { $exists: false },
+            source: "EXTERNAL",
+            "live.sequence": { $exists: true },
+            "products.0": { $exists: false },
+          },
+        ],
+      },
+      {
+        $set: {
+          ...eventMetadata,
+          eventMetadataInitialized: true,
+        },
+      }
+    );
+
+    for (const pendingVisibility of [
+      EventVisibility.OFFLINE,
+      EventVisibility.ONLINE,
+    ]) {
+      await Event.updateOne(
+        {
+          eventId: data.id,
+          eventMetadataInitialized: true,
+          pendingVisibility,
+        },
+        {
+          $set: {
+            visibility: pendingVisibility,
+            visibilityInitialized: true,
+          },
+          $unset: { pendingVisibility: 1 },
+        }
+      );
+    }
+
+    await Event.updateOne(
+      {
+        eventId: data.id,
+        eventMetadataInitialized: true,
+        visibilityInitialized: { $exists: false },
+        pendingVisibility: { $exists: false },
+        visibility: EventVisibility.OFFLINE,
+      },
+      {
+        $set: { visibilityInitialized: true },
+      }
+    );
+
+    await Event.updateOne(
+      {
+        eventId: data.id,
+        eventMetadataInitialized: true,
+        visibilityInitialized: { $ne: true },
+        pendingVisibility: { $exists: false },
+      },
+      {
+        $set: {
+          visibility,
+          visibilityInitialized: true,
+        },
+      }
+    );
 
     this.channel.ack(msg);
   }

--- a/event/src/messaging/listener/__test__/EventVisibilityListener.test.ts
+++ b/event/src/messaging/listener/__test__/EventVisibilityListener.test.ts
@@ -43,6 +43,8 @@ const createEvent = async (eventId: string, visibility = EventVisibility.ONLINE)
     time: new Date(),
     status: EventStatus.NO_RESULT,
     visibility,
+    visibilityInitialized: true,
+    eventMetadataInitialized: true,
     products: [],
   });
 };
@@ -63,6 +65,7 @@ it("marks event as offline when visibility OFFLINE arrives", async () => {
 
   const updated = await Event.findOne({ eventId });
   expect(updated!.visibility).toEqual(EventVisibility.OFFLINE);
+  expect(updated!.get("visibilityInitialized")).toBe(true);
 });
 
 it("marks event as online when visibility ONLINE arrives", async () => {
@@ -81,16 +84,18 @@ it("marks event as online when visibility ONLINE arrives", async () => {
 
   const updated = await Event.findOne({ eventId });
   expect(updated!.visibility).toEqual(EventVisibility.ONLINE);
+  expect(updated!.get("visibilityInitialized")).toBe(true);
 });
 
-it("acks without error when event is not found", async () => {
+it("stores a fail-dark pending visibility when event metadata has not arrived", async () => {
   const listener = new EventVisibilityListener(messengerWrapper.connection);
   await listener.init();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
 
   const event: IEventVibibilityEvent = {
     timestamp: new Date().toISOString(),
     data: {
-      eventId: new mongoose.Types.ObjectId().toHexString(),
+      eventId,
       visibility: EventVisibility.ONLINE,
     },
   };
@@ -98,5 +103,33 @@ it("acks without error when event is not found", async () => {
   await listener.onMessage(event, buildMessage());
 
   const events = await Event.find({});
-  expect(events.length).toEqual(0);
+  expect(events.length).toEqual(1);
+  expect(events[0].eventId).toEqual(eventId);
+  expect(events[0].visibility).toEqual(EventVisibility.OFFLINE);
+  expect(events[0].get("pendingVisibility")).toEqual(EventVisibility.ONLINE);
+  expect(events[0].get("visibilityInitialized")).toBe(false);
+  expect(events[0].get("eventMetadataInitialized")).toBe(false);
+});
+
+it("retries the pending decision after a duplicate-key upsert race", async () => {
+  const listener = new EventVisibilityListener(messengerWrapper.connection);
+  await listener.init();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+  await createEvent(eventId, EventVisibility.ONLINE);
+  jest
+    .spyOn(Event, "updateOne")
+    .mockRejectedValueOnce({ code: 11000 } as any);
+
+  await listener.onMessage(
+    {
+      timestamp: new Date().toISOString(),
+      data: { eventId, visibility: EventVisibility.OFFLINE },
+    },
+    buildMessage()
+  );
+
+  const storedEvent = await Event.findOne({ eventId });
+  expect(storedEvent!.visibility).toEqual(EventVisibility.OFFLINE);
+  expect(storedEvent!.get("pendingVisibility")).toBeUndefined();
+  expect((listener as any).channel.ack).toHaveBeenCalledTimes(1);
 });

--- a/event/src/messaging/listener/__test__/LiveEventProjectionListener.test.ts
+++ b/event/src/messaging/listener/__test__/LiveEventProjectionListener.test.ts
@@ -2,6 +2,7 @@ import { ConsumeMessage } from "amqplib";
 import {
   BettingStatus,
   EventPhase,
+  EventVisibility,
   ILiveEventUpdateEvent,
   LiveIncidentType,
   LiveMarketStatus,
@@ -254,6 +255,44 @@ it("delivers snapshots to both pod-local fanout listeners", async () => {
   expect(secondSubscriber).toHaveBeenCalledTimes(1);
   expect(firstSubscriber.mock.calls[0][0].live.sequence).toEqual(2);
   expect(secondSubscriber.mock.calls[0][0].live.sequence).toEqual(2);
+});
+
+it("refreshes authoritative visibility after a fail-dark local snapshot", async () => {
+  const projectionListener = new LiveEventProjectionListener(
+    messengerWrapper.connection
+  );
+  await projectionListener.init();
+  await projectionListener.onMessage(buildLiveUpdate(1), buildMessage());
+
+  const hub = new LiveEventHub();
+  const localListener = new LiveEventUpdateListener(messengerWrapper.connection, {
+    hub,
+    podId: "pod-visibility",
+  });
+  await localListener.init();
+
+  const subscriber = jest.fn();
+  hub.subscribe(subscriber);
+  await localListener.onMessage(buildLiveUpdate(1), buildMessage());
+  expect(subscriber.mock.calls[0][0].visibility).toEqual(
+    EventVisibility.OFFLINE
+  );
+
+  await Event.updateOne(
+    { eventId: "live-event" },
+    {
+      $set: {
+        visibility: EventVisibility.ONLINE,
+        visibilityInitialized: true,
+      },
+    }
+  );
+  await localListener.onMessage(buildLiveUpdate(2), buildMessage());
+
+  expect(subscriber).toHaveBeenCalledTimes(2);
+  expect(subscriber.mock.calls[1][0].visibility).toEqual(
+    EventVisibility.ONLINE
+  );
 });
 
 it("does not duplicate local SSE emission for durable, duplicate, or out-of-order deliveries", async () => {

--- a/event/src/messaging/listener/__test__/LiveEventUpdateListener.test.ts
+++ b/event/src/messaging/listener/__test__/LiveEventUpdateListener.test.ts
@@ -161,6 +161,9 @@ it("keeps legacy single-incident payloads valid for older publishers", async () 
 
   const updatedEvent = await Event.findOne({ eventId: "live-event" }).lean();
   const live = updatedEvent?.live as any;
+  expect(updatedEvent?.visibility).toBe(EventVisibility.OFFLINE);
+  expect((updatedEvent as any)?.visibilityInitialized).toBe(false);
+  expect((updatedEvent as any)?.eventMetadataInitialized).toBe(false);
   expect(live.sequence).toBe(1);
   expect(
     live.incidentHistory.map((incident: { id: string }) => incident.id)

--- a/event/src/messaging/listener/__test__/NewEventListener.test.ts
+++ b/event/src/messaging/listener/__test__/NewEventListener.test.ts
@@ -1,7 +1,13 @@
 import mongoose from "mongoose";
 import { ConsumeMessage } from "amqplib";
-import { EventStatus, INewEventEvent, messengerWrapper } from "@betstan/common";
+import {
+  EventStatus,
+  EventVisibility,
+  INewEventEvent,
+  messengerWrapper,
+} from "@betstan/common";
 import NewEventListener from "../NewEventListener";
+import EventVisibilityListener from "../EventVisibilityListener";
 import { Event } from "../../../model/Event";
 
 const buildMessage = (): ConsumeMessage => ({
@@ -56,6 +62,194 @@ it("creates a new event with products when a NewEvent message arrives", async ()
   expect(storedEvent!.products.length).toBeGreaterThan(0);
 });
 
+it("keeps an acceptance event offline from its first projection", async () => {
+  const listener = new NewEventListener(messengerWrapper.connection);
+  await listener.init();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+  const event = {
+    sender: "backoffice_new_event",
+    timestamp: new Date().toISOString(),
+    data: {
+      id: eventId,
+      name: "Hidden A - Hidden B",
+      time: new Date().toISOString(),
+      home: "Hidden A",
+      away: "Hidden B",
+      visibility: EventVisibility.OFFLINE,
+    },
+  };
+
+  await listener.onMessage(event, buildMessage());
+
+  expect((await Event.findOne({ eventId }))!.visibility).toEqual(
+    EventVisibility.OFFLINE
+  );
+});
+
+it("repairs a fail-dark live projection when event metadata arrives later", async () => {
+  const listener = new NewEventListener(messengerWrapper.connection);
+  await listener.init();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+
+  await Event.create({
+    eventId,
+    name: "Provisional live event",
+    time: new Date(),
+    status: EventStatus.NO_RESULT,
+    visibility: EventVisibility.OFFLINE,
+    visibilityInitialized: false,
+    products: [],
+  });
+
+  await listener.onMessage(
+    {
+      sender: "other_service",
+      timestamp: new Date().toISOString(),
+      data: {
+        id: eventId,
+        name: "Team A - Team B",
+        time: "2030-01-01T00:00:00.000Z",
+        home: "Team A",
+        away: "Team B",
+        visibility: EventVisibility.ONLINE,
+      },
+    } as INewEventEvent,
+    buildMessage()
+  );
+
+  const storedEvent = await Event.findOne({ eventId });
+  expect(storedEvent!.visibility).toEqual(EventVisibility.ONLINE);
+  expect(storedEvent!.get("visibilityInitialized")).toBe(true);
+  expect(storedEvent!.get("eventMetadataInitialized")).toBe(true);
+  expect(storedEvent!.products.length).toBeGreaterThan(0);
+});
+
+it("repairs legacy live projections whose initialization markers are missing", async () => {
+  const listener = new NewEventListener(messengerWrapper.connection);
+  await listener.init();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+
+  await Event.collection.insertOne({
+    eventId,
+    name: "Legacy provisional event",
+    time: new Date(),
+    status: EventStatus.NO_RESULT,
+    visibility: EventVisibility.ONLINE,
+    products: [],
+    source: "EXTERNAL",
+    live: { sequence: 1 },
+  });
+
+  await listener.onMessage(
+    {
+      sender: "other_service",
+      timestamp: new Date().toISOString(),
+      data: {
+        id: eventId,
+        name: "Hidden A - Hidden B",
+        time: "2030-01-01T00:00:00.000Z",
+        home: "Hidden A",
+        away: "Hidden B",
+        visibility: EventVisibility.OFFLINE,
+      },
+    } as INewEventEvent,
+    buildMessage()
+  );
+
+  const storedEvent = await Event.findOne({ eventId });
+  expect(storedEvent!.name).toEqual("Hidden A - Hidden B");
+  expect(storedEvent!.visibility).toEqual(EventVisibility.OFFLINE);
+  expect(storedEvent!.get("visibilityInitialized")).toBe(true);
+  expect(storedEvent!.get("eventMetadataInitialized")).toBe(true);
+  expect(storedEvent!.products.length).toBeGreaterThan(0);
+});
+
+it("repairs metadata without undoing a newer visibility message", async () => {
+  const newEventListener = new NewEventListener(messengerWrapper.connection);
+  const visibilityListener = new EventVisibilityListener(
+    messengerWrapper.connection
+  );
+  await newEventListener.init();
+  await visibilityListener.init();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+
+  await visibilityListener.onMessage(
+    {
+      timestamp: new Date().toISOString(),
+      data: { eventId, visibility: EventVisibility.OFFLINE },
+    },
+    buildMessage()
+  );
+  const placeholder = await Event.findOne({ eventId });
+  expect(placeholder!.visibility).toEqual(EventVisibility.OFFLINE);
+  expect(placeholder!.get("pendingVisibility")).toEqual(
+    EventVisibility.OFFLINE
+  );
+  await newEventListener.onMessage(
+    {
+      sender: "other_service",
+      timestamp: new Date().toISOString(),
+      data: {
+        id: eventId,
+        name: "Team A - Team B",
+        time: "2030-01-01T00:00:00.000Z",
+        home: "Team A",
+        away: "Team B",
+        visibility: EventVisibility.ONLINE,
+      },
+    } as INewEventEvent,
+    buildMessage()
+  );
+
+  const storedEvent = await Event.findOne({ eventId });
+  expect(storedEvent!.name).toEqual("Team A - Team B");
+  expect(storedEvent!.products.length).toBeGreaterThan(0);
+  expect(storedEvent!.visibility).toEqual(EventVisibility.OFFLINE);
+  expect(storedEvent!.get("visibilityInitialized")).toBe(true);
+  expect(storedEvent!.get("eventMetadataInitialized")).toBe(true);
+  expect(storedEvent!.get("pendingVisibility")).toBeUndefined();
+});
+
+it("keeps ambiguous legacy hidden projections fail-dark during metadata repair", async () => {
+  const listener = new NewEventListener(messengerWrapper.connection);
+  await listener.init();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+
+  await Event.collection.insertOne({
+    eventId,
+    name: "Legacy hidden projection",
+    time: new Date(),
+    status: EventStatus.NO_RESULT,
+    visibility: EventVisibility.OFFLINE,
+    products: [],
+    source: "EXTERNAL",
+    live: { sequence: 1 },
+  });
+
+  await listener.onMessage(
+    {
+      sender: "other_service",
+      timestamp: new Date().toISOString(),
+      data: {
+        id: eventId,
+        name: "Team A - Team B",
+        time: "2030-01-01T00:00:00.000Z",
+        home: "Team A",
+        away: "Team B",
+        visibility: EventVisibility.ONLINE,
+      },
+    } as INewEventEvent,
+    buildMessage()
+  );
+
+  const storedEvent = await Event.findOne({ eventId });
+  expect(storedEvent!.name).toEqual("Team A - Team B");
+  expect(storedEvent!.products.length).toBeGreaterThan(0);
+  expect(storedEvent!.visibility).toEqual(EventVisibility.OFFLINE);
+  expect(storedEvent!.get("visibilityInitialized")).toBe(true);
+  expect(storedEvent!.get("eventMetadataInitialized")).toBe(true);
+});
+
 it("ignores self-inflicted messages", async () => {
   const listener = new NewEventListener(messengerWrapper.connection);
   await listener.init();
@@ -97,6 +291,10 @@ it("keeps the original generated products when delivery is duplicated", async ()
     },
     buildMessage()
   );
+  await Event.updateOne(
+    { eventId },
+    { $set: { visibility: EventVisibility.OFFLINE } }
+  );
   await listener.onMessage(
     {
       sender: "other_service",
@@ -116,6 +314,7 @@ it("keeps the original generated products when delivery is duplicated", async ()
   expect(await Event.countDocuments()).toEqual(1);
   expect(storedEvent!.name).toEqual("Team A - Team B");
   expect(storedEvent!.products[0].odds[0].name).toEqual("Team A");
+  expect(storedEvent!.visibility).toEqual(EventVisibility.OFFLINE);
 });
 
 it("acks duplicate key races without failing the consumer", async () => {
@@ -123,7 +322,8 @@ it("acks duplicate key races without failing the consumer", async () => {
   await listener.init();
   const updateOneSpy = jest
     .spyOn(Event, "updateOne")
-    .mockRejectedValueOnce({ code: 11000 } as any);
+    .mockRejectedValueOnce({ code: 11000 } as any)
+    .mockResolvedValueOnce({ matchedCount: 0 } as any);
 
   await expect(
     listener.onMessage(
@@ -142,7 +342,7 @@ it("acks duplicate key races without failing the consumer", async () => {
     )
   ).resolves.toBeUndefined();
 
-  expect(updateOneSpy).toHaveBeenCalledTimes(1);
+  expect(updateOneSpy).toHaveBeenCalledTimes(6);
   expect((listener as any).channel.ack).toHaveBeenCalledTimes(1);
 });
 

--- a/event/src/middleware/AcceptanceEventAccess.ts
+++ b/event/src/middleware/AcceptanceEventAccess.ts
@@ -1,0 +1,74 @@
+import { NextFunction, Request, Response } from "express";
+import { verifyAdminRequest } from "../service/VerifyAdminSession";
+
+const EVENT_ID_PATTERN = /^[a-f0-9]{24}$/;
+const MAX_ACCEPTANCE_EVENTS = 10;
+
+declare global {
+  namespace Express {
+    interface Request {
+      visibleOfflineEventIds?: string[];
+    }
+  }
+}
+
+const parseAcceptanceEventIds = (value: unknown): string[] | null => {
+  if (value === undefined) {
+    return [];
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const ids = value.split(",");
+  if (
+    ids.length === 0
+    || ids.length > MAX_ACCEPTANCE_EVENTS
+    || ids.some((eventId) => !EVENT_ID_PATTERN.test(eventId))
+    || new Set(ids).size !== ids.length
+  ) {
+    return null;
+  }
+
+  return ids;
+};
+
+export const authorizeAcceptanceEventAccess = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const eventIds = parseAcceptanceEventIds(req.query.acceptanceEventIds);
+  if (eventIds === null) {
+    return res.status(400).send({
+      errors: [{ message: "acceptanceEventIds is invalid" }],
+    });
+  }
+  if (eventIds.length === 0) {
+    req.visibleOfflineEventIds = [];
+    next();
+    return;
+  }
+
+  try {
+    const status = await verifyAdminRequest(req);
+    if (status !== 204) {
+      return res.status(status).send({
+        errors: [{
+          message:
+            status === 401
+              ? "Authentication required"
+              : "Administrator role required",
+        }],
+      });
+    }
+
+    req.visibleOfflineEventIds = eventIds;
+    next();
+  } catch (_error) {
+    console.error("Acceptance event authorization failed");
+    return res.status(503).send({
+      errors: [{ message: "Authorization service unavailable" }],
+    });
+  }
+};

--- a/event/src/model/Event.ts
+++ b/event/src/model/Event.ts
@@ -218,6 +218,19 @@ const eventSchema = new Schema({
     enum: Object.values(EventVisibility),
     default: EventVisibility.ONLINE,
   },
+  visibilityInitialized: {
+    type: Boolean,
+    required: false,
+  },
+  eventMetadataInitialized: {
+    type: Boolean,
+    required: false,
+  },
+  pendingVisibility: {
+    type: String,
+    required: false,
+    enum: Object.values(EventVisibility),
+  },
   products: [
     new Schema({
       id: {

--- a/event/src/route/EventLiveStream.ts
+++ b/event/src/route/EventLiveStream.ts
@@ -6,12 +6,16 @@ import {
   PublicEventSnapshot,
   sanitizePublicEventSnapshot,
 } from "../live/LiveEventReadModel";
+import { EventVisibility } from "@betstan/common";
+import { authorizeAcceptanceEventAccess } from "../middleware/AcceptanceEventAccess";
+import { verifyAdminRequest } from "../service/VerifyAdminSession";
 
 const router = express.Router();
 
 export interface EventLiveStreamOptions {
   hub?: LiveEventHub;
   heartbeatMs?: number;
+  verifyScopedAccess?: (req: Request) => Promise<boolean>;
 }
 
 const writeSnapshot = (res: Response, snapshot: PublicEventSnapshot): void => {
@@ -39,6 +43,13 @@ export const openEventLiveStream = (
   const heartbeatMs =
     options.heartbeatMs ?? getPublicEventConfig().sseHeartbeatMs;
   const hub = options.hub ?? liveEventHub;
+  const visibleOfflineEventIds = new Set(req.visibleOfflineEventIds ?? []);
+  const hasOfflineScope = visibleOfflineEventIds.size > 0;
+  const verifyScopedAccess =
+    options.verifyScopedAccess
+    ?? (async (request: Request) => (
+      await verifyAdminRequest(request)
+    ) === 204);
 
   res.status(200);
   res.setHeader("Content-Type", "text/event-stream");
@@ -49,36 +60,106 @@ export const openEventLiveStream = (
     res.flushHeaders();
   }
 
-  const unsubscribe = hub.subscribe((snapshot) => {
-    if (!res.writableEnded) {
-      writeSnapshot(res, snapshot);
-    }
-  });
-
-  const heartbeat = setInterval(() => {
-    if (!res.writableEnded) {
-      res.write(": heartbeat\n\n");
-    }
-  }, heartbeatMs);
-
   let cleanedUp = false;
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  let unsubscribe = () => {};
+  let scopedVerification: Promise<boolean> | undefined;
+
   const cleanup = () => {
     if (cleanedUp) {
       return;
     }
 
     cleanedUp = true;
-    clearInterval(heartbeat);
+    if (heartbeat) {
+      clearInterval(heartbeat);
+    }
     unsubscribe();
   };
+
+  const closeScopedStream = () => {
+    cleanup();
+    if (!res.writableEnded) {
+      res.end();
+    }
+  };
+
+  const revalidateScopedAccess = (): Promise<boolean> => {
+    if (!scopedVerification) {
+      const verification = verifyScopedAccess(req).catch((_error) => {
+        console.error("Scoped event stream authorization failed");
+        return false;
+      });
+      scopedVerification = verification;
+      void verification.finally(() => {
+        if (scopedVerification === verification) {
+          scopedVerification = undefined;
+        }
+      });
+    }
+
+    return scopedVerification;
+  };
+
+  unsubscribe = hub.subscribe((snapshot) => {
+    if (res.writableEnded || cleanedUp) {
+      return;
+    }
+
+    if (snapshot.visibility !== EventVisibility.OFFLINE) {
+      writeSnapshot(res, snapshot);
+      return;
+    }
+
+    if (!visibleOfflineEventIds.has(snapshot.eventId)) {
+      return;
+    }
+
+    void revalidateScopedAccess().then((authorized) => {
+      if (!authorized) {
+        closeScopedStream();
+        return;
+      }
+
+      if (!res.writableEnded && !cleanedUp) {
+        writeSnapshot(res, snapshot);
+      }
+    });
+  });
+
+  heartbeat = setInterval(() => {
+    if (res.writableEnded || cleanedUp) {
+      return;
+    }
+
+    if (!hasOfflineScope) {
+      res.write(": heartbeat\n\n");
+      return;
+    }
+
+    void revalidateScopedAccess().then((authorized) => {
+      if (!authorized) {
+        closeScopedStream();
+        return;
+      }
+
+      if (!res.writableEnded && !cleanedUp) {
+        res.write(": heartbeat\n\n");
+      }
+    });
+  }, heartbeatMs);
 
   req.on("close", cleanup);
   res.on("close", cleanup);
   res.on("finish", cleanup);
 };
 
-router.get("/api/event/stream", (req: Request, res: Response) => {
-  openEventLiveStream(req, res);
-});
+router.get(
+  "/api/event/stream",
+  authorizeAcceptanceEventAccess,
+  (req: Request, res: Response) => {
+    openEventLiveStream(req, res);
+  }
+);
 
 export { router as EventLiveStream };

--- a/event/src/route/EventOddsClicked.ts
+++ b/event/src/route/EventOddsClicked.ts
@@ -5,12 +5,14 @@ import {
   BetKind,
   BettingStatus,
   EventPhase,
+  EventVisibility,
   LiveMarketStatus,
   LiveMarketType,
   TeamSide,
   messengerWrapper,
 } from "@betstan/common";
 import EventOddsSelectedPublisher from "../messaging/publisher/EventOddsSelectedPublisher";
+import { verifyAdminRequest } from "../service/VerifyAdminSession";
 
 const router = express.Router();
 
@@ -120,6 +122,27 @@ router.post(
 
     if (!event) {
       return next(new BadRequestError("Event not found"));
+    }
+
+    if (event.visibility === EventVisibility.OFFLINE) {
+      try {
+        const adminStatus = await verifyAdminRequest(req);
+        if (adminStatus !== 204) {
+          return res.status(adminStatus).send({
+            errors: [{
+              message:
+                adminStatus === 401
+                  ? "Authentication required"
+                  : "Administrator role required",
+            }],
+          });
+        }
+      } catch (_error) {
+        console.error("Offline event authorization failed");
+        return res.status(503).send({
+          errors: [{ message: "Authorization service unavailable" }],
+        });
+      }
     }
 
     if (isLiveSelectionRequest(body)) {

--- a/event/src/route/ListAllEvents.ts
+++ b/event/src/route/ListAllEvents.ts
@@ -1,10 +1,15 @@
 import express, { Request, Response } from "express";
 import { listPublicEvents } from "../live/LiveEventReadModel";
+import { authorizeAcceptanceEventAccess } from "../middleware/AcceptanceEventAccess";
 
 const router = express.Router();
 
-router.get("/api/event", async (_req: Request, res: Response) => {
-  res.send(await listPublicEvents());
-});
+router.get(
+  "/api/event",
+  authorizeAcceptanceEventAccess,
+  async (req: Request, res: Response) => {
+    res.send(await listPublicEvents(new Date(), req.visibleOfflineEventIds));
+  }
+);
 
 export { router as ListllEvents };

--- a/event/src/route/__test__/EventLiveStream.test.ts
+++ b/event/src/route/__test__/EventLiveStream.test.ts
@@ -34,6 +34,12 @@ class MockResponse extends EventEmitter {
     this.writes.push(chunk);
     return true;
   }
+
+  end() {
+    this.writableEnded = true;
+    this.emit("finish");
+    return this;
+  }
 }
 
 const buildSnapshot = (sequence: number): PublicEventSnapshot => ({
@@ -162,6 +168,10 @@ const getDataPayload = (writes: string[]) => {
   return JSON.parse(dataChunk.slice(6));
 };
 
+const flushPromises = () => new Promise<void>((resolve) => {
+  setImmediate(resolve);
+});
+
 afterEach(() => {
   jest.useRealTimers();
 });
@@ -261,6 +271,72 @@ it("sets SSE headers, sanitizes snapshots, emits heartbeats, and cleans up disco
   const writesBefore = (res as unknown as MockResponse).writes.length;
   hub.broadcast(buildSnapshot(8));
   expect((res as unknown as MockResponse).writes).toHaveLength(writesBefore);
+});
+
+it("streams offline snapshots only to an authorized scoped connection", async () => {
+  const offlineSnapshot = {
+    ...buildDirtySnapshot(),
+    visibility: EventVisibility.OFFLINE,
+  };
+  const publicHub = new LiveEventHub();
+  const publicRequest = new EventEmitter() as Request;
+  const publicResponse = new MockResponse() as unknown as Response;
+  openEventLiveStream(publicRequest, publicResponse, { hub: publicHub });
+  publicHub.broadcast(offlineSnapshot);
+  expect((publicResponse as unknown as MockResponse).writes).toEqual([]);
+
+  const adminHub = new LiveEventHub();
+  const adminRequest = new EventEmitter() as Request;
+  adminRequest.visibleOfflineEventIds = ["event-id"];
+  const adminResponse = new MockResponse() as unknown as Response;
+  const verifyScopedAccess = jest.fn(async () => true);
+  openEventLiveStream(adminRequest, adminResponse, {
+    hub: adminHub,
+    verifyScopedAccess,
+  });
+  adminHub.broadcast(offlineSnapshot);
+  await flushPromises();
+  expect((adminResponse as unknown as MockResponse).writes.join("")).toContain(
+    "id: event-id:7"
+  );
+  expect(verifyScopedAccess).toHaveBeenCalledTimes(1);
+
+  publicRequest.emit("close");
+  adminRequest.emit("close");
+});
+
+it("closes a scoped stream before sending another offline snapshot after demotion", async () => {
+  let authorized = true;
+  const hub = new LiveEventHub();
+  const req = new EventEmitter() as Request;
+  req.visibleOfflineEventIds = ["event-id"];
+  const response = new MockResponse();
+  openEventLiveStream(req, response as unknown as Response, {
+    hub,
+    verifyScopedAccess: async () => authorized,
+  });
+
+  const firstSnapshot = {
+    ...buildDirtySnapshot(),
+    visibility: EventVisibility.OFFLINE,
+  };
+  hub.broadcast(firstSnapshot);
+  await flushPromises();
+  expect(response.writes.join("")).toContain("id: event-id:7");
+
+  authorized = false;
+  hub.broadcast({
+    ...firstSnapshot,
+    live: {
+      ...firstSnapshot.live!,
+      sequence: 8,
+    },
+  });
+  await flushPromises();
+
+  expect(response.writes.join("")).not.toContain("id: event-id:8");
+  expect(response.writableEnded).toBe(true);
+  expect(hub.subscriberCount()).toBe(0);
 });
 
 it("uses default options, skips non-live payloads, and tolerates repeated cleanup without flushHeaders", () => {

--- a/event/src/route/__test__/EventOddsClicked.test.ts
+++ b/event/src/route/__test__/EventOddsClicked.test.ts
@@ -1,4 +1,5 @@
 import request from "supertest";
+import jwt from "jsonwebtoken";
 import { app } from "../../app";
 import { Event } from "../../model/Event";
 import {
@@ -12,6 +13,21 @@ import {
   TeamSide,
 } from "@betstan/common";
 import EventOddsSelectedPublisher from "../../messaging/publisher/EventOddsSelectedPublisher";
+import { setAdminSessionVerifierForTests } from "../../service/VerifyAdminSession";
+
+const buildSessionCookie = (role: "USER" | "ADMIN") => {
+  const token = jwt.sign(
+    {
+      id: "user-id",
+      email: "acceptance-admin",
+      role,
+      timestamp: new Date(),
+    },
+    process.env.JWT_KEY!
+  );
+  const session = Buffer.from(JSON.stringify({ jwt: token })).toString("base64");
+  return [`session=${session}`];
+};
 
 const createPreMatchEvent = async (time = new Date(Date.now() + 60 * 60 * 1000)) => {
   return Event.create({
@@ -118,6 +134,51 @@ it("publishes server-authoritative pre-match selections and ignores client kind/
       eventTime: event.time.toISOString(),
     }),
   });
+});
+
+it("keeps offline acceptance events unavailable to non-admin users", async () => {
+  const event = await createPreMatchEvent();
+  event.visibility = EventVisibility.OFFLINE;
+  await event.save();
+  const selection = {
+    eventId: "test-event-id",
+    productId: "product-1",
+    oddsId: "odds-1",
+  };
+
+  await request(app).post("/api/event/odds").send(selection).expect(401);
+  await request(app)
+    .post("/api/event/odds")
+    .set("Cookie", buildSessionCookie("USER"))
+    .send(selection)
+    .expect(403);
+  expect(EventOddsSelectedPublisher.prototype.publish).not.toHaveBeenCalled();
+
+  await request(app)
+    .post("/api/event/odds")
+    .set("Cookie", buildSessionCookie("ADMIN"))
+    .send(selection)
+    .expect(200);
+  expect(EventOddsSelectedPublisher.prototype.publish).toHaveBeenCalledTimes(1);
+});
+
+it("rejects a demoted administrator for an offline acceptance event", async () => {
+  const event = await createPreMatchEvent();
+  event.visibility = EventVisibility.OFFLINE;
+  await event.save();
+  setAdminSessionVerifierForTests(async () => 403);
+
+  await request(app)
+    .post("/api/event/odds")
+    .set("Cookie", buildSessionCookie("ADMIN"))
+    .send({
+      eventId: "test-event-id",
+      productId: "product-1",
+      oddsId: "odds-1",
+    })
+    .expect(403);
+
+  expect(EventOddsSelectedPublisher.prototype.publish).not.toHaveBeenCalled();
 });
 
 it("returns 400 when event not found", async () => {

--- a/event/src/route/__test__/ListAllEvents.test.ts
+++ b/event/src/route/__test__/ListAllEvents.test.ts
@@ -13,6 +13,8 @@ import {
   TeamSide,
 } from "@betstan/common";
 import NewEventPublisher from "../../messaging/publisher/NewEventPublisher";
+import jwt from "jsonwebtoken";
+import { setAdminSessionVerifierForTests } from "../../service/VerifyAdminSession";
 
 const createPreMatchEvent = async (
   eventId: string,
@@ -33,6 +35,20 @@ const createPreMatchEvent = async (
       },
     ],
   });
+};
+
+const adminCookie = () => {
+  const token = jwt.sign(
+    {
+      id: new mongoose.Types.ObjectId().toHexString(),
+      email: "acceptance-admin",
+      role: "ADMIN",
+      timestamp: new Date(),
+    },
+    process.env.JWT_KEY!
+  );
+  const session = Buffer.from(JSON.stringify({ jwt: token })).toString("base64");
+  return [`session=${session}`];
 };
 
 it("returns a bounded event list with live events sorted before pre-match events", async () => {
@@ -95,6 +111,68 @@ it("returns an empty array without creating events when DB is empty", async () =
   expect(res.body).toEqual([]);
   expect(await Event.countDocuments()).toEqual(0);
   expect(NewEventPublisher.prototype.publish).not.toHaveBeenCalled();
+});
+
+it("hides offline events unless an administrator requests their exact IDs", async () => {
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+  await createPreMatchEvent(eventId, new Date(Date.now() + 10 * 60 * 1000));
+  await Event.updateOne(
+    { eventId },
+    { $set: { visibility: EventVisibility.OFFLINE } }
+  );
+
+  expect((await request(app).get("/api/event").expect(200)).body).toEqual([]);
+  await request(app)
+    .get(`/api/event?acceptanceEventIds=${eventId}`)
+    .expect(401);
+
+  const response = await request(app)
+    .get(`/api/event?acceptanceEventIds=${eventId}`)
+    .set("Cookie", adminCookie())
+    .expect(200);
+  expect(response.body.map((event: { eventId: string }) => event.eventId)).toEqual(
+    [eventId]
+  );
+});
+
+it("rejects stale administrators and fails closed when auth verification is unavailable", async () => {
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+  await createPreMatchEvent(eventId, new Date(Date.now() + 10 * 60 * 1000));
+  await Event.updateOne(
+    { eventId },
+    { $set: { visibility: EventVisibility.OFFLINE } }
+  );
+
+  setAdminSessionVerifierForTests(async () => 403);
+  await request(app)
+    .get(`/api/event?acceptanceEventIds=${eventId}`)
+    .set("Cookie", adminCookie())
+    .expect(403);
+
+  setAdminSessionVerifierForTests(async () => {
+    throw new Error("auth unavailable");
+  });
+  await request(app)
+    .get(`/api/event?acceptanceEventIds=${eventId}`)
+    .set("Cookie", adminCookie())
+    .expect(503);
+});
+
+it("rejects malformed or oversized acceptance event scopes", async () => {
+  const cookie = adminCookie();
+  await request(app)
+    .get("/api/event?acceptanceEventIds=ABCDEFABCDEFABCDEFABCDEF")
+    .set("Cookie", cookie)
+    .expect(400);
+
+  const tooManyIds = Array.from(
+    { length: 11 },
+    () => new mongoose.Types.ObjectId().toHexString()
+  ).join(",");
+  await request(app)
+    .get(`/api/event?acceptanceEventIds=${tooManyIds}`)
+    .set("Cookie", cookie)
+    .expect(400);
 });
 
 it("keeps legacy event documents readable without requiring live fields", async () => {

--- a/event/src/service/VerifyAdminSession.ts
+++ b/event/src/service/VerifyAdminSession.ts
@@ -1,0 +1,78 @@
+import http from "http";
+import https from "https";
+import { Request } from "express";
+
+const VERIFICATION_TIMEOUT_MS = 3000;
+
+export type AdminVerificationStatus = 204 | 401 | 403;
+export type AdminSessionVerifier = (
+  cookieHeader: string
+) => Promise<AdminVerificationStatus>;
+
+const verifyAdminSessionOverHttp: AdminSessionVerifier = (cookieHeader) => {
+  const serviceUrl = process.env.AUTH_SERVICE_URL;
+  if (!serviceUrl) {
+    return Promise.reject(new Error("AUTH_SERVICE_URL is not configured"));
+  }
+
+  const url = new URL("/api/auth/admin/verify", serviceUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return Promise.reject(new Error("AUTH_SERVICE_URL must use HTTP or HTTPS"));
+  }
+  const transport = url.protocol === "https:" ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const verificationRequest = transport.request(
+      url,
+      {
+        method: "GET",
+        headers: { Cookie: cookieHeader },
+        timeout: VERIFICATION_TIMEOUT_MS,
+      },
+      (response) => {
+        response.resume();
+        const status = response.statusCode;
+        if (status === 204 || status === 401 || status === 403) {
+          resolve(status);
+          return;
+        }
+
+        reject(new Error(`Unexpected auth verification status ${status}`));
+      }
+    );
+
+    verificationRequest.on("timeout", () => {
+      verificationRequest.destroy(new Error("Auth verification timed out"));
+    });
+    verificationRequest.on("error", reject);
+    verificationRequest.end();
+  });
+};
+
+export const verifyAdminSession = verifyAdminSessionOverHttp;
+let sessionVerifier: AdminSessionVerifier = verifyAdminSessionOverHttp;
+
+export const setAdminSessionVerifierForTests = (
+  verifier: AdminSessionVerifier
+) => {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error("Admin session verifier can only be replaced in tests");
+  }
+  sessionVerifier = verifier;
+};
+
+export const verifyAdminRequest = async (
+  req: Request
+): Promise<AdminVerificationStatus> => {
+  if (!req.currentUser) {
+    return 401;
+  }
+  const role = (
+    req.currentUser as typeof req.currentUser & { role?: string }
+  ).role;
+  if (role !== "ADMIN") {
+    return 403;
+  }
+
+  return sessionVerifier(req.headers.cookie ?? "");
+};

--- a/event/src/service/__test__/VerifyAdminSession.test.ts
+++ b/event/src/service/__test__/VerifyAdminSession.test.ts
@@ -1,0 +1,60 @@
+import http from "http";
+import { AddressInfo } from "net";
+import { verifyAdminSession } from "../VerifyAdminSession";
+
+let server: http.Server | undefined;
+
+afterEach(async () => {
+  delete process.env.AUTH_SERVICE_URL;
+  if (server) {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => (error ? reject(error) : resolve()));
+    });
+    server = undefined;
+  }
+});
+
+async function startAuthStub(status: number) {
+  let receivedCookie: string | undefined;
+  server = http.createServer((request, response) => {
+    receivedCookie = request.headers.cookie;
+    response.statusCode = status;
+    response.end();
+  });
+  await new Promise<void>((resolve) => {
+    server?.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  process.env.AUTH_SERVICE_URL = `http://127.0.0.1:${address.port}`;
+
+  return () => receivedCookie;
+}
+
+it.each([204, 401, 403] as const)(
+  "returns the supported auth verification status %s",
+  async (status) => {
+    const receivedCookie = await startAuthStub(status);
+
+    await expect(verifyAdminSession("session=signed")).resolves.toBe(status);
+    expect(receivedCookie()).toBe("session=signed");
+  }
+);
+
+it("rejects an unexpected auth response", async () => {
+  await startAuthStub(500);
+
+  await expect(verifyAdminSession("session=signed")).rejects.toThrow(
+    "Unexpected auth verification status 500"
+  );
+});
+
+it("rejects a missing or unsupported auth service URL", async () => {
+  await expect(verifyAdminSession("session=signed")).rejects.toThrow(
+    "AUTH_SERVICE_URL is not configured"
+  );
+
+  process.env.AUTH_SERVICE_URL = "file:///tmp/auth";
+  await expect(verifyAdminSession("session=signed")).rejects.toThrow(
+    "AUTH_SERVICE_URL must use HTTP or HTTPS"
+  );
+});

--- a/event/src/test/setup.ts
+++ b/event/src/test/setup.ts
@@ -1,6 +1,7 @@
 import { MongoMemoryServer } from "mongodb-memory-server";
 import mongoose from "mongoose";
 import { liveEventHub } from "../live/LiveEventHub";
+import { setAdminSessionVerifierForTests } from "../service/VerifyAdminSession";
 
 jest.mock("@betstan/common", () => {
   const actual = jest.requireActual("@betstan/common");
@@ -70,6 +71,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   jest.clearAllMocks();
   liveEventHub.reset();
+  setAdminSessionVerifierForTests(async () => 204);
   const collections = await mongoose.connection.db.collections();
 
   for (let collection of collections) {

--- a/gamemaster/src/event/listener/NewEventListener.ts
+++ b/gamemaster/src/event/listener/NewEventListener.ts
@@ -8,6 +8,7 @@ import {
 } from "@betstan/common";
 import { Event } from "../../model/Event";
 import { EventArchive } from "../../model/EventArchive";
+import { createLiveSeed } from "../../simulation/liveSeed";
 
 class NewEventListener extends AListener<INewEventEvent> {
   serviceName: string = "gamemaster_new_event";
@@ -33,6 +34,7 @@ class NewEventListener extends AListener<INewEventEvent> {
             away: data.away,
             status: EventStatus.NO_RESULT,
             phase: EventPhase.PRE_MATCH,
+            liveSeed: createLiveSeed(),
           },
         },
         { upsert: true }

--- a/gamemaster/src/event/listener/__test__/NewEventListener.test.ts
+++ b/gamemaster/src/event/listener/__test__/NewEventListener.test.ts
@@ -78,6 +78,8 @@ it("stores new events with their live pre-match defaults", async () => {
   expect(stored?.name).toBe("New event");
   expect(stored?.phase).toBe("PRE_MATCH");
   expect(stored?.liveConfirmedReplayCursor).toBe(0);
+  expect(stored?.liveSeed).toMatch(/^[a-f0-9]{64}$/);
+  expect(stored?.liveSeed).not.toBe(data.data.id);
 });
 
 it("keeps the first insert when a NewEvent delivery is duplicated", async () => {
@@ -85,6 +87,7 @@ it("keeps the first insert when a NewEvent delivery is duplicated", async () => 
   const data = getData();
 
   await listener.onMessage(data, message);
+  const firstSeed = (await Event.findOne({ eventId: data.data.id }))?.liveSeed;
   await listener.onMessage(
     {
       ...data,
@@ -103,6 +106,7 @@ it("keeps the first insert when a NewEvent delivery is duplicated", async () => 
   expect(stored?.name).toBe("New event");
   expect(stored?.home).toBe("Player 1");
   expect(stored?.away).toBe("Player 2");
+  expect(stored?.liveSeed).toBe(firstSeed);
 });
 
 it("acknowledges late NewEvent deliveries without resurrecting an archive", async () => {

--- a/gamemaster/src/simulation/__test__/liveSeed.test.ts
+++ b/gamemaster/src/simulation/__test__/liveSeed.test.ts
@@ -1,0 +1,17 @@
+import { createLiveSeed, isPrivateLiveSeed } from "../liveSeed";
+
+it("creates independent 256-bit hexadecimal seeds", () => {
+  const first = createLiveSeed();
+  const second = createLiveSeed();
+
+  expect(first).toMatch(/^[a-f0-9]{64}$/);
+  expect(second).toMatch(/^[a-f0-9]{64}$/);
+  expect(second).not.toBe(first);
+});
+
+it("rejects public identifiers and weak legacy seeds", () => {
+  expect(isPrivateLiveSeed("public-event-id")).toBe(false);
+  expect(isPrivateLiveSeed("a".repeat(63))).toBe(false);
+  expect(isPrivateLiveSeed("A".repeat(64))).toBe(false);
+  expect(isPrivateLiveSeed("a".repeat(64))).toBe(true);
+});

--- a/gamemaster/src/simulation/liveSeed.ts
+++ b/gamemaster/src/simulation/liveSeed.ts
@@ -1,0 +1,11 @@
+import { randomBytes } from "crypto";
+
+const LIVE_SEED_PATTERN = /^[a-f0-9]{64}$/;
+
+export function createLiveSeed(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export function isPrivateLiveSeed(value: unknown): value is string {
+  return typeof value === "string" && LIVE_SEED_PATTERN.test(value);
+}

--- a/gamemaster/src/worker/GamemasterWorker.ts
+++ b/gamemaster/src/worker/GamemasterWorker.ts
@@ -22,6 +22,7 @@ import {
   SimulationTransition,
   simulateMatch,
 } from "../simulation";
+import { createLiveSeed, isPrivateLiveSeed } from "../simulation/liveSeed";
 
 const DEFAULT_WORK_CADENCE_MS = 1000;
 const DEFAULT_LEASE_DURATION_MS = 30000;
@@ -44,8 +45,9 @@ interface GamemasterWorkerOptions {
   clock?: WorkerClock;
   cadenceMs?: number;
   leaseDurationMs?: number;
-  liveKickoffsEnabled?: () => boolean;
+  liveKickoffsEnabled?: (now: Date) => boolean;
   simulate?: typeof simulateMatch;
+  createLiveSeed?: () => string;
 }
 
 const systemClock: WorkerClock = {
@@ -54,17 +56,30 @@ const systemClock: WorkerClock = {
   clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
 };
 
-function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
-  if (value === undefined) {
-    return defaultValue;
+export function liveKickoffsAllowedAt(
+  now: Date,
+  enabledValue = process.env.LIVE_KICKOFFS_ENABLED,
+  leaseUntilEpochValue = process.env.LIVE_KICKOFFS_LEASE_UNTIL_EPOCH
+): boolean {
+  if (enabledValue?.trim().toLowerCase() !== "true") {
+    return false;
   }
 
-  const normalised = value.trim().toLowerCase();
-  if (!normalised) {
-    return defaultValue;
+  if (leaseUntilEpochValue === undefined) {
+    return true;
   }
 
-  return !["0", "false", "no", "off"].includes(normalised);
+  const normalisedLease = leaseUntilEpochValue.trim();
+  if (!/^[1-9][0-9]*$/.test(normalisedLease)) {
+    return false;
+  }
+
+  const leaseUntilEpoch = Number(normalisedLease);
+  if (!Number.isSafeInteger(leaseUntilEpoch)) {
+    return false;
+  }
+
+  return now.getTime() < leaseUntilEpoch * 1000;
 }
 
 function asDate(value: Date | string | null | undefined): Date {
@@ -180,8 +195,9 @@ export class GamemasterWorker {
   private readonly clock: WorkerClock;
   private readonly cadenceMs: number;
   private readonly leaseDurationMs: number;
-  private readonly liveKickoffsEnabled: () => boolean;
+  private readonly liveKickoffsEnabled: (now: Date) => boolean;
   private readonly simulate: typeof simulateMatch;
+  private readonly createLiveSeed: () => string;
   private initPromise?: Promise<void>;
   private scheduledTick?: TimerHandle;
   private running = false;
@@ -193,8 +209,9 @@ export class GamemasterWorker {
     this.leaseDurationMs = options.leaseDurationMs ?? DEFAULT_LEASE_DURATION_MS;
     this.liveKickoffsEnabled =
       options.liveKickoffsEnabled
-      ?? (() => parseBoolean(process.env.LIVE_KICKOFFS_ENABLED, false));
+      ?? ((now: Date) => liveKickoffsAllowedAt(now));
     this.simulate = options.simulate ?? simulateMatch;
+    this.createLiveSeed = options.createLiveSeed ?? createLiveSeed;
   }
 
   async init() {
@@ -335,7 +352,7 @@ export class GamemasterWorker {
         { liveNextTransitionAt: 1, time: 1 },
         now
       )
-      ?? (this.liveKickoffsEnabled()
+      ?? (this.liveKickoffsEnabled(now)
         ? await this.claimEvent(
           {
             status: EventStatus.NO_RESULT,
@@ -452,15 +469,18 @@ export class GamemasterWorker {
     }
 
     const kickoffAt = asDate(event.time);
-    if (kickoffAt.getTime() > this.clock.now().getTime()) {
+    const now = this.clock.now();
+    if (kickoffAt.getTime() > now.getTime()) {
       return event;
     }
 
-    if (!this.liveKickoffsEnabled()) {
+    if (!this.liveKickoffsEnabled(now)) {
       return event;
     }
 
-    const seed = String(event.liveSeed ?? event.eventId);
+    const seed = isPrivateLiveSeed(event.liveSeed)
+      ? event.liveSeed
+      : this.createLiveSeed();
     const simulation = this.simulate({
       eventId: event.eventId,
       seed,
@@ -484,7 +504,8 @@ export class GamemasterWorker {
             kickoffAt,
             simulation,
             persistencePlan.confirmedSequence,
-            persistencePlan.liveEndedAt
+            persistencePlan.liveEndedAt,
+            seed
           ),
         },
         { new: true }
@@ -531,7 +552,8 @@ export class GamemasterWorker {
     kickoffAt: Date,
     simulation: SimulationResult,
     confirmedSequence = 0,
-    liveEndedAtOverride?: Date
+    liveEndedAtOverride?: Date,
+    privateSeed = String(simulation.timeline.seed)
   ): Record<string, unknown> {
     const confirmedTransition =
       confirmedSequence > 0
@@ -540,7 +562,7 @@ export class GamemasterWorker {
 
     return {
       phase: confirmedTransition?.phase ?? EventPhase.PRE_MATCH,
-      liveSeed: String(simulation.timeline.seed),
+      liveSeed: privateSeed,
       liveEngineVersion: simulation.engineVersion,
       liveStartedAt: kickoffAt,
       liveEndedAt:

--- a/gamemaster/src/worker/__test__/GamemasterWorker.test.ts
+++ b/gamemaster/src/worker/__test__/GamemasterWorker.test.ts
@@ -20,7 +20,11 @@ import {
   SimulationTransition,
   TeamSide,
 } from "../../simulation";
-import { GamemasterWorker, WorkerClock } from "../GamemasterWorker";
+import {
+  GamemasterWorker,
+  WorkerClock,
+  liveKickoffsAllowedAt,
+} from "../GamemasterWorker";
 
 beforeAll(() => {
   jest.spyOn(ResultSetPublisher.prototype, "init").mockResolvedValue(undefined);
@@ -43,6 +47,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   process.env.LIVE_KICKOFFS_ENABLED = "true";
+  delete process.env.LIVE_KICKOFFS_LEASE_UNTIL_EPOCH;
   (
     ResultSetPublisher.prototype.publishWithConfirm as unknown as jest.Mock
   ).mockResolvedValue(undefined);
@@ -654,6 +659,7 @@ it("persists a simulation before kickoff publication and replays it after restar
   const event = await createEvent(baseKickoff);
   const simulation = buildSimulationResult(event.eventId);
   const simulate = jest.fn(() => simulation);
+  const privateSeed = "a".repeat(64);
   const firstClock: WorkerClock = {
     now: () => new Date(baseKickoff.getTime()),
     setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
@@ -668,11 +674,21 @@ it("persists a simulation before kickoff publication and replays it after restar
     expect(stored?.liveConfirmedReplayCursor).toBe(0);
   });
 
-  const firstWorker = new GamemasterWorker({ clock: firstClock, simulate });
+  const firstWorker = new GamemasterWorker({
+    clock: firstClock,
+    simulate,
+    createLiveSeed: () => privateSeed,
+  });
   await firstWorker.checkEventsOnce();
 
   const afterKickoff = await Event.findOne({ eventId: event.eventId });
   expect(simulate).toHaveBeenCalledTimes(1);
+  expect(simulate).toHaveBeenCalledWith({
+    eventId: event.eventId,
+    seed: privateSeed,
+  });
+  expect(afterKickoff?.liveSeed).toBe(privateSeed);
+  expect(afterKickoff?.liveSeed).not.toBe(event.eventId);
   expect(afterKickoff?.liveConfirmedReplayCursor).toBe(1);
   expect(afterKickoff?.phase).toBe(EventPhase.FIRST_HALF);
   expect(
@@ -816,6 +832,56 @@ it("keeps new kickoffs dark by default when the env flag is missing", async () =
   expect(
     ResultSetPublisher.prototype.publishWithConfirm
   ).not.toHaveBeenCalled();
+});
+
+it("fails dark when an activation lease is malformed or expired", () => {
+  const now = new Date("2025-01-01T12:00:00.500Z");
+  const nowEpoch = Math.floor(now.getTime() / 1000);
+
+  expect(liveKickoffsAllowedAt(now, "true", undefined)).toBe(true);
+  expect(
+    liveKickoffsAllowedAt(now, "true", String(nowEpoch + 60))
+  ).toBe(true);
+  expect(liveKickoffsAllowedAt(now, "true", String(nowEpoch))).toBe(false);
+  expect(
+    liveKickoffsAllowedAt(now, "true", String(nowEpoch - 1))
+  ).toBe(false);
+  expect(liveKickoffsAllowedAt(now, "true", "not-an-epoch")).toBe(false);
+  expect(liveKickoffsAllowedAt(now, "true", "0")).toBe(false);
+  expect(
+    liveKickoffsAllowedAt(now, "false", String(nowEpoch + 60))
+  ).toBe(false);
+});
+
+it("lets active matches finish but blocks new kickoffs after the lease expires", async () => {
+  const newEvent = await createEvent(baseKickoff);
+  const activeEvent = await createEvent(baseKickoff);
+  const activeSimulation = buildSimulationResult(activeEvent.eventId);
+  await storeSimulation(activeEvent, activeSimulation, 4);
+
+  const now = new Date(baseKickoff.getTime() + 5000);
+  process.env.LIVE_KICKOFFS_LEASE_UNTIL_EPOCH = String(
+    Math.floor(now.getTime() / 1000) - 1
+  );
+  const worker = new GamemasterWorker({
+    clock: createStaticClock(now),
+    simulate: jest.fn(() => buildSimulationResult(newEvent.eventId)),
+  });
+
+  await worker.checkEventsOnce();
+
+  const untouchedNewEvent = await Event.findOne({ eventId: newEvent.eventId });
+  const completedActiveArchive = await EventArchive.findOne({
+    eventId: activeEvent.eventId,
+  });
+  expect(untouchedNewEvent?.liveTransitions).toEqual([]);
+  expect(completedActiveArchive?.homeResult).toBe(1);
+  expect(
+    LiveEventUpdatePublisher.prototype.publishWithConfirm
+  ).toHaveBeenCalledTimes(1);
+  expect(
+    ResultSetPublisher.prototype.publishWithConfirm
+  ).toHaveBeenCalledTimes(1);
 });
 
 it("uses a lease so concurrent workers do not process the same match twice", async () => {
@@ -1307,6 +1373,7 @@ it("covers claim selection and persistence planning helper branches", async () =
     clock: baseClock,
     liveKickoffsEnabled: () => true,
     simulate: simulateSpy,
+    createLiveSeed: () => "b".repeat(64),
   });
 
   const storedEvent = {
@@ -1353,7 +1420,7 @@ it("covers claim selection and persistence planning helper branches", async () =
     _id: new mongoose.Types.ObjectId(),
     eventId: "recovering-event",
     time: baseKickoff,
-    liveSeed: "stored-seed",
+    liveSeed: "a".repeat(64),
     processingLease: { token: "lease-token" },
     liveTransitions: [],
   };
@@ -1369,7 +1436,7 @@ it("covers claim selection and persistence planning helper branches", async () =
   ).resolves.toEqual({ recovered: true });
   expect(simulateSpy).toHaveBeenCalledWith({
     eventId: "recovering-event",
-    seed: "stored-seed",
+    seed: "a".repeat(64),
   });
 
   findOneAndUpdateSpy.mockRestore();

--- a/infra/azure/agents/copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/copilot-cli-run-approval-stan.sh
@@ -50,6 +50,12 @@ case "$EXPECTED_WORKFLOW:$EXPECTED_ENVIRONMENT" in
   oci-production-deploy.yml:oci-production)
     expected_event="workflow_dispatch"
     ;;
+  oci-live-betting-activate.yml:oci-production)
+    expected_event="workflow_dispatch"
+    ;;
+  oci-live-betting-disable.yml:oci-production)
+    expected_event="workflow_dispatch"
+    ;;
   *)
     fail "workflow/environment pair is not eligible for automatic approval"
     ;;

--- a/infra/azure/agents/production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/production-run-exclusivity-stan.sh
@@ -48,6 +48,8 @@ paths = {
     ".github/workflows/oci-infrastructure.yml",
     ".github/workflows/oci-capacity-acquire.yml",
     ".github/workflows/oci-live-data-rollout.yml",
+    ".github/workflows/oci-live-betting-activate.yml",
+    ".github/workflows/oci-live-betting-disable.yml",
     ".github/workflows/oci-migrate.yml",
     ".github/workflows/oci-migration-recovery.yml",
 }

--- a/infra/azure/agents/production-workflow-inventory-stan.rb
+++ b/infra/azure/agents/production-workflow-inventory-stan.rb
@@ -12,6 +12,8 @@ AZURE_WORKFLOWS = %w[
 OCI_WORKFLOWS = %w[
   oci-capacity-acquire
   oci-infrastructure
+  oci-live-betting-activate
+  oci-live-betting-disable
   oci-live-data-rollout
   oci-migrate
   oci-migration-recovery
@@ -24,6 +26,8 @@ PROTECTED_ENVIRONMENTS = {
   "production-rollback" => "production-emergency",
   "oci-capacity-acquire" => "oci-capacity-acquire",
   "oci-infrastructure" => "oci-infrastructure",
+  "oci-live-betting-activate" => "oci-production",
+  "oci-live-betting-disable" => "oci-production",
   "oci-live-data-rollout" => "oci-migration",
   "oci-migrate" => "oci-migration",
   "oci-migration-recovery" => "azure-migration-recovery",
@@ -45,6 +49,19 @@ ROLLBACK_ACTION_PINS = {
     "oracle-actions/configure-kubectl-oke" => "77a733d79446dabe7bf0e58eb56197d33ce4dc58"
   },
   "oci-live-data-rollout" => {
+    "actions/checkout" => "11bd71901bbe5b1630ceea73d27597364c9af683",
+    "actions/download-artifact" => "d3f86a106a0bac45b974a628896c90dbdf5c8093",
+    "actions/upload-artifact" => "ea165f8d65b6e75b540449e92b4886f43607fa02",
+    "oracle-actions/configure-kubectl-oke" => "77a733d79446dabe7bf0e58eb56197d33ce4dc58"
+  },
+  "oci-live-betting-activate" => {
+    "actions/checkout" => "11bd71901bbe5b1630ceea73d27597364c9af683",
+    "actions/download-artifact" => "d3f86a106a0bac45b974a628896c90dbdf5c8093",
+    "actions/setup-node" => "49933ea5288caeca8642d1e84afbd3f7d6820020",
+    "actions/upload-artifact" => "ea165f8d65b6e75b540449e92b4886f43607fa02",
+    "oracle-actions/configure-kubectl-oke" => "77a733d79446dabe7bf0e58eb56197d33ce4dc58"
+  },
+  "oci-live-betting-disable" => {
     "actions/checkout" => "11bd71901bbe5b1630ceea73d27597364c9af683",
     "actions/download-artifact" => "d3f86a106a0bac45b974a628896c90dbdf5c8093",
     "actions/upload-artifact" => "ea165f8d65b6e75b540449e92b4886f43607fa02",
@@ -739,6 +756,158 @@ def validate_live_data_rollout_workflow!(file, document, content)
   )
 end
 
+def validate_live_betting_activation_workflow!(file, document, content)
+  name = "oci-live-betting-activate"
+  unless File.basename(file) == "#{name}.yml"
+    fail_inventory("#{name} must use .github/workflows/#{name}.yml")
+  end
+
+  validate_dispatch_only_workflow!(name, document)
+  validate_required_workflow_dispatch_inputs!(
+    name,
+    document,
+    %w[
+      approved_sha
+      build_run_id
+      infrastructure_run_id
+      deployment_run_id
+      confirmation
+    ]
+  )
+  validate_exact_permissions!(name, document, { "actions" => "read", "contents" => "read" })
+  validate_expected_action_pins!(name, content)
+
+  {
+    "ACTIVATE OCI LIVE BETTING" => "exact activation confirmation",
+    "oci-production-build.yml" => "exact build provenance",
+    "oci-infrastructure.yml" => "exact infrastructure provenance",
+    "oci-production-deploy.yml" => "exact dark deployment provenance",
+    "oci-live-readiness-" => "dark readiness evidence",
+    "live-betting-control-stan.sh" => "reviewed flag operator",
+    "ACTION: activate" => "explicit activation action",
+    "LIVE_ACTIVATION_LEASE_SECONDS" => "bounded activation lease",
+    "activation_state=leased" => "leased pre-commit provenance",
+    "COMMIT OCI LIVE BETTING" => "exact permanent activation confirmation",
+    "ACTION: commit" => "post-acceptance activation commit",
+    "ACTION: disable" => "automatic failure disable action",
+    "steps.accepted.outcome != 'success'" => "failure-triggered disable gate",
+    "steps.evidence_upload.outcome != 'success'" => "evidence-failure disable gate",
+    "steps.commit_preflight.outcome != 'success'" => "commit preflight failure gate",
+    "steps.commit.outcome != 'success'" => "commit failure disable gate",
+    "runtime_fingerprint" => "deployment-to-infrastructure runtime binding",
+    "infrastructure_provenance_sha256" => "exact infrastructure artifact binding",
+    "revalidate-live-activation-stan.sh" => "immediate master and provenance revalidation",
+    "ROLLBACK_BASELINE_FILE" => "dark rollback baseline validation",
+    "role:set" => "protected disposable administrator operator",
+    "playwright-live-acceptance.config.js" => "production browser acceptance",
+    "service-ops-stan.sh" => "sanitized runtime log inspection"
+  }.each do |literal, label|
+    require_content(
+      content,
+      /#{Regexp.escape(literal)}/,
+      "#{name} is missing #{label}"
+    )
+  end
+
+  require_content(
+    content,
+    /group:\s*oci-control-plane/,
+    "#{name} must serialize with the OCI control plane"
+  )
+  require_content(
+    content,
+    /cancel-in-progress:\s*false/,
+    "#{name} must never cancel an in-flight activation"
+  )
+  if content.scan("revalidate-live-activation-stan.sh").length < 3
+    fail_inventory(
+      "#{name} must revalidate before mutation, acceptance, and permanent activation"
+    )
+  end
+
+  evidence_position = content.index("- name: Upload protected activation evidence")
+  commit_revalidation_position =
+    content.index("- name: Revalidate release head before permanent activation")
+  commit_position = content.index("- name: Commit accepted live activation")
+  unless evidence_position &&
+      commit_revalidation_position &&
+      commit_position &&
+      evidence_position < commit_revalidation_position &&
+      commit_revalidation_position < commit_position
+    fail_inventory(
+      "#{name} must upload evidence and revalidate before permanent activation"
+    )
+  end
+end
+
+def validate_live_betting_disable_workflow!(file, document, content)
+  name = "oci-live-betting-disable"
+  unless File.basename(file) == "#{name}.yml"
+    fail_inventory("#{name} must use .github/workflows/#{name}.yml")
+  end
+
+  validate_dispatch_only_workflow!(name, document)
+  validate_required_workflow_dispatch_inputs!(
+    name,
+    document,
+    %w[approved_sha deployment_run_id infrastructure_run_id confirmation]
+  )
+  validate_exact_permissions!(name, document, { "actions" => "read", "contents" => "read" })
+  validate_expected_action_pins!(name, content)
+
+  {
+    "DISABLE OCI LIVE BETTING" => "exact disable confirmation",
+    "oci-production-deploy.yml" => "exact deployment provenance",
+    "oci-infrastructure.yml" => "exact infrastructure provenance",
+    "authorize-github-runner.sh authorize" => "exact runner authorization",
+    "revoke-github-runner.sh" => "always-run runner revocation",
+    "configure-k3s-access.sh open" => "k3s runner authorization",
+    "configure-k3s-access.sh cleanup" => "always-run k3s access cleanup",
+    "runtime_fingerprint" => "deployment-to-infrastructure runtime binding",
+    "infrastructure_provenance_sha256" => "exact infrastructure artifact binding",
+    "merge-base --is-ancestor" => "deployed-master ancestry validation",
+    "live-betting-control-stan.sh" => "reviewed flag operator",
+    "ACTION: disable" => "explicit disable action",
+    "MODE=rollback-drain" => "live-aware drain gate",
+    "live betting did not drain within 20 minutes" => "bounded drain timeout",
+    "steps.disable.outcome != 'success'" => "workflow-level dark reassertion",
+    "service-ops-stan.sh" => "sanitized runtime diagnostics",
+    "oci-live-betting-disable-" => "attempt-bound disable evidence"
+  }.each do |literal, label|
+    require_content(
+      content,
+      /#{Regexp.escape(literal)}/,
+      "#{name} is missing #{label}"
+    )
+  end
+
+  require_content(
+    content,
+    /group:\s*oci-control-plane/,
+    "#{name} must serialize with the OCI control plane"
+  )
+  require_content(
+    content,
+    /cancel-in-progress:\s*false/,
+    "#{name} must never cancel an in-flight disable or drain"
+  )
+end
+
+def validate_oci_production_deploy_binding!(name, document, content)
+  validate_manual_oci_workflow!(name, document, content)
+  {
+    "infrastructure_run_id=%s" => "infrastructure run binding",
+    "infrastructure_run_attempt=1" => "first-attempt infrastructure binding",
+    "infrastructure_provenance_sha256=%s" => "infrastructure artifact digest binding"
+  }.each do |literal, label|
+    require_content(
+      content,
+      /#{Regexp.escape(literal)}/,
+      "#{name} is missing #{label}"
+    )
+  end
+end
+
 def validate_oci_workflow!(name, file, document, content)
   expected_file = "#{name}.yml"
   unless File.basename(file) == expected_file
@@ -806,6 +975,12 @@ def validate_oci_workflow!(name, file, document, content)
     validate_migration_recovery_workflow!(name, document, content)
   elsif name == "oci-live-data-rollout"
     validate_live_data_rollout_workflow!(file, document, content)
+  elsif name == "oci-live-betting-activate"
+    validate_live_betting_activation_workflow!(file, document, content)
+  elsif name == "oci-live-betting-disable"
+    validate_live_betting_disable_workflow!(file, document, content)
+  elsif name == "oci-production-deploy"
+    validate_oci_production_deploy_binding!(name, document, content)
   else
     validate_manual_oci_workflow!(name, document, content)
   end

--- a/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
@@ -32,7 +32,7 @@ gh() {
       "[{\"environment\":{\"id\":456,\"name\":\"${STUB_ENVIRONMENT:-production-emergency}\"},\"current_user_can_approve\":true}]"
   elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID" ]]; then
     printf '%s\n' \
-      "{\"id\":$RUN_ID,\"path\":\".github/workflows/${STUB_WORKFLOW:-production-build.yml}\",\"event\":\"push\",\"head_sha\":\"$SHA\",\"head_branch\":\"master\",\"head_repository\":{\"full_name\":\"example/repo\"},\"run_attempt\":${STUB_ATTEMPT:-1},\"status\":\"waiting\"}"
+      "{\"id\":$RUN_ID,\"path\":\".github/workflows/${STUB_WORKFLOW:-production-build.yml}\",\"event\":\"${STUB_EVENT:-push}\",\"head_sha\":\"$SHA\",\"head_branch\":\"master\",\"head_repository\":{\"full_name\":\"example/repo\"},\"run_attempt\":${STUB_ATTEMPT:-1},\"status\":\"waiting\"}"
   elif [[ "$1" == "api" && "$2" == *"/commits/$SHA/pulls"* ]]; then
     local labels='[{"name":"copilot-cli-managed"}]'
     if [[ "${STUB_LABEL:-present}" == "missing" ]]; then
@@ -57,6 +57,28 @@ common_env=(
 )
 
 env "${common_env[@]}" "$APPROVER" "$RUN_ID" >/dev/null
+
+env \
+  REPO=example/repo \
+  EXPECTED_SHA="$SHA" \
+  EXPECTED_WORKFLOW=oci-live-betting-activate.yml \
+  EXPECTED_ENVIRONMENT=oci-production \
+  PRODUCTION_RUN_EXCLUSIVITY="$tmp_dir/production-exclusivity" \
+  STUB_WORKFLOW=oci-live-betting-activate.yml \
+  STUB_EVENT=workflow_dispatch \
+  STUB_ENVIRONMENT=oci-production \
+    "$APPROVER" "$RUN_ID" >/dev/null
+
+env \
+  REPO=example/repo \
+  EXPECTED_SHA="$SHA" \
+  EXPECTED_WORKFLOW=oci-live-betting-disable.yml \
+  EXPECTED_ENVIRONMENT=oci-production \
+  PRODUCTION_RUN_EXCLUSIVITY="$tmp_dir/production-exclusivity" \
+  STUB_WORKFLOW=oci-live-betting-disable.yml \
+  STUB_EVENT=workflow_dispatch \
+  STUB_ENVIRONMENT=oci-production \
+    "$APPROVER" "$RUN_ID" >/dev/null
 
 env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
   "$APPROVER" "$RUN_ID" --approve >/dev/null

--- a/infra/azure/agents/test-production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/test-production-run-exclusivity-stan.sh
@@ -27,6 +27,10 @@ gh() {
     local path=.github/workflows/production-build.yml
     if [[ "$STUB_MODE" == "data-active" ]]; then
       path=.github/workflows/oci-live-data-rollout.yml
+    elif [[ "$STUB_MODE" == "activation-active" ]]; then
+      path=.github/workflows/oci-live-betting-activate.yml
+    elif [[ "$STUB_MODE" == "disable-active" ]]; then
+      path=.github/workflows/oci-live-betting-disable.yml
     fi
     printf '%s\n' \
       "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"workflow_id\":$WORKFLOW_ID,\"path\":\"$path\",\"head_branch\":\"$branch\",\"status\":\"in_progress\",\"updated_at\":\"$updated_at\"}]}"
@@ -64,7 +68,7 @@ REPO=example/repo NOW_EPOCH=2000 STUB_MODE=stale-disabled \
 REPO=example/repo NOW_EPOCH=2000 STUB_MODE=active EXCLUDE_RUN_ID=$RUN_ID \
   "$EXCLUSIVITY" >/dev/null
 
-for mode in active data-active recent-disabled pending-disabled jobs-disabled overflow; do
+for mode in active data-active activation-active disable-active recent-disabled pending-disabled jobs-disabled overflow; do
   if REPO=example/repo NOW_EPOCH=2000 STUB_MODE="$mode" \
     "$EXCLUSIVITY" >/dev/null 2>&1; then
     echo "production exclusivity accepted unsafe mode=$mode" >&2

--- a/infra/azure/agents/test-production-workflow-inventory-stan.sh
+++ b/infra/azure/agents/test-production-workflow-inventory-stan.sh
@@ -161,6 +161,9 @@ jobs:
           git fetch origin master:refs/remotes/origin/master
           [ "${{ inputs.approved_sha }}" = "$(git rev-parse origin/master)" ]
           kubectl set image deployment/client client=iad.ocir.io/example/client:${{ inputs.approved_sha }}
+          printf 'infrastructure_run_id=%s\n' "$INFRASTRUCTURE_RUN_ID"
+          printf 'infrastructure_run_attempt=1\n'
+          printf 'infrastructure_provenance_sha256=%s\n' "$INFRASTRUCTURE_SHA256"
 YAML
 
   cat > "$tmp_dir/oci-migrate.yml" <<'YAML'
@@ -249,6 +252,8 @@ jobs:
 YAML
 
   cp "$ROOT_DIR/.github/workflows/oci-live-data-rollout.yml" "$tmp_dir/"
+  cp "$ROOT_DIR/.github/workflows/oci-live-betting-activate.yml" "$tmp_dir/"
+  cp "$ROOT_DIR/.github/workflows/oci-live-betting-disable.yml" "$tmp_dir/"
   cp "$ROOT_DIR/.github/workflows/oci-production-rollback.yml" "$tmp_dir/"
 }
 
@@ -657,7 +662,7 @@ PY
 }
 
 azure_set="production-build,production-deploy,production-rollback"
-full_set="oci-capacity-acquire,oci-infrastructure,oci-live-data-rollout,oci-migrate,oci-migration-recovery,oci-production-build,oci-production-deploy,oci-production-rollback,production-build,production-deploy,production-rollback"
+full_set="oci-capacity-acquire,oci-infrastructure,oci-live-betting-activate,oci-live-betting-disable,oci-live-data-rollout,oci-migrate,oci-migration-recovery,oci-production-build,oci-production-deploy,oci-production-rollback,production-build,production-deploy,production-rollback"
 install_pr_gh_stub
 
 reset_fixtures
@@ -1055,6 +1060,76 @@ sed -i.bak '/terraform apply/i\
           echo "${{ secrets[\"OCI_CLI_USER\"] }}"' "$tmp_dir/oci-infrastructure.yml"
 rm "$tmp_dir/oci-infrastructure.yml.bak"
 assert_pass "$full_set"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak "/steps.accepted.outcome != 'success'/d" \
+  "$tmp_dir/oci-live-betting-activate.yml"
+rm "$tmp_dir/oci-live-betting-activate.yml.bak"
+assert_fail \
+  "activation without automatic disable" \
+  "is missing failure-triggered disable gate"
+
+reset_fixtures
+write_complete_oci_set
+python3 - "$tmp_dir/oci-live-betting-activate.yml" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+needle = "run: ./infra/oci/scripts/revalidate-live-activation-stan.sh"
+path.write_text(text.replace(needle, "run: echo skipped-revalidation", 1))
+PY
+assert_fail \
+  "activation with only two release revalidations" \
+  "must revalidate before mutation, acceptance, and permanent activation"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/MODE=rollback-drain/d' \
+  "$tmp_dir/oci-live-betting-disable.yml"
+rm "$tmp_dir/oci-live-betting-disable.yml.bak"
+assert_fail \
+  "disable without drain gate" \
+  "is missing live-aware drain gate"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak "/steps.disable.outcome != 'success'/d" \
+  "$tmp_dir/oci-live-betting-disable.yml"
+rm "$tmp_dir/oci-live-betting-disable.yml.bak"
+assert_fail \
+  "disable without final dark reassertion" \
+  "is missing workflow-level dark reassertion"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak \
+  's#actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020#actions/setup-node@v4#' \
+  "$tmp_dir/oci-live-betting-activate.yml"
+rm "$tmp_dir/oci-live-betting-activate.yml.bak"
+assert_fail \
+  "activation with mutable action" \
+  "must pin actions/setup-node to a full 40-character lowercase hex commit SHA"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/infrastructure_provenance_sha256=%s/d' \
+  "$tmp_dir/oci-production-deploy.yml"
+rm "$tmp_dir/oci-production-deploy.yml.bak"
+assert_fail \
+  "deployment without infrastructure artifact binding" \
+  "is missing infrastructure artifact digest binding"
+
+reset_fixtures
+write_complete_oci_set
+sed -i.bak '/runtime_fingerprint/d' \
+  "$tmp_dir/oci-live-betting-disable.yml"
+rm "$tmp_dir/oci-live-betting-disable.yml.bak"
+assert_fail \
+  "disable without runtime identity binding" \
+  "is missing deployment-to-infrastructure runtime binding"
 
 reset_fixtures
 write_complete_oci_set

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -32,6 +32,8 @@ rollback_workflow=".github/workflows/production-rollback.yml"
 branch_workflow=".github/workflows/branch-policy.yml"
 policy_script=".github/scripts/publish-pr-policy.js"
 oci_data_workflow=".github/workflows/oci-live-data-rollout.yml"
+oci_live_activate_workflow=".github/workflows/oci-live-betting-activate.yml"
+oci_live_disable_workflow=".github/workflows/oci-live-betting-disable.yml"
 oci_migrate_workflow=".github/workflows/oci-migrate.yml"
 oci_recovery_workflow=".github/workflows/oci-migration-recovery.yml"
 oci_rollback_workflow=".github/workflows/oci-production-rollback.yml"
@@ -39,7 +41,8 @@ oci_rollback_workflow=".github/workflows/oci-production-rollback.yml"
 for file in \
   "$build_workflow" "$deploy_workflow" "$branch_workflow" "$policy_script" \
   "$rollback_workflow" "$oci_data_workflow" "$oci_migrate_workflow" \
-  "$oci_recovery_workflow" "$oci_rollback_workflow"; do
+  "$oci_recovery_workflow" "$oci_rollback_workflow" \
+  "$oci_live_activate_workflow" "$oci_live_disable_workflow"; do
   [[ -f "$file" ]] || fail "required workflow missing: $file"
 done
 
@@ -189,6 +192,20 @@ require_literal "$policy_script" "? [pull.headSha, pull.mergeSha]" "promotion he
 require_literal "$policy_script" "assertExpectedPull(finalPull, pull)" "final stale-event check"
 require_literal "$policy_script" "relation.base?.sha === pull.baseSha" "exact base snapshot relation"
 
+for live_workflow in "$oci_live_activate_workflow" "$oci_live_disable_workflow"; do
+  require_literal "$live_workflow" "  workflow_dispatch:" "manual live control trigger"
+  reject_literal "$live_workflow" "  workflow_run:" "automatic live control trigger"
+  reject_literal "$live_workflow" "  push:" "push-triggered live control mutation"
+  reject_literal "$live_workflow" "  schedule:" "scheduled live control mutation"
+  require_literal "$live_workflow" "if: github.run_attempt == 1" "first-attempt-only live control"
+  require_literal "$live_workflow" "name: oci-production" "protected OCI production environment"
+  require_literal "$live_workflow" "group: oci-control-plane" "shared OCI control-plane concurrency"
+  require_literal "$live_workflow" "cancel-in-progress: false" "non-cancelling live control"
+done
+require_literal "$oci_live_activate_workflow" "ACTIVATE OCI LIVE BETTING" "exact activation confirmation"
+require_literal "$oci_live_activate_workflow" "COMMIT OCI LIVE BETTING" "exact activation commit"
+require_literal "$oci_live_disable_workflow" "DISABLE OCI LIVE BETTING" "exact disable confirmation"
+
 require_literal "$oci_data_workflow" "name: oci-live-data-rollout" "OCI live data workflow identity"
 require_literal "$oci_data_workflow" "  workflow_dispatch:" "manual OCI live data trigger"
 reject_literal "$oci_data_workflow" "  workflow_run:" "automatic OCI live data trigger"
@@ -252,7 +269,7 @@ workflow_set="$(
   ./infra/azure/agents/production-workflow-inventory-stan.sh |
     sed -n 's/^production_workflows=//p'
 )"
-oci_workflow_set="oci-capacity-acquire,oci-infrastructure,oci-live-data-rollout,oci-migrate,oci-migration-recovery,oci-production-build,oci-production-deploy,oci-production-rollback,production-build,production-deploy,production-rollback"
+oci_workflow_set="oci-capacity-acquire,oci-infrastructure,oci-live-betting-activate,oci-live-betting-disable,oci-live-data-rollout,oci-migrate,oci-migration-recovery,oci-production-build,oci-production-deploy,oci-production-rollback,production-build,production-deploy,production-rollback"
 [[ "$workflow_set" == "$oci_workflow_set" ]] ||
   fail "unexpected production workflow set: ${workflow_set:-none}"
 

--- a/infra/k8s/backoffice-depl.yaml
+++ b/infra/k8s/backoffice-depl.yaml
@@ -36,6 +36,8 @@ spec:
               value: "mongodb://gaming-shared-mongo-srv:27017/gaming_backoffice"
             - name: RABBITMQ_URI
               value: "amqp://gaming-rabbitmq-srv"
+            - name: AUTH_SERVICE_URL
+              value: "http://gaming-auth-srv:3000"
             - name: CLIENT_ID
               valueFrom:
                 fieldRef:

--- a/infra/k8s/event-depl.yaml
+++ b/infra/k8s/event-depl.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: MONGO_URI
               value: "mongodb://gaming-shared-mongo-srv:27017/gaming_event"
+            - name: AUTH_SERVICE_URL
+              value: "http://gaming-auth-srv:3000"
             - name: RABBITMQ_URI
               value: "amqp://gaming-rabbitmq-srv"
             - name: CLIENT_ID

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -14,6 +14,34 @@ conversation summaries are not authority.
   Do not replace it with a newer `master` SHA.
 - Only one mutation-producing release or migration workflow may run at once.
 
+## Live feature activation
+
+- A successful dark deployment is not permission to enable new live kickoffs.
+  Bind activation to the exact first-attempt build, infrastructure, and deploy
+  runs, the infrastructure artifact digest, and the selected runtime
+  fingerprint; revalidate current `master` immediately before each mutation.
+- Activate with a bounded `LIVE_KICKOFFS_LEASE_UNTIL_EPOCH`, not an
+  unbounded boolean. Gamemaster must stop only new kickoffs when that lease is
+  malformed or expired and continue persisted active simulations.
+- Remove the lease only through a same-run, same-SHA commit after the complete
+  browser journey, queue/log/restart checks, protected evidence upload, and a
+  final provenance revalidation. A hard-killed runner before commit therefore
+  expires independently.
+- Disable and ambiguous-write recovery set `LIVE_KICKOFFS_ENABLED=false` and
+  remove the lease in one deployment update. Normal signal traps are useful,
+  but they are not a substitute for an expiry mechanism that survives
+  `SIGKILL`.
+- Production acceptance fixtures must start `OFFLINE`. Ordinary REST and SSE
+  remain server-filtered, while exact fixture IDs require current persisted
+  administrator verification; the odds path repeats that verification before
+  allowing a synthetic selection.
+- Acceptance must also prove that an anonymous backoffice catalog read returns
+  `401` without fixture names. Live-update-first projections stay `OFFLINE`
+  until event metadata establishes visibility; metadata repair must not undo a
+  newer visibility message. Revoked scoped clients purge cached fixtures
+  immediately, while healthy SSE clients still reconcile REST periodically so
+  newly hidden events disappear.
+
 ## OCI provider behavior
 
 - OCI deletion and registry layer reclamation are asynchronous. Wait for

--- a/infra/oci/agents/oci-live-acceptance.spec.js
+++ b/infra/oci/agents/oci-live-acceptance.spec.js
@@ -1,0 +1,419 @@
+const fs = require('fs');
+const path = require('path');
+const { test, expect } = require('@playwright/test');
+
+const LIVE_MARKETS = [
+  'NEXT_YELLOW_CARD',
+  'NEXT_RED_CARD',
+  'NEXT_CORNER',
+  'NEXT_PENALTY',
+  'HALF_TIME_RESULT',
+];
+const STRUCTURAL_INCIDENTS = [
+  'KICK_OFF',
+  'ADDED_TIME_ANNOUNCED',
+  'HALF_TIME',
+  'SECOND_HALF_KICK_OFF',
+  'FULL_TIME',
+];
+const TERMINAL_BET_STATUSES = ['WIN', 'LOSS', 'VOID'];
+
+const board = (page, betKind) => page.locator(
+  `section[aria-labelledby="slip-board-title-${betKind}"]`,
+);
+
+const requiredEnv = (name) => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+};
+
+const findBySlipId = (bets, slipId) => (
+  Array.isArray(bets) ? bets.find((bet) => bet.slipId === slipId) : undefined
+);
+
+test('production live matches, dual slips, and settlement stay coherent', async ({
+  browser,
+  page,
+}) => {
+  const username = requiredEnv('LIVE_ACCEPTANCE_USERNAME');
+  const password = requiredEnv('LIVE_ACCEPTANCE_PASSWORD');
+  const runId = requiredEnv('LIVE_ACCEPTANCE_RUN_ID');
+  const evidenceFile = requiredEnv('LIVE_ACCEPTANCE_EVIDENCE_FILE');
+  const pageErrors = [];
+  const consoleErrors = [];
+  const apiFailures = [];
+
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on('requestfailed', (request) => {
+    if (request.url().includes('/api/')) {
+      apiFailures.push(`${request.method()} ${new URL(request.url()).pathname}`);
+    }
+  });
+
+  const unauthorized = await page.request.post('/api/backoffice/new_event', {
+    data: { home: 'Unauthorized', away: 'Mutation' },
+  });
+  expect(unauthorized.status()).toBe(401);
+
+  await page.goto('/login?ui=v2&theme=dark', { waitUntil: 'domcontentloaded' });
+  await page.getByLabel('Username or email').fill(username);
+  await page.getByLabel('Password', { exact: true }).fill(password);
+  await page.getByRole('button', { name: 'Log in', exact: true }).click();
+  await expect(page.getByTitle('Backoffice')).toBeVisible();
+
+  const suffix = String(runId).slice(-10);
+  const fixtures = [
+    {
+      home: `E2E-${suffix}-Alpha`,
+      away: `E2E-${suffix}-Bravo`,
+      kickoffDelaySeconds: 45,
+      visibility: 'OFFLINE',
+    },
+    {
+      home: `E2E-${suffix}-Charlie`,
+      away: `E2E-${suffix}-Delta`,
+      kickoffDelaySeconds: 60,
+      visibility: 'OFFLINE',
+    },
+    {
+      home: `E2E-${suffix}-Future`,
+      away: `E2E-${suffix}-Reserve`,
+      kickoffDelaySeconds: 30 * 60,
+      visibility: 'OFFLINE',
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const response = await page.request.post('/api/backoffice/new_event', {
+      data: fixture,
+    });
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    fixture.eventId = body.event.eventId;
+    fixture.name = body.event.name;
+  }
+
+  const acceptanceEventIds = fixtures
+    .map((fixture) => fixture.eventId)
+    .join(',');
+  const acceptanceQuery = `acceptanceEventIds=${acceptanceEventIds}`;
+  await expect.poll(async () => {
+    const events = await (
+      await page.request.get(`/api/event?${acceptanceQuery}`)
+    ).json();
+    return fixtures.every((fixture) => events.some((event) => (
+      event.eventId === fixture.eventId
+      && event.visibility === 'OFFLINE'
+    )));
+  }, {
+    timeout: 30000,
+    intervals: [500, 1000, 2000],
+  }).toBe(true);
+
+  const publicContext = await browser.newContext({
+    baseURL: process.env.E2E_BASE_URL,
+  });
+  const publicBackoffice = await publicContext.request.get('/api/backoffice');
+  expect(publicBackoffice.status()).toBe(401);
+  const publicBackofficeBody = await publicBackoffice.text();
+  for (const fixture of fixtures) {
+    expect(publicBackofficeBody).not.toContain(fixture.name);
+  }
+  const publicPage = await publicContext.newPage();
+  const publicEventsLoaded = publicPage.waitForResponse(
+    (response) => (
+      new URL(response.url()).pathname === '/api/event'
+      && response.request().method() === 'GET'
+    ),
+  );
+  await publicPage.goto('/?ui=v2&theme=dark', {
+    waitUntil: 'domcontentloaded',
+  });
+  await publicEventsLoaded;
+  for (const fixture of fixtures) {
+    await expect(
+      publicPage.getByRole('article', { name: fixture.name }),
+    ).toHaveCount(0);
+  }
+  await publicContext.close();
+
+  await page.goto(
+    `/?ui=v2&theme=dark&acceptanceEventIds=${acceptanceEventIds}`,
+    { waitUntil: 'domcontentloaded' },
+  );
+  await page.evaluate((eventIds) => {
+    const snapshots = [];
+    const source = new EventSource(
+      `/api/event/stream?acceptanceEventIds=${encodeURIComponent(eventIds)}`,
+    );
+    source.addEventListener('snapshot', (message) => {
+      snapshots.push(JSON.parse(message.data));
+    });
+    window.__liveAcceptance = { snapshots, source };
+  }, acceptanceEventIds);
+  await expect.poll(
+    () => page.evaluate(() => Boolean(window.__liveAcceptance)),
+  ).toBe(true);
+  for (const fixture of fixtures) {
+    await expect(
+      page.getByRole('article', { name: fixture.name }),
+    ).toBeVisible({ timeout: 30000 });
+  }
+
+  const futureFixture = fixtures[2];
+  const futureArticle = page.getByRole('article', { name: futureFixture.name });
+  await expect(futureArticle.getByText('1X2', { exact: true })).toBeVisible();
+  await expect(
+    futureArticle.getByText('Correct Score', { exact: true }),
+  ).toBeVisible();
+  await futureArticle.getByRole('button', { name: /^Select 1X2 .* at / }).first().click();
+
+  const preMatchBoard = board(page, 'PRE_MATCH');
+  await expect(preMatchBoard).toContainText(futureFixture.name);
+  await page.getByLabel('Wager for PRE-MATCH SLIP').fill('10');
+
+  await expect(page.getByRole('heading', { name: 'Live now' })).toBeVisible({
+    timeout: 100000,
+  });
+  for (const fixture of fixtures.slice(0, 2)) {
+    const article = page.getByRole('article', { name: fixture.name });
+    await expect(article).toBeVisible({ timeout: 100000 });
+    await expect(article.locator('.event-market-card')).toHaveCount(5);
+    for (const marketName of [
+      'Next Yellow Card',
+      'Next Red Card',
+      'Next Corner',
+      'Next Penalty',
+      'Half Time Result',
+    ]) {
+      await expect(article.getByText(marketName, { exact: true })).toBeVisible();
+    }
+  }
+
+  const articleLabels = await page.getByRole('article').evaluateAll(
+    (articles) => articles.map((article) => article.getAttribute('aria-label')),
+  );
+  expect(articleLabels.indexOf(fixtures[0].name)).toBeLessThan(
+    articleLabels.indexOf(futureFixture.name),
+  );
+  expect(articleLabels.indexOf(fixtures[1].name)).toBeLessThan(
+    articleLabels.indexOf(futureFixture.name),
+  );
+
+  for (const fixture of fixtures.slice(0, 2)) {
+    const marketCards = page
+      .getByRole('article', { name: fixture.name })
+      .locator('.event-market-card');
+    for (let marketIndex = 0; marketIndex < LIVE_MARKETS.length; marketIndex += 1) {
+      await marketCards.nth(marketIndex).getByRole('button').first().click();
+    }
+  }
+
+  const liveBoard = board(page, 'LIVE');
+  await expect(liveBoard.locator('.slip-row-card')).toHaveCount(
+    LIVE_MARKETS.length * 2,
+    { timeout: 15000 },
+  );
+  await expect(liveBoard).toContainText(fixtures[0].name);
+  await expect(liveBoard).toContainText(fixtures[1].name);
+  await expect(preMatchBoard).toContainText(futureFixture.name);
+
+  await page.getByLabel('Wager for LIVE SLIP').fill('5');
+  const boardsBeforeLiveSubmit = await (
+    await page.request.get('/api/slip/boards')
+  ).json();
+  const liveSlipId = boardsBeforeLiveSubmit.LIVE._id;
+  await liveBoard.getByRole('button', { name: 'BET!' }).click();
+
+  await expect(page.getByLabel('Wager for PRE-MATCH SLIP')).toHaveValue('10');
+  await expect(page.getByLabel('Wager for PRE-MATCH SLIP')).toBeEnabled();
+  await expect(preMatchBoard.getByRole('button', { name: 'BET!' })).toBeEnabled();
+
+  await expect.poll(async () => {
+    const bets = await (await page.request.get('/api/bet')).json();
+    return findBySlipId(bets, liveSlipId)?.status;
+  }, {
+    timeout: 30000,
+    intervals: [500, 1000, 2000],
+  }).toMatch(/^(CONFIRMED|WIN|LOSS|VOID)$/);
+
+  await expect.poll(async () => {
+    const events = await (await page.request.get('/api/backoffice')).json();
+    return fixtures.slice(0, 2).every((fixture) => (
+      events.some((event) => (
+        event.eventId === fixture.eventId
+        && event.status === 'RESULTED'
+        && Number.isInteger(event.homeResult)
+        && Number.isInteger(event.awayResult)
+      ))
+    ));
+  }, {
+    timeout: 13 * 60 * 1000,
+    intervals: [5000],
+  }).toBe(true);
+
+  const backofficeEvents = await (
+    await page.request.get('/api/backoffice')
+  ).json();
+  const snapshots = await page.evaluate(
+    () => window.__liveAcceptance.snapshots,
+  );
+  expect(JSON.stringify(snapshots)).not.toContain('liveSeed');
+  expect(JSON.stringify(snapshots)).not.toContain('"seed"');
+
+  const eventEvidence = fixtures.slice(0, 2).map((fixture) => {
+    const eventSnapshots = snapshots.filter(
+      (snapshot) => snapshot.eventId === fixture.eventId,
+    );
+    const sequences = eventSnapshots.map((snapshot) => snapshot.live.sequence);
+    expect(sequences.length).toBeGreaterThan(5);
+    expect(new Set(sequences).size).toBe(sequences.length);
+    expect([...sequences].sort((left, right) => left - right)).toEqual(sequences);
+
+    const phases = new Set(
+      eventSnapshots.map((snapshot) => snapshot.live.phase),
+    );
+    for (const phase of [
+      'FIRST_HALF',
+      'FIRST_HALF_STOPPAGE',
+      'HALF_TIME',
+      'SECOND_HALF',
+      'SECOND_HALF_STOPPAGE',
+      'FULL_TIME',
+    ]) {
+      expect(phases.has(phase)).toBe(true);
+    }
+
+    const incidents = new Map();
+    for (const snapshot of eventSnapshots) {
+      for (const incident of snapshot.live.incidentHistory ?? []) {
+        incidents.set(incident.id, incident);
+      }
+    }
+    const incidentTypes = new Set(
+      [...incidents.values()].map((incident) => incident.type),
+    );
+    for (const incidentType of STRUCTURAL_INCIDENTS) {
+      expect(incidentTypes.has(incidentType)).toBe(true);
+    }
+
+    const kickoffSnapshot = eventSnapshots.find(
+      (snapshot) => snapshot.live.phase === 'FIRST_HALF',
+    );
+    expect(
+      kickoffSnapshot.live.currentMarkets.map((market) => market.marketType).sort(),
+    ).toEqual([...LIVE_MARKETS].sort());
+
+    const finalSnapshot = [...eventSnapshots].reverse().find(
+      (snapshot) => snapshot.live.phase === 'FULL_TIME',
+    );
+    expect(finalSnapshot).toBeDefined();
+    expect(
+      finalSnapshot.live.currentMarkets.every(
+        (market) => market.status !== 'OPEN',
+      ),
+    ).toBe(true);
+
+    const goals = { HOME: 0, AWAY: 0 };
+    for (const incident of incidents.values()) {
+      if (incident.type === 'GOAL') {
+        goals[incident.side] += 1;
+      }
+    }
+    expect(finalSnapshot.live.homeScore).toBe(goals.HOME);
+    expect(finalSnapshot.live.awayScore).toBe(goals.AWAY);
+
+    const resultedEvent = backofficeEvents.find(
+      (event) => event.eventId === fixture.eventId,
+    );
+    expect(resultedEvent.homeResult).toBe(finalSnapshot.live.homeScore);
+    expect(resultedEvent.awayResult).toBe(finalSnapshot.live.awayScore);
+
+    return {
+      eventId: fixture.eventId,
+      finalSequence: finalSnapshot.live.sequence,
+      homeScore: finalSnapshot.live.homeScore,
+      awayScore: finalSnapshot.live.awayScore,
+      incidentTypes: [...incidentTypes].sort(),
+    };
+  });
+
+  const settledBets = await (await page.request.get('/api/bet')).json();
+  const liveBet = findBySlipId(settledBets, liveSlipId);
+  expect(TERMINAL_BET_STATUSES).toContain(liveBet.status);
+  expect(liveBet.betKind).toBe('LIVE');
+  expect(liveBet.rows).toHaveLength(LIVE_MARKETS.length * 2);
+  expect(
+    liveBet.rows.every((row) => (
+      row.betKind === 'LIVE' && row.status !== 'NOT_SETTLED'
+    )),
+  ).toBe(true);
+
+  const boardsBeforePreMatchSubmit = await (
+    await page.request.get('/api/slip/boards')
+  ).json();
+  const preMatchSlipId = boardsBeforePreMatchSubmit.PRE_MATCH._id;
+  await preMatchBoard.getByRole('button', { name: 'BET!' }).click();
+  await expect.poll(async () => {
+    const bets = await (await page.request.get('/api/bet')).json();
+    return findBySlipId(bets, preMatchSlipId)?.status;
+  }, {
+    timeout: 30000,
+    intervals: [500, 1000, 2000],
+  }).toBe('CONFIRMED');
+
+  const manualResult = await page.request.post('/api/backoffice/result', {
+    data: {
+      eventId: futureFixture.eventId,
+      homeResult: 1,
+      awayResult: 0,
+    },
+  });
+  expect(manualResult.ok()).toBeTruthy();
+  await expect.poll(async () => {
+    const bets = await (await page.request.get('/api/bet')).json();
+    return findBySlipId(bets, preMatchSlipId)?.status;
+  }, {
+    timeout: 30000,
+    intervals: [500, 1000, 2000],
+  }).toBe('WIN');
+
+  await page.getByTitle('My bets').click();
+  const liveHistory = page.locator('.my-bets-card').filter({
+    hasText: fixtures[0].name,
+  });
+  await expect(liveHistory).toContainText('Live');
+  await expect(liveHistory).toContainText(liveBet.status);
+  const preMatchHistory = page.locator('.my-bets-card').filter({
+    hasText: futureFixture.name,
+  });
+  await expect(preMatchHistory).toContainText('Pre-match');
+  await expect(preMatchHistory).toContainText('WIN');
+
+  expect(pageErrors).toEqual([]);
+  expect(consoleErrors).toEqual([]);
+  expect(apiFailures).toEqual([]);
+
+  await page.evaluate(() => window.__liveAcceptance.source.close());
+  fs.mkdirSync(path.dirname(evidenceFile), { recursive: true });
+  fs.writeFileSync(evidenceFile, `${JSON.stringify({
+    runId,
+    events: eventEvidence,
+    liveSlipId,
+    liveBetStatus: liveBet.status,
+    liveRowStatuses: liveBet.rows.map((row) => row.status),
+    preMatchSlipId,
+    preMatchBetStatus: 'WIN',
+    pageErrors: pageErrors.length,
+    consoleErrors: consoleErrors.length,
+    apiFailures: apiFailures.length,
+  }, null, 2)}\n`);
+});

--- a/infra/oci/agents/oci-live-smoke.spec.js
+++ b/infra/oci/agents/oci-live-smoke.spec.js
@@ -15,8 +15,7 @@ test('OCI signup, logout, login, and navigation journey', async ({ page }) => {
 
   await page.getByTitle('My bets').click();
   await expect(page).toHaveURL(/\/bets/);
-  await page.getByTitle('Backoffice').click();
-  await expect(page).toHaveURL(/\/backoffice/);
+  await expect(page.getByTitle('Backoffice')).toHaveCount(0);
 
   await page.getByTitle('Log out').click();
   await expect(page.getByTitle('Log in')).toBeVisible();

--- a/infra/oci/agents/playwright-live-acceptance.config.js
+++ b/infra/oci/agents/playwright-live-acceptance.config.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+module.exports = {
+  testDir: __dirname,
+  testMatch: 'oci-live-acceptance.spec.js',
+  timeout: 15 * 60 * 1000,
+  expect: {
+    timeout: 100 * 1000,
+  },
+  use: {
+    baseURL: process.env.E2E_BASE_URL,
+    trace: 'off',
+    video: 'off',
+    screenshot: 'off',
+  },
+  outputDir: path.resolve(
+    process.env.OCI_E2E_OUTPUT_DIR || 'artifacts/oci-live-acceptance',
+  ),
+};

--- a/infra/oci/scripts/live-betting-control-stan.sh
+++ b/infra/oci/scripts/live-betting-control-stan.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${ACTION:-}"
+SOURCE_SHA="${SOURCE_SHA:-}"
+CONTROL_RUN_ID="${CONTROL_RUN_ID:-}"
+CONFIRMATION="${CONFIRMATION:-}"
+NAMESPACE="${NAMESPACE:-betstan-oci}"
+DEPLOYMENT="${DEPLOYMENT:-gaming-gamemaster-depl}"
+CONTAINER="${CONTAINER:-gaming-gamemaster}"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-10m}"
+OUTPUT_DIR="${OUTPUT_DIR:-artifacts/oci-live-control}"
+EVIDENCE_FILE="$OUTPUT_DIR/control.env"
+LEASE_DURATION_SECONDS="${LEASE_DURATION_SECONDS:-1800}"
+NO_LEASE="none"
+
+case "$ACTION" in
+  activate)
+    expected_confirmation="ACTIVATE OCI LIVE BETTING"
+    target_flag="true"
+    ;;
+  commit)
+    expected_confirmation="COMMIT OCI LIVE BETTING"
+    target_flag="true"
+    ;;
+  disable)
+    expected_confirmation="DISABLE OCI LIVE BETTING"
+    target_flag="false"
+    ;;
+  *)
+    echo "ACTION must be activate, commit, or disable" >&2
+    exit 1
+    ;;
+esac
+
+[[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "SOURCE_SHA must be a full lowercase commit SHA" >&2
+  exit 1
+}
+[[ "$CONTROL_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+  echo "CONTROL_RUN_ID must be a positive integer" >&2
+  exit 1
+}
+[[ "$CONFIRMATION" == "$expected_confirmation" ]] || {
+  echo "CONFIRMATION does not match $ACTION" >&2
+  exit 1
+}
+[[ "$NAMESPACE" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || {
+  echo "NAMESPACE is invalid" >&2
+  exit 1
+}
+[[ "$DEPLOYMENT" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || {
+  echo "DEPLOYMENT is invalid" >&2
+  exit 1
+}
+[[ "$CONTAINER" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || {
+  echo "CONTAINER is invalid" >&2
+  exit 1
+}
+[[ "$ROLLOUT_TIMEOUT" =~ ^[1-9][0-9]*[smh]$ ]] || {
+  echo "ROLLOUT_TIMEOUT is invalid" >&2
+  exit 1
+}
+if [[ "$ACTION" == "activate" ]]; then
+  [[ "$LEASE_DURATION_SECONDS" =~ ^[1-9][0-9]*$ ]] || {
+    echo "LEASE_DURATION_SECONDS must be an integer" >&2
+    exit 1
+  }
+  if (( LEASE_DURATION_SECONDS < 900 || LEASE_DURATION_SECONDS > 3600 )); then
+    echo "LEASE_DURATION_SECONDS must be between 900 and 3600" >&2
+    exit 1
+  fi
+fi
+
+for command_name in kubectl python3; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "required command is unavailable: $command_name" >&2
+    exit 1
+  }
+done
+
+mkdir -p "$OUTPUT_DIR"
+umask 077
+
+read_state() {
+  kubectl get deployment "$DEPLOYMENT" \
+    -n "$NAMESPACE" \
+    -o json |
+    python3 -c '
+import json
+import sys
+
+deployment = json.load(sys.stdin)
+container_name = sys.argv[1]
+containers = [
+    container
+    for container in deployment.get("spec", {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+    if container.get("name") == container_name
+]
+if len(containers) != 1:
+    raise SystemExit("expected exactly one gamemaster container")
+values = [
+    item.get("value")
+    for item in containers[0].get("env", [])
+    if item.get("name") == "LIVE_KICKOFFS_ENABLED"
+]
+if len(values) != 1 or values[0] not in ("true", "false"):
+    raise SystemExit("LIVE_KICKOFFS_ENABLED must occur exactly once as a boolean")
+lease_values = [
+    item.get("value")
+    for item in containers[0].get("env", [])
+    if item.get("name") == "LIVE_KICKOFFS_LEASE_UNTIL_EPOCH"
+]
+if len(lease_values) > 1:
+    raise SystemExit("LIVE_KICKOFFS_LEASE_UNTIL_EPOCH must occur at most once")
+lease = lease_values[0] if lease_values else "none"
+if lease != "none" and (
+    not isinstance(lease, str)
+    or not lease.isdigit()
+    or lease.startswith("0")
+):
+    raise SystemExit(
+        "LIVE_KICKOFFS_LEASE_UNTIL_EPOCH must be a positive epoch or absent"
+    )
+annotations = deployment.get("metadata", {}).get("annotations", {})
+action = annotations.get("betstan.dev/live-control-action", "none")
+run_id = annotations.get("betstan.dev/live-control-run-id", "none")
+source_sha = annotations.get("betstan.dev/live-control-source-sha", "none")
+print("\t".join((values[0], lease, action, run_id, source_sha)))
+' "$CONTAINER"
+}
+
+before_flag="unknown"
+before_lease_until_epoch="$NO_LEASE"
+before_action="none"
+before_run_id="none"
+before_source_sha="none"
+target_lease_until_epoch="$NO_LEASE"
+mutation_attempted=0
+operation_committed=0
+
+write_evidence() {
+  local after_flag="${1:-unknown}"
+  local after_lease_until_epoch="${2:-unknown}"
+  local rollback_attempted="${3:-false}"
+  local rollout_verified="${4:-false}"
+  printf '%s\n' \
+    "action=$ACTION" \
+    "source_sha=$SOURCE_SHA" \
+    "control_run_id=$CONTROL_RUN_ID" \
+    "namespace=$NAMESPACE" \
+    "deployment=$DEPLOYMENT" \
+    "before_flag=$before_flag" \
+    "before_lease_until_epoch=$before_lease_until_epoch" \
+    "before_action=$before_action" \
+    "before_run_id=$before_run_id" \
+    "before_source_sha=$before_source_sha" \
+    "target_flag=$target_flag" \
+    "target_lease_until_epoch=$target_lease_until_epoch" \
+    "after_flag=$after_flag" \
+    "after_lease_until_epoch=$after_lease_until_epoch" \
+    "mutation_attempted=$mutation_attempted" \
+    "rollback_attempted=$rollback_attempted" \
+    "rollout_verified=$rollout_verified" \
+    >"$EVIDENCE_FILE"
+}
+
+rollback_activation() {
+  local status=$?
+  trap - EXIT INT TERM
+  if [[ "$operation_committed" != "1" ]]; then
+    set +e
+    kubectl set env deployment/"$DEPLOYMENT" \
+      -n "$NAMESPACE" \
+      LIVE_KICKOFFS_ENABLED=false \
+      LIVE_KICKOFFS_LEASE_UNTIL_EPOCH- >/dev/null
+    kubectl rollout status deployment/"$DEPLOYMENT" \
+      -n "$NAMESPACE" \
+      --timeout="$ROLLOUT_TIMEOUT" >/dev/null
+    after_rollback_flag="unknown"
+    after_rollback_lease="unknown"
+    IFS=$'\t' read -r \
+      after_rollback_flag \
+      after_rollback_lease \
+      _ \
+      _ \
+      _ < <(read_state 2>/dev/null || printf 'unknown\tunknown\tunknown\tunknown\tunknown\n')
+    write_evidence \
+      "$after_rollback_flag" \
+      "$after_rollback_lease" \
+      true \
+      false
+    set -e
+  elif [[ "$status" != "0" ]]; then
+    write_evidence "$before_flag" "$before_lease_until_epoch" false false
+  fi
+  exit "$status"
+}
+trap rollback_activation EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+IFS=$'\t' read -r \
+  before_flag \
+  before_lease_until_epoch \
+  before_action \
+  before_run_id \
+  before_source_sha < <(read_state)
+
+if [[ "$ACTION" == "activate" && "$before_flag" != "false" ]]; then
+  echo "activation requires LIVE_KICKOFFS_ENABLED=false" >&2
+  exit 1
+fi
+
+if [[ "$ACTION" == "commit" ]]; then
+  [[ "$before_flag" == "true" ]] || {
+    echo "commit requires LIVE_KICKOFFS_ENABLED=true" >&2
+    exit 1
+  }
+  [[ "$before_lease_until_epoch" =~ ^[1-9][0-9]*$ ]] || {
+    echo "commit requires an active activation lease" >&2
+    exit 1
+  }
+  if (( before_lease_until_epoch <= $(date +%s) )); then
+    echo "activation lease expired before commit" >&2
+    exit 1
+  fi
+  [[ "$before_action" == "activate" ]] || {
+    echo "commit requires activation-owned runtime state" >&2
+    exit 1
+  }
+  [[ "$before_run_id" == "$CONTROL_RUN_ID" ]] || {
+    echo "commit run ID does not own the activation lease" >&2
+    exit 1
+  }
+  [[ "$before_source_sha" == "$SOURCE_SHA" ]] || {
+    echo "commit source SHA does not own the activation lease" >&2
+    exit 1
+  }
+fi
+
+case "$ACTION" in
+  activate)
+    target_lease_until_epoch=$(( $(date +%s) + LEASE_DURATION_SECONDS ))
+    mutation_attempted=1
+    kubectl set env deployment/"$DEPLOYMENT" \
+      -n "$NAMESPACE" \
+      LIVE_KICKOFFS_ENABLED=true \
+      "LIVE_KICKOFFS_LEASE_UNTIL_EPOCH=$target_lease_until_epoch" >/dev/null
+    ;;
+  commit)
+    mutation_attempted=1
+    kubectl set env deployment/"$DEPLOYMENT" \
+      -n "$NAMESPACE" \
+      LIVE_KICKOFFS_LEASE_UNTIL_EPOCH- >/dev/null
+    ;;
+  disable)
+    if [[ "$before_flag" != "false" \
+        || "$before_lease_until_epoch" != "$NO_LEASE" ]]; then
+      mutation_attempted=1
+      kubectl set env deployment/"$DEPLOYMENT" \
+        -n "$NAMESPACE" \
+        LIVE_KICKOFFS_ENABLED=false \
+        LIVE_KICKOFFS_LEASE_UNTIL_EPOCH- >/dev/null
+    fi
+    ;;
+esac
+
+if [[ "$mutation_attempted" == "1" ]]; then
+  kubectl rollout status deployment/"$DEPLOYMENT" \
+    -n "$NAMESPACE" \
+    --timeout="$ROLLOUT_TIMEOUT" >/dev/null
+fi
+
+kubectl annotate deployment/"$DEPLOYMENT" \
+  -n "$NAMESPACE" \
+  --overwrite \
+  "betstan.dev/live-control-action=$ACTION" \
+  "betstan.dev/live-control-run-id=$CONTROL_RUN_ID" \
+  "betstan.dev/live-control-source-sha=$SOURCE_SHA" >/dev/null
+
+IFS=$'\t' read -r \
+  after_flag \
+  after_lease_until_epoch \
+  after_action \
+  after_run_id \
+  after_source_sha < <(read_state)
+if [[ "$after_flag" != "$target_flag" ]]; then
+  echo "LIVE_KICKOFFS_ENABLED did not reach $target_flag" >&2
+  false
+fi
+if [[ "$after_lease_until_epoch" != "$target_lease_until_epoch" ]]; then
+  echo "LIVE_KICKOFFS_LEASE_UNTIL_EPOCH did not reach the target state" >&2
+  false
+fi
+if [[ "$after_action" != "$ACTION" \
+    || "$after_run_id" != "$CONTROL_RUN_ID" \
+    || "$after_source_sha" != "$SOURCE_SHA" ]]; then
+  echo "live control annotations do not match the committed operation" >&2
+  false
+fi
+
+write_evidence "$after_flag" "$after_lease_until_epoch" false true
+operation_committed=1
+trap - EXIT INT TERM
+echo "live_betting_control=$ACTION"

--- a/infra/oci/scripts/revalidate-live-activation-stan.sh
+++ b/infra/oci/scripts/revalidate-live-activation-stan.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_SHA="${SOURCE_SHA:-}"
+BUILD_RUN_ID="${BUILD_RUN_ID:-}"
+INFRASTRUCTURE_RUN_ID="${INFRASTRUCTURE_RUN_ID:-}"
+DEPLOYMENT_RUN_ID="${DEPLOYMENT_RUN_ID:-}"
+REPOSITORY="${REPOSITORY:-${GITHUB_REPOSITORY:-}}"
+
+[[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "SOURCE_SHA must be a full lowercase commit SHA" >&2
+  exit 1
+}
+for run_id in "$BUILD_RUN_ID" "$INFRASTRUCTURE_RUN_ID" "$DEPLOYMENT_RUN_ID"; do
+  [[ "$run_id" =~ ^[1-9][0-9]*$ ]] || {
+    echo "all provenance run IDs must be positive integers" >&2
+    exit 1
+  }
+done
+[[ "$REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+  echo "REPOSITORY is invalid" >&2
+  exit 1
+}
+[[ "${GITHUB_REF_NAME:-}" == "master" ]] || {
+  echo "activation must run from master" >&2
+  exit 1
+}
+[[ "${GITHUB_RUN_ATTEMPT:-}" == "1" ]] || {
+  echo "activation reruns are not permitted" >&2
+  exit 1
+}
+
+for command_name in gh git; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "required command is unavailable: $command_name" >&2
+    exit 1
+  }
+done
+
+git fetch --quiet origin master:refs/remotes/origin/master
+[[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] || {
+  echo "checked out source no longer matches the approved SHA" >&2
+  exit 1
+}
+[[ "$(git rev-parse origin/master)" == "$SOURCE_SHA" ]] || {
+  echo "approved SHA is no longer current master" >&2
+  exit 1
+}
+
+verify_run() {
+  local run_id="$1"
+  local workflow_file="$2"
+  local expected_event="$3"
+  local path event head_sha head_branch repository status conclusion attempt
+
+  read -r path event head_sha head_branch repository status conclusion attempt <<<"$(
+    gh api "repos/$REPOSITORY/actions/runs/$run_id" \
+      --jq '[.path,.event,.head_sha,.head_branch,.head_repository.full_name,.status,.conclusion,.run_attempt] | @tsv'
+  )"
+  [[ "$path" == ".github/workflows/$workflow_file" ]]
+  [[ "$event" == "$expected_event" ]]
+  [[ "$head_sha" == "$SOURCE_SHA" ]]
+  [[ "$head_branch" == "master" ]]
+  [[ "$repository" == "$REPOSITORY" ]]
+  [[ "$status" == "completed" ]]
+  [[ "$conclusion" == "success" ]]
+  [[ "$attempt" == "1" ]]
+}
+
+verify_run "$BUILD_RUN_ID" oci-production-build.yml workflow_run
+verify_run "$INFRASTRUCTURE_RUN_ID" oci-infrastructure.yml workflow_dispatch
+verify_run "$DEPLOYMENT_RUN_ID" oci-production-deploy.yml workflow_dispatch
+
+echo "live_activation_revalidation=PASS source_sha=$SOURCE_SHA"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -26,12 +26,30 @@ PYTHONPYCACHEPREFIX="$WORK_DIR/pycache" \
   python3 -m py_compile "$OCI_DIR/agents/health-contract.py"
 node --check "$OCI_DIR/agents/playwright.config.js"
 node --check "$OCI_DIR/agents/oci-live-smoke.spec.js"
+node --check "$OCI_DIR/agents/playwright-live-acceptance.config.js"
+node --check "$OCI_DIR/agents/oci-live-acceptance.spec.js"
 grep -Fq "getByRole('link', { name: 'BetStan', exact: true })" \
   "$OCI_DIR/agents/oci-live-smoke.spec.js" ||
   fail "OCI browser check does not use the accessible BetStan brand"
 if grep -Fq "locator('body')).toContainText('BetStan')" \
     "$OCI_DIR/agents/oci-live-smoke.spec.js"; then
   fail "OCI browser check still relies on image alt text appearing in body text"
+fi
+acceptance_spec="$OCI_DIR/agents/oci-live-acceptance.spec.js"
+grep -Fq 'const publicContext = await browser.newContext({' "$acceptance_spec" &&
+  grep -Fq 'baseURL: process.env.E2E_BASE_URL' "$acceptance_spec" ||
+  fail "OCI live acceptance public context is not bound to the configured base URL"
+grep -Fq '}, acceptanceEventIds);' "$acceptance_spec" ||
+  fail "OCI live acceptance does not pass scoped event IDs into the browser context"
+grep -Fq "publicContext.request.get('/api/backoffice')" "$acceptance_spec" &&
+  grep -Fq 'expect(publicBackoffice.status()).toBe(401)' "$acceptance_spec" ||
+  fail "OCI live acceptance does not prove anonymous backoffice reads fail closed"
+for phase in FIRST_HALF_STOPPAGE SECOND_HALF_STOPPAGE; do
+  grep -Fq "'$phase'" "$acceptance_spec" ||
+    fail "OCI live acceptance omits runtime phase $phase"
+done
+if grep -Fq "'STOPPAGE_TIME'" "$acceptance_spec"; then
+  fail "OCI live acceptance asserts a phase that the runtime never emits"
 fi
 
 lessons="$OCI_DIR/LESSONS_LEARNED.md"
@@ -934,11 +952,15 @@ expected_syntax_targets = [
   "infra/oci/agents/live-betting-readiness-stan.sh",
   "infra/oci/scripts/deploy.sh",
   "infra/oci/scripts/live-data-maintenance-stan.sh",
+  "infra/oci/scripts/live-betting-control-stan.sh",
+  "infra/oci/scripts/revalidate-live-activation-stan.sh",
   "infra/oci/scripts/live-betting-data-rollout-stan.sh",
   "infra/oci/scripts/shared-mongo-operation-lock-stan.sh",
   "infra/oci/scripts/verify-live-betting-data-evidence-stan.sh",
   "infra/oci/tests/test-deploy-validation-loop-stan.sh",
   "infra/oci/tests/test-live-data-maintenance-stan.sh",
+  "infra/oci/tests/test-live-betting-control-stan.sh",
+  "infra/oci/tests/test-revalidate-live-activation-stan.sh",
   "infra/oci/tests/test-live-betting-data-rollout-stan.sh",
   "infra/oci/tests/test-live-betting-readiness-stan.sh",
   "infra/oci/tests/rollback-live-readiness-contract.sh",
@@ -953,6 +975,8 @@ expected_exec_targets = [
   "./infra/azure/agents/test-production-rollback-stan.sh",
   "./infra/oci/tests/test-deploy-validation-loop-stan.sh",
   "./infra/oci/tests/test-live-data-maintenance-stan.sh",
+  "./infra/oci/tests/test-live-betting-control-stan.sh",
+  "./infra/oci/tests/test-revalidate-live-activation-stan.sh",
   "./infra/oci/tests/test-live-betting-data-rollout-stan.sh",
   "./infra/oci/tests/test-live-betting-readiness-stan.sh",
   "./infra/oci/tests/rollback-live-readiness-contract.sh",
@@ -961,6 +985,8 @@ expected_exec_targets = [
 expected_yaml_targets = [
   ".github/workflows/production-build.yml",
   ".github/workflows/production-deploy.yml",
+  ".github/workflows/oci-live-betting-activate.yml",
+  ".github/workflows/oci-live-betting-disable.yml",
   ".github/workflows/oci-live-data-rollout.yml",
   ".github/workflows/oci-production-deploy.yml",
 ]

--- a/infra/oci/tests/test-live-betting-control-stan.sh
+++ b/infra/oci/tests/test-live-betting-control-stan.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$ROOT_DIR/infra/oci/scripts/live-betting-control-stan.sh"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+mkdir -p "$WORK_DIR/bin"
+cat >"$WORK_DIR/bin/kubectl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${STUB_LOG:?}"
+if [[ "$1" == "get" ]]; then
+  flag="$(cat "${STUB_STATE:?}")"
+  lease_json=""
+  if [[ -s "${STUB_STATE}.lease" ]]; then
+    lease_json=',{"name":"LIVE_KICKOFFS_LEASE_UNTIL_EPOCH","value":"'"$(cat "${STUB_STATE}.lease")"'"}'
+  fi
+  printf '{"metadata":{"annotations":{"betstan.dev/live-control-action":"%s","betstan.dev/live-control-run-id":"%s","betstan.dev/live-control-source-sha":"%s"}},"spec":{"template":{"spec":{"containers":[{"name":"gaming-gamemaster","env":[{"name":"LIVE_KICKOFFS_ENABLED","value":"%s"}%s]}]}}}}\n' \
+    "$(cat "${STUB_STATE}.action" 2>/dev/null || printf none)" \
+    "$(cat "${STUB_STATE}.run" 2>/dev/null || printf none)" \
+    "$(cat "${STUB_STATE}.sha" 2>/dev/null || printf none)" \
+    "$flag" \
+    "$lease_json"
+elif [[ "$1" == "set" && "$2" == "env" ]]; then
+  requested_false=0
+  requested_true=0
+  for value in "$@"; do
+    [[ "$value" == "LIVE_KICKOFFS_ENABLED=false" ]] && requested_false=1
+    [[ "$value" == "LIVE_KICKOFFS_ENABLED=true" ]] && requested_true=1
+  done
+  if [[ "${STUB_FAIL_FALSE_SET_ONCE:-0}" == "1" \
+      && "$requested_false" == "1" \
+      && ! -f "${STUB_FAIL_ONCE_STATE:-${STUB_STATE}.fail-once}" ]]; then
+    : >"${STUB_FAIL_ONCE_STATE:-${STUB_STATE}.fail-once}"
+    exit 1
+  fi
+  removed_lease=0
+  for value in "$@"; do
+    case "$value" in
+      LIVE_KICKOFFS_ENABLED=*)
+        printf '%s\n' "${value#LIVE_KICKOFFS_ENABLED=}" >"$STUB_STATE"
+        ;;
+      LIVE_KICKOFFS_LEASE_UNTIL_EPOCH=*)
+        printf '%s\n' \
+          "${value#LIVE_KICKOFFS_LEASE_UNTIL_EPOCH=}" \
+          >"${STUB_STATE}.lease"
+        ;;
+      LIVE_KICKOFFS_LEASE_UNTIL_EPOCH-)
+        rm -f "${STUB_STATE}.lease"
+        removed_lease=1
+        ;;
+    esac
+  done
+  if [[ "${STUB_FAIL_TRUE_SET_AFTER_MUTATION:-0}" == "1" \
+      && "$requested_true" == "1" ]]; then
+    exit 1
+  fi
+  if [[ "${STUB_FAIL_COMMIT_AFTER_MUTATION:-0}" == "1" \
+      && "$removed_lease" == "1" \
+      && "$(cat "$STUB_STATE")" == "true" ]]; then
+    exit 1
+  fi
+elif [[ "$1" == "rollout" ]]; then
+  if [[ "${STUB_FAIL_TRUE_ROLLOUT:-0}" == "1" && "$(cat "$STUB_STATE")" == "true" ]]; then
+    exit 1
+  fi
+elif [[ "$1" == "annotate" ]]; then
+  for value in "$@"; do
+    case "$value" in
+      betstan.dev/live-control-action=*)
+        printf '%s\n' "${value#betstan.dev/live-control-action=}" \
+          >"${STUB_STATE}.action"
+        ;;
+      betstan.dev/live-control-run-id=*)
+        printf '%s\n' "${value#betstan.dev/live-control-run-id=}" \
+          >"${STUB_STATE}.run"
+        ;;
+      betstan.dev/live-control-source-sha=*)
+        printf '%s\n' "${value#betstan.dev/live-control-source-sha=}" \
+          >"${STUB_STATE}.sha"
+        ;;
+    esac
+  done
+else
+  echo "unexpected kubectl command: $*" >&2
+  exit 1
+fi
+STUB
+chmod +x "$WORK_DIR/bin/kubectl"
+
+run_control() {
+  local action="$1"
+  local confirmation="$2"
+  local output_dir="$3"
+  PATH="$WORK_DIR/bin:$PATH" \
+  STUB_LOG="$WORK_DIR/kubectl.log" \
+  STUB_STATE="$WORK_DIR/flag" \
+  ACTION="$action" \
+  SOURCE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  CONTROL_RUN_ID=123 \
+  CONFIRMATION="$confirmation" \
+  NAMESPACE=betstan-oci \
+  OUTPUT_DIR="$output_dir" \
+    "$SCRIPT"
+}
+
+reset_state() {
+  local flag="$1"
+  local lease="${2:-}"
+  printf '%s\n' "$flag" >"$WORK_DIR/flag"
+  rm -f \
+    "$WORK_DIR/flag.lease" \
+    "$WORK_DIR/flag.action" \
+    "$WORK_DIR/flag.run" \
+    "$WORK_DIR/flag.sha"
+  if [[ -n "$lease" ]]; then
+    printf '%s\n' "$lease" >"$WORK_DIR/flag.lease"
+  fi
+}
+
+: >"$WORK_DIR/kubectl.log"
+reset_state false
+run_control activate "ACTIVATE OCI LIVE BETTING" "$WORK_DIR/activate"
+[[ "$(cat "$WORK_DIR/flag")" == "true" ]]
+[[ "$(cat "$WORK_DIR/flag.lease")" =~ ^[1-9][0-9]*$ ]]
+grep -Fq 'before_flag=false' "$WORK_DIR/activate/control.env"
+grep -Fq 'after_flag=true' "$WORK_DIR/activate/control.env"
+grep -Eq '^after_lease_until_epoch=[1-9][0-9]*$' \
+  "$WORK_DIR/activate/control.env"
+grep -Fq 'rollout_verified=true' "$WORK_DIR/activate/control.env"
+grep -Fq 'LIVE_KICKOFFS_ENABLED=true' "$WORK_DIR/kubectl.log"
+grep -Fq 'LIVE_KICKOFFS_LEASE_UNTIL_EPOCH=' "$WORK_DIR/kubectl.log"
+
+: >"$WORK_DIR/kubectl.log"
+run_control commit "COMMIT OCI LIVE BETTING" "$WORK_DIR/commit"
+[[ "$(cat "$WORK_DIR/flag")" == "true" ]]
+[[ ! -e "$WORK_DIR/flag.lease" ]]
+grep -Fq 'before_action=activate' "$WORK_DIR/commit/control.env"
+grep -Fq 'after_flag=true' "$WORK_DIR/commit/control.env"
+grep -Fq 'after_lease_until_epoch=none' "$WORK_DIR/commit/control.env"
+grep -Fq 'LIVE_KICKOFFS_LEASE_UNTIL_EPOCH-' "$WORK_DIR/kubectl.log"
+
+: >"$WORK_DIR/kubectl.log"
+run_control disable "DISABLE OCI LIVE BETTING" "$WORK_DIR/disable"
+[[ "$(cat "$WORK_DIR/flag")" == "false" ]]
+grep -Fq 'before_flag=true' "$WORK_DIR/disable/control.env"
+grep -Fq 'after_flag=false' "$WORK_DIR/disable/control.env"
+grep -Fq 'after_lease_until_epoch=none' "$WORK_DIR/disable/control.env"
+grep -Fq 'LIVE_KICKOFFS_ENABLED=false' "$WORK_DIR/kubectl.log"
+
+: >"$WORK_DIR/kubectl.log"
+reset_state true 2000000000
+rm -f "$WORK_DIR/fail-once"
+if PATH="$WORK_DIR/bin:$PATH" \
+    STUB_LOG="$WORK_DIR/kubectl.log" \
+    STUB_STATE="$WORK_DIR/flag" \
+    STUB_FAIL_FALSE_SET_ONCE=1 \
+    STUB_FAIL_ONCE_STATE="$WORK_DIR/fail-once" \
+    ACTION=disable \
+    SOURCE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    CONTROL_RUN_ID=123 \
+    CONFIRMATION="DISABLE OCI LIVE BETTING" \
+    NAMESPACE=betstan-oci \
+    OUTPUT_DIR="$WORK_DIR/disable-retry" \
+      "$SCRIPT" >/dev/null 2>&1; then
+  echo "failed first disable write unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "$(cat "$WORK_DIR/flag")" == "false" ]]
+grep -Fq 'rollback_attempted=true' "$WORK_DIR/disable-retry/control.env"
+[[ "$(grep -Fc 'LIVE_KICKOFFS_ENABLED=false' "$WORK_DIR/kubectl.log")" -eq 2 ]]
+
+: >"$WORK_DIR/kubectl.log"
+reset_state false
+if run_control activate "wrong confirmation" "$WORK_DIR/rejected" >/dev/null 2>&1; then
+  echo "invalid confirmation unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ ! -s "$WORK_DIR/kubectl.log" ]]
+[[ "$(cat "$WORK_DIR/flag")" == "false" ]]
+
+: >"$WORK_DIR/kubectl.log"
+reset_state false
+if PATH="$WORK_DIR/bin:$PATH" \
+    STUB_LOG="$WORK_DIR/kubectl.log" \
+    STUB_STATE="$WORK_DIR/flag" \
+    STUB_FAIL_TRUE_ROLLOUT=1 \
+    ACTION=activate \
+    SOURCE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    CONTROL_RUN_ID=123 \
+    CONFIRMATION="ACTIVATE OCI LIVE BETTING" \
+    NAMESPACE=betstan-oci \
+    OUTPUT_DIR="$WORK_DIR/rollback" \
+      "$SCRIPT" >/dev/null 2>&1; then
+  echo "failed rollout unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "$(cat "$WORK_DIR/flag")" == "false" ]]
+[[ ! -e "$WORK_DIR/flag.lease" ]]
+grep -Fq 'rollback_attempted=true' "$WORK_DIR/rollback/control.env"
+grep -Fq 'LIVE_KICKOFFS_ENABLED=true' "$WORK_DIR/kubectl.log"
+grep -Fq 'LIVE_KICKOFFS_ENABLED=false' "$WORK_DIR/kubectl.log"
+
+: >"$WORK_DIR/kubectl.log"
+reset_state false
+if PATH="$WORK_DIR/bin:$PATH" \
+    STUB_LOG="$WORK_DIR/kubectl.log" \
+    STUB_STATE="$WORK_DIR/flag" \
+    STUB_FAIL_TRUE_SET_AFTER_MUTATION=1 \
+    ACTION=activate \
+    SOURCE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    CONTROL_RUN_ID=123 \
+    CONFIRMATION="ACTIVATE OCI LIVE BETTING" \
+    NAMESPACE=betstan-oci \
+    OUTPUT_DIR="$WORK_DIR/ambiguous-write" \
+      "$SCRIPT" >/dev/null 2>&1; then
+  echo "ambiguous activation write unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "$(cat "$WORK_DIR/flag")" == "false" ]]
+[[ ! -e "$WORK_DIR/flag.lease" ]]
+grep -Fq 'rollback_attempted=true' "$WORK_DIR/ambiguous-write/control.env"
+grep -Fq 'LIVE_KICKOFFS_ENABLED=true' "$WORK_DIR/kubectl.log"
+grep -Fq 'LIVE_KICKOFFS_ENABLED=false' "$WORK_DIR/kubectl.log"
+
+: >"$WORK_DIR/kubectl.log"
+reset_state true 1
+printf 'activate\n' >"$WORK_DIR/flag.action"
+printf '123\n' >"$WORK_DIR/flag.run"
+printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' >"$WORK_DIR/flag.sha"
+if run_control commit "COMMIT OCI LIVE BETTING" "$WORK_DIR/expired-commit" \
+    >/dev/null 2>&1; then
+  echo "expired activation lease unexpectedly committed" >&2
+  exit 1
+fi
+[[ "$(cat "$WORK_DIR/flag")" == "false" ]]
+[[ ! -e "$WORK_DIR/flag.lease" ]]
+grep -Fq 'rollback_attempted=true' "$WORK_DIR/expired-commit/control.env"
+
+: >"$WORK_DIR/kubectl.log"
+reset_state false
+run_control activate "ACTIVATE OCI LIVE BETTING" "$WORK_DIR/commit-ambiguous-start"
+if PATH="$WORK_DIR/bin:$PATH" \
+    STUB_LOG="$WORK_DIR/kubectl.log" \
+    STUB_STATE="$WORK_DIR/flag" \
+    STUB_FAIL_COMMIT_AFTER_MUTATION=1 \
+    ACTION=commit \
+    SOURCE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+    CONTROL_RUN_ID=123 \
+    CONFIRMATION="COMMIT OCI LIVE BETTING" \
+    NAMESPACE=betstan-oci \
+    OUTPUT_DIR="$WORK_DIR/commit-ambiguous" \
+      "$SCRIPT" >/dev/null 2>&1; then
+  echo "ambiguous activation commit unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "$(cat "$WORK_DIR/flag")" == "false" ]]
+[[ ! -e "$WORK_DIR/flag.lease" ]]
+grep -Fq 'rollback_attempted=true' "$WORK_DIR/commit-ambiguous/control.env"
+
+echo "live betting control contract: PASS"

--- a/infra/oci/tests/test-revalidate-live-activation-stan.sh
+++ b/infra/oci/tests/test-revalidate-live-activation-stan.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$ROOT_DIR/infra/oci/scripts/revalidate-live-activation-stan.sh"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+SOURCE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+mkdir -p "$WORK_DIR/bin"
+
+cat >"$WORK_DIR/bin/git" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "fetch" ]]; then
+  exit 0
+fi
+if [[ "$1" == "rev-parse" && "$2" == "HEAD" ]]; then
+  printf '%s\n' "${STUB_HEAD_SHA:?}"
+  exit 0
+fi
+if [[ "$1" == "rev-parse" && "$2" == "origin/master" ]]; then
+  printf '%s\n' "${STUB_MASTER_SHA:?}"
+  exit 0
+fi
+echo "unexpected git invocation: $*" >&2
+exit 1
+STUB
+
+cat >"$WORK_DIR/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+endpoint="$2"
+run_id="${endpoint##*/}"
+case "$run_id" in
+  101) path=".github/workflows/oci-production-build.yml"; event="workflow_run" ;;
+  102) path=".github/workflows/oci-infrastructure.yml"; event="workflow_dispatch" ;;
+  103) path=".github/workflows/oci-production-deploy.yml"; event="workflow_dispatch" ;;
+  *) echo "unexpected run ID: $run_id" >&2; exit 1 ;;
+esac
+printf '%s\t%s\t%s\tmaster\texample/repo\tcompleted\tsuccess\t%s\n' \
+  "$path" "$event" "${STUB_RUN_SHA:?}" "${STUB_RUN_ATTEMPT:-1}"
+STUB
+chmod +x "$WORK_DIR/bin/git" "$WORK_DIR/bin/gh"
+
+run_revalidation() {
+  PATH="$WORK_DIR/bin:$PATH" \
+  STUB_HEAD_SHA="${STUB_HEAD_SHA:-$SOURCE_SHA}" \
+  STUB_MASTER_SHA="${STUB_MASTER_SHA:-$SOURCE_SHA}" \
+  STUB_RUN_SHA="${STUB_RUN_SHA:-$SOURCE_SHA}" \
+  STUB_RUN_ATTEMPT="${STUB_RUN_ATTEMPT:-1}" \
+  SOURCE_SHA="$SOURCE_SHA" \
+  BUILD_RUN_ID=101 \
+  INFRASTRUCTURE_RUN_ID=102 \
+  DEPLOYMENT_RUN_ID=103 \
+  REPOSITORY=example/repo \
+  GITHUB_REF_NAME=master \
+  GITHUB_RUN_ATTEMPT=1 \
+    "$SCRIPT"
+}
+
+run_revalidation >/dev/null
+
+if STUB_MASTER_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+  run_revalidation >/dev/null 2>&1; then
+  echo "revalidation accepted an advanced master" >&2
+  exit 1
+fi
+
+if STUB_RUN_ATTEMPT=2 run_revalidation >/dev/null 2>&1; then
+  echo "revalidation accepted rerun provenance" >&2
+  exit 1
+fi
+
+echo "live activation revalidation contract: PASS"


### PR DESCRIPTION
## Summary
- enforce persisted-role authorization and isolate offline production-acceptance fixtures
- add fail-dark live simulation activation leases, exact-SHA controls, and rollback-safe workflows
- close live-event ordering, SSE revocation, and client reconciliation races
- update production acceptance, tests, learnings, and reusable agents

## Validation
- auth: 43 tests
- backoffice: 48 tests + TypeScript
- event: 99 tests + TypeScript
- gamemaster: 47 tests
- bet: 68 tests
- moderation: 64 tests
- slip: 81 tests
- common contracts: 7 tests
- client: 39 tests + production build
- deterministic Playwright: 7 tests
- complete OCI contract suite
- independent code, security, and concurrency reviews: APPROVE / READY