### PR TITLE
Fix OCI auth-dependent startup verification

### DIFF
--- a/infra/oci/scripts/verify-images.sh
+++ b/infra/oci/scripts/verify-images.sh
@@ -152,6 +152,7 @@ if [[ "$BOOT_IMAGES" == "1" ]]; then
         -e JWT_KEY=offline-verification-only \
         -e "MONGO_URI=mongodb://mongo:27017/gaming_${service}" \
         -e RABBITMQ_URI=amqp://rabbitmq \
+        -e AUTH_SERVICE_URL=http://auth:3000 \
         -e "CLIENT_ID=oci-verification-${service}" \
         "$image_ref" >/dev/null
     fi

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -563,6 +563,8 @@ grep -Fq '.layers_size_bytes <= $max_bytes' "$registry_pruner" ||
   fail "registry pruning does not wait for bounded registry accounting"
 grep -Fq 'docker run -d --platform linux/arm64 --name "$container"' "$verify_images" ||
   fail "OCI application boot verification must run the ARM64 images"
+grep -Fq -- '-e AUTH_SERVICE_URL=http://auth:3000' "$verify_images" ||
+  fail "OCI application boot verification omits the required internal auth endpoint"
 if grep -Eq -- '--platform linux/arm64 --name "\$(mongo|rabbit)"' "$verify_images"; then
   fail "OCI build verification dependencies must use the runner native platform"
 fi


### PR DESCRIPTION
Provide the required internal `AUTH_SERVICE_URL` when boot-verifying backend ARM64 images.

The first-attempt OCI build for the superseded master SHA failed safely because the hardened backoffice service now validates this production dependency at startup. This focused fix covers the verifier contract and also carries the latest protected `master` ancestry back into `dev`. No failed build is reused or rerun.