### PR TITLE
Promote OCI startup verification fix

### DIFF
--- a/infra/oci/scripts/verify-images.sh
+++ b/infra/oci/scripts/verify-images.sh
@@ -152,6 +152,7 @@ if [[ "$BOOT_IMAGES" == "1" ]]; then
         -e JWT_KEY=offline-verification-only \
         -e "MONGO_URI=mongodb://mongo:27017/gaming_${service}" \
         -e RABBITMQ_URI=amqp://rabbitmq \
+        -e AUTH_SERVICE_URL=http://auth:3000 \
         -e "CLIENT_ID=oci-verification-${service}" \
         "$image_ref" >/dev/null
     fi

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -563,6 +563,8 @@ grep -Fq '.layers_size_bytes <= $max_bytes' "$registry_pruner" ||
   fail "registry pruning does not wait for bounded registry accounting"
 grep -Fq 'docker run -d --platform linux/arm64 --name "$container"' "$verify_images" ||
   fail "OCI application boot verification must run the ARM64 images"
+grep -Fq -- '-e AUTH_SERVICE_URL=http://auth:3000' "$verify_images" ||
+  fail "OCI application boot verification omits the required internal auth endpoint"
 if grep -Eq -- '--platform linux/arm64 --name "\$(mongo|rabbit)"' "$verify_images"; then
   fail "OCI build verification dependencies must use the runner native platform"
 fi


### PR DESCRIPTION
Promote the focused OCI ARM64 startup-verification correction.

The previous first-attempt OCI build failed safely and is not reused. A fresh master SHA will require fresh first-attempt production and OCI build provenance before any capacity, data, deployment, or activation operation.