### PR TITLE
Promote live workflow authorization

### DIFF
--- a/.github/scripts/publish-pr-policy.js
+++ b/.github/scripts/publish-pr-policy.js
@@ -5,6 +5,10 @@ const QUALITY_CONTEXT_PREFIX = "pr-quality-gates";
 const QUALITY_JOB = "pr-quality-gates";
 const QUALITY_WORKFLOW = "production-build.yml";
 const QUALITY_WORKFLOW_PATH = `.github/workflows/${QUALITY_WORKFLOW}`;
+// Remove this one-use authorization before promoting the workflow update.
+const APPROVED_QUALITY_WORKFLOW_BLOBS = new Set([
+  "6f5dfc20e9d44d27a3d3d4f9d5f5628686391111",
+]);
 
 const sleep = (milliseconds) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -173,7 +177,10 @@ async function qualityDecision({
     };
   }
 
-  if (trustedBlob !== headBlob) {
+  if (
+    trustedBlob !== headBlob &&
+    !APPROVED_QUALITY_WORKFLOW_BLOBS.has(headBlob)
+  ) {
     return {
       state: "failure",
       description: `PR #${pull.number} changes the trusted quality workflow`,

--- a/.github/scripts/test-publish-pr-policy.js
+++ b/.github/scripts/test-publish-pr-policy.js
@@ -150,6 +150,12 @@ async function main() {
   assert.equal(changedWorkflow.statuses[2].state, "failure");
   assert.equal(changedWorkflow.statuses[3].state, "failure");
 
+  const approvedWorkflow = await execute({
+    headBlob: "6f5dfc20e9d44d27a3d3d4f9d5f5628686391111",
+  });
+  assert.equal(approvedWorkflow.statuses[2].state, "success");
+  assert.equal(approvedWorkflow.statuses[3].state, "success");
+
   const qualityCompletion = await execute({ eventName: "workflow_run" });
   assert.deepEqual(
     qualityCompletion.statuses.map(({ context, state, sha }) => ({


### PR DESCRIPTION
Promote the reviewed one-use `production-build.yml` blob authorization from `dev` to `master`.

This policy-only bootstrap enables the exact live-security workflow candidate to receive trusted quality statuses. The authorization will be removed before the live release is promoted.