### PR TITLE
Enforce shared Mongo rollout readiness

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -34,6 +34,15 @@ Before changing or assessing deployment behavior, read:
 - `.github/agents/betstan-azure-retirement.agent.md`
 
 Inspect the current git graph and remote default branch. Do not infer that a merged PR is missing merely because its old head differs from a newer `master`; use `git merge-base --is-ancestor` and inspect the current tree.
+Resolve the remote default branch's full SHA through the GitHub API or
+`git ls-remote`, fetch and verify that immutable commit, and read every cited path from that same tree.
+Never treat a local branch or remote-tracking ref as authority. Immediately
+before mutation, resolve the remote SHA again and require it to be unchanged.
+
+A workflow absent from the authoritative tree is not necessarily retired.
+Require authoritative Actions workflow-state and paginated nonterminal-run
+checks, including historical runs for removed paths, before treating it as
+inactive. Fail closed when either query is incomplete or fails.
 
 ## Production trigger rules
 
@@ -85,6 +94,9 @@ Before deployment:
 - validate manifest YAML offline;
 - run `ingress-routing-guard-stan.sh`;
 - require `shared-mongo-topology-guard-stan.sh` to confirm the validated one-Mongo topology;
+- require the target-specific retained Mongo PVC identity to be `Bound` and
+  reject every additional Mongo PVC; never infer topology safety from a count
+  threshold;
 - return `NO_GO` when the topology journal is in `transition`; normal deployment
   must not race migration, cleanup, or rollback;
 - check production health and rollback readiness;

--- a/infra/azure/agents/live-betting-readiness-lib.sh
+++ b/infra/azure/agents/live-betting-readiness-lib.sh
@@ -909,6 +909,8 @@ live_betting_apply_metric() {
     topology_mode) LIVE_BETTING_TOPOLOGY_MODE="$value" ;;
     topology_validated) LIVE_BETTING_TOPOLOGY_VALIDATED="$value" ;;
     lock_state) LIVE_BETTING_LOCK_STATE="$value" ;;
+    mongo_pvc_name) LIVE_BETTING_MONGO_PVC_NAME="$value" ;;
+    mongo_pvc_phase) LIVE_BETTING_MONGO_PVC_PHASE="$value" ;;
     public_event_status) LIVE_BETTING_PUBLIC_EVENT_STATUS="$value" ;;
     public_event_items) LIVE_BETTING_PUBLIC_EVENT_ITEMS="$value" ;;
     legacy_prematch_events) LIVE_BETTING_LEGACY_PREMATCH_EVENTS="$value" ;;
@@ -1145,11 +1147,15 @@ PY
 live_betting_check_topology() {
   local topology_file="$1"
   local lock_file="$2"
+  local pvc_file="$3"
   local result_stdout="$LIVE_BETTING_WORK_DIR/topology.result"
   local result_stderr="$LIVE_BETTING_WORK_DIR/topology.result.stderr"
   if ! python3 - \
     "$topology_file" \
     "$lock_file" \
+    "$pvc_file" \
+    "$LIVE_BETTING_REQUIRED_MONGO_TOPOLOGY_MODE" \
+    "$LIVE_BETTING_EXPECTED_SHARED_MONGO_PVC" \
     "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_HOLDER" \
     "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_ID" \
     "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_SOURCE_SHA" \
@@ -1158,15 +1164,50 @@ import json
 import sys
 from pathlib import Path
 
-topology_path, lock_path, expected_holder, expected_operation, expected_sha = sys.argv[1:]
+(
+    topology_path,
+    lock_path,
+    pvc_path,
+    required_mode,
+    expected_shared_pvc,
+    expected_holder,
+    expected_operation,
+    expected_sha,
+) = sys.argv[1:]
 topology = json.loads(Path(topology_path).read_text(encoding="utf-8"))
 topology_data = topology.get("data") or {}
 mode = str(topology_data.get("mode", "legacy") or "legacy")
 validated = str(topology_data.get("validated", "false") or "false").lower()
+if required_mode and mode != required_mode:
+    raise SystemExit(f"Mongo topology mode must be {required_mode}")
 expect_active_lock = bool(expected_holder or expected_operation or expected_sha)
 if mode == "shared":
     if validated != "true":
         raise SystemExit("shared Mongo topology must be validated")
+    if expected_shared_pvc:
+        if not pvc_path or not Path(pvc_path).is_file():
+            raise SystemExit("shared Mongo PVC inventory is missing")
+        pvc_payload = json.loads(Path(pvc_path).read_text(encoding="utf-8"))
+        pvc_items = pvc_payload.get("items")
+        if not isinstance(pvc_items, list):
+            raise SystemExit("shared Mongo PVC inventory is invalid")
+        mongo_pvcs = []
+        for item in pvc_items:
+            if not isinstance(item, dict):
+                raise SystemExit("shared Mongo PVC inventory contains an invalid item")
+            metadata = item.get("metadata") or {}
+            status = item.get("status") or {}
+            name = metadata.get("name")
+            if isinstance(name, str) and "mongo" in name.lower():
+                mongo_pvcs.append((name, str(status.get("phase", ""))))
+        mongo_pvcs.sort()
+        if [name for name, _phase in mongo_pvcs] != [expected_shared_pvc]:
+            raise SystemExit("shared Mongo PVC inventory differs from the exact retained claim")
+        pvc_phase = mongo_pvcs[0][1]
+        if pvc_phase != "Bound":
+            raise SystemExit("retained shared Mongo PVC is not Bound")
+        print(f"mongo_pvc_name={expected_shared_pvc}")
+        print(f"mongo_pvc_phase={pvc_phase}")
     lock_state = "missing"
     if Path(lock_path).exists():
         lock = json.loads(Path(lock_path).read_text(encoding="utf-8"))
@@ -1828,6 +1869,8 @@ aux_workloads_ready=$LIVE_BETTING_AUX_WORKLOADS_READY
 topology_mode=$LIVE_BETTING_TOPOLOGY_MODE
 topology_validated=$LIVE_BETTING_TOPOLOGY_VALIDATED
 lock_state=$LIVE_BETTING_LOCK_STATE
+mongo_pvc_name=$LIVE_BETTING_MONGO_PVC_NAME
+mongo_pvc_phase=$LIVE_BETTING_MONGO_PVC_PHASE
 rabbit_live_ready_messages=$LIVE_BETTING_RABBIT_READY
 rabbit_live_unacked_messages=$LIVE_BETTING_RABBIT_UNACK
 rabbit_live_consumers=$LIVE_BETTING_RABBIT_CONSUMERS
@@ -1881,6 +1924,8 @@ live_betting_readiness_main() {
   LIVE_BETTING_EXPECTED_OPERATION_LOCK_HOLDER="${EXPECTED_OPERATION_LOCK_HOLDER:-}"
   LIVE_BETTING_EXPECTED_OPERATION_LOCK_ID="${EXPECTED_OPERATION_LOCK_ID:-}"
   LIVE_BETTING_EXPECTED_OPERATION_LOCK_SOURCE_SHA="${EXPECTED_OPERATION_LOCK_SOURCE_SHA:-}"
+  LIVE_BETTING_REQUIRED_MONGO_TOPOLOGY_MODE="${REQUIRED_MONGO_TOPOLOGY_MODE:-}"
+  LIVE_BETTING_EXPECTED_SHARED_MONGO_PVC="${EXPECTED_SHARED_MONGO_PVC:-}"
   LIVE_BETTING_PUBLIC_HOSTS_REQUIRED="${PUBLIC_HOSTS_REQUIRED:-0}"
   LIVE_BETTING_DIAGNOSTIC_URL_REQUIRED="${DIAGNOSTIC_URL_REQUIRED:-0}"
   LIVE_BETTING_REQUIRE_HTTPS_PRIMARY="${REQUIRE_HTTPS_PRIMARY:-0}"
@@ -1926,6 +1971,8 @@ live_betting_readiness_main() {
   LIVE_BETTING_TOPOLOGY_MODE="unknown"
   LIVE_BETTING_TOPOLOGY_VALIDATED="unknown"
   LIVE_BETTING_LOCK_STATE="unknown"
+  LIVE_BETTING_MONGO_PVC_NAME="unknown"
+  LIVE_BETTING_MONGO_PVC_PHASE="unknown"
   LIVE_BETTING_PUBLIC_EVENT_STATUS="unknown"
   LIVE_BETTING_PUBLIC_EVENT_ITEMS="unknown"
   LIVE_BETTING_LEGACY_PREMATCH_EVENTS="unknown"
@@ -1973,6 +2020,18 @@ live_betting_readiness_main() {
     [[ "$LIVE_BETTING_EXPECTED_OPERATION_LOCK_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
       live_betting_record_failure preflight "EXPECTED_OPERATION_LOCK_SOURCE_SHA is invalid"
   fi
+  case "$LIVE_BETTING_REQUIRED_MONGO_TOPOLOGY_MODE" in
+    ""|legacy|shared) ;;
+    *) live_betting_record_failure preflight "REQUIRED_MONGO_TOPOLOGY_MODE must be legacy or shared" ;;
+  esac
+  if [[ -n "$LIVE_BETTING_EXPECTED_SHARED_MONGO_PVC" ]]; then
+    [[ "$LIVE_BETTING_EXPECTED_SHARED_MONGO_PVC" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] ||
+      live_betting_record_failure preflight "EXPECTED_SHARED_MONGO_PVC is invalid"
+  fi
+  if [[ "$LIVE_BETTING_REQUIRED_MONGO_TOPOLOGY_MODE" == "shared" &&
+        -z "$LIVE_BETTING_EXPECTED_SHARED_MONGO_PVC" ]]; then
+    live_betting_record_failure preflight "EXPECTED_SHARED_MONGO_PVC is required for shared topology"
+  fi
   live_betting_require_uint REQUEST_TIMEOUT "$LIVE_BETTING_REQUEST_TIMEOUT"
   live_betting_require_uint SSE_TIMEOUT "$LIVE_BETTING_SSE_TIMEOUT"
   live_betting_require_uint MAX_ACTIVE_MATCHES "$LIVE_BETTING_MAX_ACTIVE_MATCHES"
@@ -2005,7 +2064,7 @@ live_betting_readiness_main() {
   live_betting_check_schema_evidence || true
   live_betting_check_rollback_baseline || true
 
-  local workloads_json pods_json topology_stderr lock_stderr rabbit_stderr
+  local workloads_json pods_json pvcs_json topology_stderr lock_stderr rabbit_stderr
   if workloads_json="$(live_betting_capture_command workloads kubectl --request-timeout="$LIVE_BETTING_KUBECTL_TIMEOUT" get deploy,sts -n "$LIVE_BETTING_NAMESPACE" -o json)"; then
     printf '%s\n' "$workloads_json" >"$LIVE_BETTING_WORK_DIR/workloads.json"
   else
@@ -2019,11 +2078,19 @@ live_betting_readiness_main() {
   if [[ -f "$LIVE_BETTING_WORK_DIR/workloads.json" && -f "$LIVE_BETTING_PODS_JSON_FILE" && -f "$LIVE_BETTING_IMAGE_PROVENANCE_FILE" ]]; then
     live_betting_check_workloads "$LIVE_BETTING_WORK_DIR/workloads.json" "$LIVE_BETTING_PODS_JSON_FILE" || true
   fi
+  if [[ -n "$LIVE_BETTING_EXPECTED_SHARED_MONGO_PVC" ]]; then
+    if pvcs_json="$(live_betting_capture_command pvcs kubectl --request-timeout="$LIVE_BETTING_KUBECTL_TIMEOUT" get persistentvolumeclaims -n "$LIVE_BETTING_NAMESPACE" -o json)"; then
+      printf '%s\n' "$pvcs_json" >"$LIVE_BETTING_WORK_DIR/pvcs.json"
+    else
+      live_betting_record_failure topology_lock "unable to inspect Mongo PVC inventory"
+    fi
+  fi
 
   topology_stderr="$LIVE_BETTING_WORK_DIR/topology.stderr"
   if kubectl --request-timeout="$LIVE_BETTING_KUBECTL_TIMEOUT" get configmap gaming-mongo-topology -n "$LIVE_BETTING_NAMESPACE" -o json >"$LIVE_BETTING_WORK_DIR/topology.json" 2>"$topology_stderr"; then
     live_betting_write_sanitized_file "$topology_stderr" "$LIVE_BETTING_OUTPUT_DIR/topology.stderr"
-  elif grep -Eqi 'not[ -]?found' "$topology_stderr"; then
+  elif grep -Eqi 'not[ -]?found' "$topology_stderr" &&
+      [[ "$LIVE_BETTING_REQUIRED_MONGO_TOPOLOGY_MODE" != "shared" ]]; then
     live_betting_write_sanitized_file "$topology_stderr" "$LIVE_BETTING_OUTPUT_DIR/topology.stderr"
     printf '{"data":{"mode":"legacy","validated":"true"}}\n' >"$LIVE_BETTING_WORK_DIR/topology.json"
   else
@@ -2041,7 +2108,10 @@ live_betting_readiness_main() {
     live_betting_record_failure topology_lock "unable to inspect Mongo operation lock"
   fi
   if [[ -f "$LIVE_BETTING_WORK_DIR/topology.json" ]]; then
-    live_betting_check_topology "$LIVE_BETTING_WORK_DIR/topology.json" "$LIVE_BETTING_WORK_DIR/lock.json" || true
+    live_betting_check_topology \
+      "$LIVE_BETTING_WORK_DIR/topology.json" \
+      "$LIVE_BETTING_WORK_DIR/lock.json" \
+      "$LIVE_BETTING_WORK_DIR/pvcs.json" || true
   fi
 
   local rabbit_pod

--- a/infra/azure/agents/live-betting-readiness-test-lib.sh
+++ b/infra/azure/agents/live-betting-readiness-test-lib.sh
@@ -216,6 +216,26 @@ print(json.dumps({'items': items}))
 PY
   exit 0
 fi
+if [[ "$args" == *"get persistentvolumeclaims"* ]]; then
+  [[ "$fail_command" != "pvcs" ]] || exit 1
+  python3 - \
+    "${STUB_MONGO_PVC_NAME:-gaming-auth-mongo-data}" \
+    "${STUB_MONGO_PVC_PHASE:-Bound}" \
+    "${STUB_EXTRA_MONGO_PVC:-}" \
+    "${STUB_MONGO_PVC_MISSING:-0}" <<'PY'
+import json
+import sys
+
+name, phase, extra_name, missing = sys.argv[1:]
+items = []
+if missing != "1":
+    items.append({"metadata": {"name": name}, "status": {"phase": phase}})
+if extra_name:
+    items.append({"metadata": {"name": extra_name}, "status": {"phase": "Bound"}})
+print(json.dumps({"items": items}))
+PY
+  exit 0
+fi
 if [[ "$args" == *"get pods"* ]]; then
   [[ "$fail_command" != "pods" ]] || exit 1
   python3 - "$IMAGE_PROVENANCE_FILE" "${STUB_TOPOLOGY_MODE:-shared}" <<'PY'
@@ -561,6 +581,9 @@ run_live_betting_scenario() {
     export STUB_TOPOLOGY_MODE=shared
     export STUB_TOPOLOGY_VALIDATED=true
     export STUB_TOPOLOGY_MISSING=0
+    export STUB_MONGO_PVC_PHASE=Bound
+    export STUB_EXTRA_MONGO_PVC=
+    export STUB_MONGO_PVC_MISSING=0
     export STUB_LOCK_STATE=released
     export STUB_LOCK_HOLDER=
     export STUB_LOCK_OPERATION_ID=
@@ -616,10 +639,12 @@ run_live_betting_scenario() {
     export STUB_COMMAND_FAILURE=
     export MODE=dark
     if [[ "$stack" == "azure" ]]; then
+      export STUB_MONGO_PVC_NAME="gaming-auth-mongo-data-gaming-auth-mongo-depl-0"
       export BASE_URL="https://public.example.invalid"
       export SECONDARY_PUBLIC_URL=""
       export DIAGNOSTIC_URL=""
     else
+      export STUB_MONGO_PVC_NAME="gaming-auth-mongo-data"
       unset BASE_URL SECONDARY_PUBLIC_URL DIAGNOSTIC_URL
       export OCI_PUBLIC_URL="https://betstan.xyz"
       export OCI_REDIRECT_URL="https://www.betstan.xyz"

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -8,6 +8,13 @@ conversation summaries are not authority.
 
 - Bind every mutation to one full current source SHA and one internally
   consistent build, capacity, infrastructure, deploy, or migration chain.
+- Resolve the remote default branch SHA through GitHub or `git ls-remote`,
+  fetch and verify that immutable commit, and read workflow, agent, manifest,
+  and test evidence from that same tree. Revalidate the remote SHA immediately
+  before mutation; local and remote-tracking refs are not authority.
+- Absence from the current tree does not retire historical workflow runs.
+  Require authoritative workflow-state and complete nonterminal-run queries,
+  and fail closed when either query fails or cannot be fully paginated.
 - A protected-environment approval wait is an active workflow state, not a
   hang. Never rerun or cancel it to bypass review.
 - Recovery uses the interrupted migration journal SHA and fencing generation.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -139,9 +139,10 @@ permissions; `boot-volumes` is not an individual IAM resource type.
 ```
 
 The tests parse every OCI YAML file, check every shell script with `bash -n`,
-render the explicit overlay with sanitized fixture provenance, verify one
-Mongo/PVC/load balancer, canonical/redirect/diagnostic ingress and certificate
-contracts, verify the k3s local-PV and Bastion cleanup
+render the explicit overlay with sanitized fixture provenance, verify the exact
+`Bound` `gaming-auth-mongo-data` shared claim with no additional Mongo PVC,
+verify the single Mongo/load balancer and canonical/redirect/diagnostic ingress
+and certificate contracts, verify the k3s local-PV and Bastion cleanup
 contracts, reject mixed OKE/k3s inventory, mutable application images, and
 legacy Mongo, check credential separation, and exercise health failure
 fixtures. The entrypoint also validates shared migration-success provenance,
@@ -214,8 +215,9 @@ concurrent retirement fixture isolation without masking failed suites.
    image digests, and deploys Mongo, RabbitMQ, backends, client, and ingress
    sequentially.
 8. `agents/deploy-validation-loop-stan.sh` must pass canonical apex, permanent
-   `www` redirect, diagnostic TLS, API, browser, cluster, and zero-cost checks
-   before the deployment is healthy.
+   `www` redirect, diagnostic TLS, API, browser, cluster, zero-cost, validated
+   shared-Mongo marker/lock, and exact `Bound` shared-PVC checks before the
+   deployment is healthy.
 9. Dispatch `oci-migrate` only with the exact current master SHA, successful
    first-attempt build/infrastructure/deploy run IDs,
    `replace_oci_data=true`, and the destructive confirmation. The workflow

--- a/infra/oci/agents/health-check-stan.sh
+++ b/infra/oci/agents/health-check-stan.sh
@@ -388,6 +388,16 @@ jq -e 'type == "array"' <<<"$database_json" >/dev/null || oci_die "Mongo databas
 
 mongo_sts_count="$(jq '[.items[]? | select(.metadata.name | test("mongo"))] | length' "$statefulsets_json")"
 mongo_pvc_count="$(jq '[.items[]? | select(.metadata.name | test("mongo"))] | length' "$pvcs_json")"
+mongo_pvc_inventory="$(
+  jq -c '[
+    .items[]?
+    | select(.metadata.name | test("mongo"))
+    | {
+        name: .metadata.name,
+        phase: (.status.phase // "")
+      }
+  ] | sort_by(.name)' "$pvcs_json"
+)"
 mongo_pvc_bound="$(jq -r '[.items[]? | select(.metadata.name == "gaming-auth-mongo-data")][0].status.phase == "Bound"' "$pvcs_json")"
 mongo_pvc_size="$(jq -r '[.items[]? | select(.metadata.name == "gaming-auth-mongo-data")][0].spec.resources.requests.storage // ""' "$pvcs_json")"
 mongo_pvc_gib=0
@@ -508,6 +518,7 @@ jq -n \
   --argjson pods "$pods" \
   --argjson mongo_sts_count "$mongo_sts_count" \
   --argjson mongo_pvc_count "$mongo_pvc_count" \
+  --argjson mongo_pvc_inventory "$mongo_pvc_inventory" \
   --argjson mongo_pvc_bound "$mongo_pvc_bound" \
   --argjson mongo_pvc_gib "$mongo_pvc_gib" \
   --argjson mongo_runtime "$mongo_runtime_json" \
@@ -557,6 +568,7 @@ jq -n \
     mongo: {
       statefulset_count: $mongo_sts_count,
       pvc_count: $mongo_pvc_count,
+      pvc_inventory: $mongo_pvc_inventory,
       pvc_bound: $mongo_pvc_bound,
       pvc_gib: $mongo_pvc_gib,
       version: $mongo_runtime.version,

--- a/infra/oci/agents/health-contract.py
+++ b/infra/oci/agents/health-contract.py
@@ -39,6 +39,12 @@ EXPECTED_DATABASES = {
     "gaming_resulting",
     "gaming_slip",
 }
+EXPECTED_MONGO_PVC_INVENTORY = [
+    {
+        "name": "gaming-auth-mongo-data",
+        "phase": "Bound",
+    }
+]
 EXPECTED_PLATFORM_DIGESTS = {
     "ingress-nginx/ingress-nginx-controller": "sha256:594ceea76b01c592858f803f9ff4d2cb40542cae2060410b2c95f75907d659e1",
     "cert-manager/cert-manager": "sha256:416a2d76870d996460e62bd7f521bf14fa017be9e3e904aab92163a331fcb61a",
@@ -168,6 +174,11 @@ def validate(snapshot):
 
     mongo = snapshot.get("mongo", {})
     require(mongo.get("statefulset_count") == 1, "extra-mongo", "expected exactly one Mongo StatefulSet")
+    require(
+        mongo.get("pvc_inventory") == EXPECTED_MONGO_PVC_INVENTORY,
+        "mongo-pvc-topology",
+        "Mongo PVC inventory differs from the exact Bound shared claim",
+    )
     require(mongo.get("pvc_count") == 1, "mongo-pvc-count", "expected exactly one Mongo PVC")
     require(mongo.get("pvc_bound") is True, "mongo-pvc-unbound", "Mongo PVC is not Bound")
     require(mongo.get("pvc_gib") == 50, "mongo-pvc-size", "Mongo PVC was not created at 50 GiB")

--- a/infra/oci/agents/live-betting-readiness-stan.sh
+++ b/infra/oci/agents/live-betting-readiness-stan.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 LIVE_BETTING_STACK="oci"
+export REQUIRED_MONGO_TOPOLOGY_MODE=shared
+export EXPECTED_SHARED_MONGO_PVC=gaming-auth-mongo-data
 BASE_URL="${BASE_URL:-${OCI_PUBLIC_URL:-}}"
 SECONDARY_PUBLIC_URL="${SECONDARY_PUBLIC_URL:-${OCI_REDIRECT_URL:-}}"
 DIAGNOSTIC_URL="${DIAGNOSTIC_URL:-${OCI_DIAGNOSTIC_URL:-}}"

--- a/infra/oci/agents/test-health-contract-stan.sh
+++ b/infra/oci/agents/test-health-contract-stan.sh
@@ -48,6 +48,9 @@ run_failure missing-workload 'del(.workloads[0])' workload-set
 run_failure platform-digest '.platform_workloads[0].image="mutable"' platform-digest
 run_failure empty-endpoint '.services[0].ready_endpoints=false' empty-endpoint
 run_failure extra-mongo '.mongo.statefulset_count=2' extra-mongo
+run_failure wrong-pvc-identity '.mongo.pvc_inventory[0].name="gaming-bet-mongo-data"' mongo-pvc-topology
+run_failure extra-legacy-pvc '.mongo.pvc_inventory += [{"name":"gaming-bet-mongo-data-gaming-bet-mongo-depl-0","phase":"Bound"}]' mongo-pvc-topology
+run_failure inventory-unbound-pvc '.mongo.pvc_inventory[0].phase="Pending"' mongo-pvc-topology
 run_failure unbound-pvc '.mongo.pvc_bound=false' mongo-pvc-unbound
 run_failure mongo-version '.mongo.version="7.0.21"|.mongo.major_minor="7.0"' mongo-version
 run_failure mongo-fcv '.mongo.fcv="8.0"' mongo-fcv

--- a/infra/oci/tests/fixtures/health/healthy.json
+++ b/infra/oci/tests/fixtures/health/healthy.json
@@ -85,6 +85,12 @@
   "mongo": {
     "statefulset_count": 1,
     "pvc_count": 1,
+    "pvc_inventory": [
+      {
+        "name": "gaming-auth-mongo-data",
+        "phase": "Bound"
+      }
+    ],
     "pvc_bound": true,
     "pvc_gib": 50,
     "version": "8.2.12",

--- a/infra/oci/tests/rollback-contract.sh
+++ b/infra/oci/tests/rollback-contract.sh
@@ -739,6 +739,24 @@ case "${1:-}" in
           exit 1
         fi
         ;;
+      persistentvolumeclaims)
+        python3 - \
+          "${STUB_MONGO_PVC_NAME:-gaming-auth-mongo-data}" \
+          "${STUB_MONGO_PVC_PHASE:-Bound}" \
+          "${STUB_EXTRA_MONGO_PVC:-}" <<'PY'
+import json
+import sys
+
+name, phase, extra_name = sys.argv[1:]
+items = [{"metadata": {"name": name}, "status": {"phase": phase}}]
+if extra_name:
+    items.append({
+        "metadata": {"name": extra_name},
+        "status": {"phase": "Bound"},
+    })
+print(json.dumps({"items": items}))
+PY
+        ;;
       configmap)
         name="$2"
         case "$name" in

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -605,6 +605,21 @@ migrate_workflow="$ROOT_DIR/.github/workflows/oci-migrate.yml"
 recovery_workflow="$ROOT_DIR/.github/workflows/oci-migration-recovery.yml"
 validate_workflow="$ROOT_DIR/.github/workflows/oci-validate.yml"
 cli_installer="$OCI_DIR/scripts/install-cli.sh"
+deployment_safety_agent="$ROOT_DIR/.github/agents/betstan-deployment-safety.agent.md"
+azure_deploy_workflow="$ROOT_DIR/.github/workflows/production-deploy.yml"
+oci_live_readiness="$OCI_DIR/agents/live-betting-readiness-stan.sh"
+
+grep -Fq 'read every cited path from that same tree' "$deployment_safety_agent"
+grep -Fq 'never infer topology safety from a count' "$deployment_safety_agent"
+grep -Fq './infra/azure/agents/shared-mongo-topology-guard-stan.sh' \
+  "$azure_deploy_workflow"
+grep -Fq 'export REQUIRED_MONGO_TOPOLOGY_MODE=shared' "$oci_live_readiness"
+grep -Fq 'export EXPECTED_SHARED_MONGO_PVC=gaming-auth-mongo-data' \
+  "$oci_live_readiness"
+if grep -Eiq 'at least (eight|8) Mongo PVC' \
+  "$deployment_safety_agent" "$azure_deploy_workflow" "$deploy_workflow"; then
+  fail "current production safety sources retain the retired eight-PVC gate"
+fi
 
 grep -Fq 'workflow_run:' "$build_workflow"
 grep -Fq 'workflows: ["production-build"]' "$build_workflow"
@@ -628,6 +643,8 @@ grep -Fq 'cron: "*/5 * * * *"' "$capacity_workflow"
 grep -Fq 'workflow_dispatch:' "$capacity_workflow"
 grep -Fq 'github.run_attempt == 1' "$capacity_workflow"
 grep -Fq "vars.OCI_CAPACITY_CATCHER_ENABLED == 'true'" "$capacity_workflow"
+grep -Fq "github.event_name == 'workflow_dispatch'" "$capacity_workflow"
+grep -Fq "inputs.approved_sha != ''" "$capacity_workflow"
 grep -Fq 'group: oci-control-plane' "$capacity_workflow"
 grep -Fq 'name: oci-capacity-acquire' "$capacity_workflow"
 grep -Fq 'OCI_CAPACITY_PRIVATE_KEY_PEM' "$capacity_workflow"

--- a/infra/oci/tests/test-live-betting-readiness-stan.sh
+++ b/infra/oci/tests/test-live-betting-readiness-stan.sh
@@ -32,6 +32,9 @@ assert_contains "$RUN_SUMMARY_FILE" 'mode=monitor' 'OCI monitor summary should p
 assert_contains "$RUN_SUMMARY_FILE" 'secondary_redirect_status=308' 'OCI monitor should validate redirect host'
 assert_contains "$RUN_SUMMARY_FILE" 'diagnostic_event_status=200' 'OCI monitor should validate diagnostic event API'
 assert_contains "$RUN_SUMMARY_FILE" 'sse_diagnostic_status=200' 'OCI monitor should validate diagnostic SSE'
+assert_contains "$RUN_SUMMARY_FILE" 'topology_mode=shared' 'OCI monitor should require shared Mongo topology'
+assert_contains "$RUN_SUMMARY_FILE" 'mongo_pvc_name=gaming-auth-mongo-data' 'OCI monitor should record the exact shared Mongo PVC'
+assert_contains "$RUN_SUMMARY_FILE" 'mongo_pvc_phase=Bound' 'OCI monitor should require the shared Mongo PVC to be Bound'
 assert_contains "$RUN_SUMMARY_FILE" 'bet_pending_bet_update_processing_count=1' 'OCI monitor should surface bet processing backlog'
 assert_contains "$RUN_SUMMARY_FILE" 'moderation_parked_place_bet_processing_count=1' 'OCI monitor should surface moderation processing backlog'
 assert_contains "$RUN_SUMMARY_FILE" 'resulting_pending_moderation_result_processing_count=1' 'OCI monitor should surface resulting processing backlog'
@@ -48,20 +51,40 @@ assert_contains "$RUN_SUMMARY_FILE" 'rollback_baseline_verified=true' 'OCI activ
 assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=none' 'OCI activate should report no failed checks'
 assert_contains "$RUN_SUMMARY_FILE" 'legacy_prematch_events=1' 'OCI activate should persist prematch evidence'
 
-run_live_betting_scenario oci-legacy-monitor "$SCRIPT" oci \
+run_live_betting_scenario oci-legacy-topology "$SCRIPT" oci \
   MODE=monitor \
   STUB_TOPOLOGY_MODE=legacy \
+  STUB_FLAG_VALUE=true
+assert_eq 1 "$RUN_RC" "OCI monitor should reject legacy Mongo topology"
+assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=topology_lock' 'legacy OCI topology should fail the topology contract'
+
+run_live_betting_scenario oci-wrong-shared-pvc "$SCRIPT" oci \
+  MODE=monitor \
   STUB_FLAG_VALUE=true \
-  STUB_BET_LEGACY_PENDING_COUNT=1 \
-  STUB_BET_LEGACY_PENDING_AGE_SECONDS=120 \
-  STUB_RESULTING_RETRY_LEGACY_PENDING_COUNT=1 \
-  STUB_RESULTING_RETRY_LEGACY_PENDING_AGE_SECONDS=180
-assert_eq 0 "$RUN_RC" "OCI monitor should support legacy topology parking diagnostics"
-assert_contains "$RUN_SUMMARY_FILE" 'topology_mode=legacy' 'OCI legacy monitor should persist topology mode'
-assert_contains "$RUN_SUMMARY_FILE" 'bet_pending_bet_update_pending_count=1' 'OCI legacy monitor should classify missing-status bet docs as pending'
-assert_contains "$RUN_SUMMARY_FILE" 'resulting_retry_record_pending_count=1' 'OCI legacy monitor should classify missing-status retry docs as pending'
-assert_contains "$RUN_QUERY_CAPTURE_DIR/mongo-bet-pending-bet-update.js" 'includeLegacyMissingStatus: true' 'OCI bet query should include legacy missing-status docs'
-assert_contains "$RUN_QUERY_CAPTURE_DIR/mongo-resulting-retry-record.js" 'includeLegacyMissingStatus: true' 'OCI retry query should include legacy missing-status docs'
+  STUB_MONGO_PVC_NAME=gaming-bet-mongo-data
+assert_eq 1 "$RUN_RC" "OCI monitor should reject a different single Mongo PVC"
+assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=topology_lock' 'wrong shared PVC identity should fail the topology contract'
+
+run_live_betting_scenario oci-unbound-shared-pvc "$SCRIPT" oci \
+  MODE=monitor \
+  STUB_FLAG_VALUE=true \
+  STUB_MONGO_PVC_PHASE=Pending
+assert_eq 1 "$RUN_RC" "OCI monitor should reject an unbound shared Mongo PVC"
+assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=topology_lock' 'unbound shared PVC should fail the topology contract'
+
+run_live_betting_scenario oci-extra-legacy-pvc "$SCRIPT" oci \
+  MODE=monitor \
+  STUB_FLAG_VALUE=true \
+  STUB_EXTRA_MONGO_PVC=gaming-bet-mongo-data-gaming-bet-mongo-depl-0
+assert_eq 1 "$RUN_RC" "OCI monitor should reject an additional legacy Mongo PVC"
+assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=topology_lock' 'additional legacy PVC should fail the topology contract'
+
+run_live_betting_scenario oci-missing-topology-marker "$SCRIPT" oci \
+  MODE=monitor \
+  STUB_FLAG_VALUE=true \
+  STUB_TOPOLOGY_MISSING=1
+assert_eq 1 "$RUN_RC" "OCI monitor should fail closed when the shared topology marker is missing"
+assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=topology_lock' 'missing shared topology marker should fail the topology contract'
 
 run_live_betting_scenario oci-sse-heartbeat "$SCRIPT" oci MODE=monitor STUB_FLAG_VALUE=true STUB_SSE_MODE=bad-heartbeat
 assert_eq 1 "$RUN_RC" "OCI monitor should fail without SSE heartbeat"
@@ -87,4 +110,4 @@ assert_contains "$RUN_SUMMARY_FILE" 'failed_checks=mongo_workflow_parking' 'OCI 
 assert_contains "$RUN_SCENARIO_DIR/output/mongo-bet-pending-bet-update.json" '"exhausted":{"count":1,"oldestAgeSeconds":30}' 'OCI bet terminal fixture should surface exhausted counts'
 assert_contains "$RUN_SCENARIO_DIR/output/mongo-resulting-pending-moderation-result.json" '"exhausted":{"count":1,"oldestAgeSeconds":60}' 'OCI resulting pending moderation terminal fixture should surface exhausted counts'
 
-echo 'live_betting_readiness_tests=PASS stack=oci scenarios=7'
+echo 'live_betting_readiness_tests=PASS stack=oci scenarios=11'


### PR DESCRIPTION
Align production readiness with the authoritative shared-Mongo topology.

The gates now require exactly the expected shared PVC by identity in `Bound` state, reject legacy/additional Mongo PVCs, and keep lock, rollback, exact-SHA, and fail-closed checks intact. Deployment-safety guidance now resolves and revalidates the immutable remote SHA and treats historical workflow runs as active until authoritative state/exclusivity checks prove otherwise.

The complete OCI contract suite passes (13/13). Production remains dark; the previous master build is intentionally held.