### PR TITLE
chore: promote batch registry pruning

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -82,6 +82,13 @@ inactive. Fail closed when either query is incomplete or fails.
 - Do not deploy `latest` as the source of truth.
 - Verify every application Deployment uses the intended SHA after rollout.
 - If several commits were built, state whether an older SHA was skipped or superseded.
+- Treat a failed OCI build that published before verification as registry
+  state, not reusable release provenance. Before approving a batch prune,
+  require terminal first-attempt run bindings for every explicit target,
+  immutable artifacts for successful targets, source-tagged service rows for
+  failed targets, and exhaustive preservation of the candidate, deployed, and
+  fallback digest sets. Accept a partial target subset only as bounded
+  convergence after an interrupted prune.
 
 ## Deployment gates
 

--- a/.github/workflows/oci-infrastructure.yml
+++ b/.github/workflows/oci-infrastructure.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       phase:
-        description: Prepare/finalize zero-cost infrastructure or prune one obsolete image generation
+        description: Prepare/finalize zero-cost infrastructure or prune obsolete image generations
         required: true
         default: prepare
         type: choice
@@ -27,12 +27,17 @@ on:
         default: ""
         type: string
       obsolete_sha:
-        description: Obsolete source SHA whose complete image generation may be pruned
+        description: Legacy single obsolete source SHA
         required: false
         default: ""
         type: string
       obsolete_build_run_id:
-        description: First-attempt OCI build provenance for the obsolete generation
+        description: Legacy single-generation first-attempt OCI build run
+        required: false
+        default: ""
+        type: string
+      obsolete_generations:
+        description: JSON array of obsolete first-attempt build SHA/run pairs
         required: false
         default: ""
         type: string
@@ -78,6 +83,7 @@ jobs:
       CANDIDATE_BUILD_RUN_ID: ${{ inputs.candidate_build_run_id }}
       OBSOLETE_SHA: ${{ inputs.obsolete_sha }}
       OBSOLETE_BUILD_RUN_ID: ${{ inputs.obsolete_build_run_id }}
+      OBSOLETE_GENERATIONS: ${{ inputs.obsolete_generations }}
       DEPLOYED_SHA: ${{ inputs.deployed_sha }}
       DEPLOYED_RUN_ID: ${{ inputs.deployed_run_id }}
       FALLBACK_SHA: ${{ inputs.fallback_sha }}
@@ -132,14 +138,13 @@ jobs:
           set -euo pipefail
           [ "$GITHUB_REF_NAME" = "master" ]
           [ "$CONFIRMATION" = "PRUNE OBSOLETE OCI IMAGE GENERATION" ]
-          for sha in \
-            "$SOURCE_SHA" "$OBSOLETE_SHA" "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
+          for sha in "$SOURCE_SHA" "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
             [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
             git cat-file -e "${sha}^{commit}"
           done
           for run_id in \
-            "$CANDIDATE_BUILD_RUN_ID" "$OBSOLETE_BUILD_RUN_ID" \
-            "$DEPLOYED_RUN_ID" "$FALLBACK_BUILD_RUN_ID"; do
+            "$CANDIDATE_BUILD_RUN_ID" "$DEPLOYED_RUN_ID" \
+            "$FALLBACK_BUILD_RUN_ID"; do
             [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
           done
           [ "$GITHUB_RUN_ATTEMPT" = "1" ]
@@ -147,13 +152,56 @@ jobs:
           [ "$SOURCE_SHA" = "$(git rev-parse HEAD)" ]
           git fetch --quiet origin master:refs/remotes/origin/master
           [ "$SOURCE_SHA" = "$(git rev-parse origin/master)" ]
-          [ "$OBSOLETE_SHA" != "$SOURCE_SHA" ]
-          [ "$OBSOLETE_SHA" != "$DEPLOYED_SHA" ]
-          [ "$OBSOLETE_SHA" != "$FALLBACK_SHA" ]
+          [ "$SOURCE_SHA" != "$DEPLOYED_SHA" ]
+          [ "$SOURCE_SHA" != "$FALLBACK_SHA" ]
           [ "$DEPLOYED_SHA" != "$FALLBACK_SHA" ]
-          for ancestor in "$OBSOLETE_SHA" "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
+          for ancestor in "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
             git merge-base --is-ancestor "$ancestor" "$SOURCE_SHA"
           done
+
+          if [ -n "$OBSOLETE_GENERATIONS" ]; then
+            [ -z "$OBSOLETE_SHA" ]
+            [ -z "$OBSOLETE_BUILD_RUN_ID" ]
+            jq -ceS '
+              . as $rows
+              | select(
+                  type == "array"
+                  and length >= 1
+                  and length <= 10
+                  and all(
+                    .[];
+                    type == "object"
+                    and (keys | sort) == ["build_run_id", "sha"]
+                    and (.sha | type) == "string"
+                    and (.sha | test("^[0-9a-f]{40}$"))
+                    and (.build_run_id | type) == "string"
+                    and (.build_run_id | test("^[1-9][0-9]*$"))
+                  )
+                  and ([$rows[].sha] | unique | length) == ($rows | length)
+                  and ([$rows[].build_run_id] | unique | length) == ($rows | length)
+                )
+            ' <<<"$OBSOLETE_GENERATIONS" \
+              > "$WORK_DIR/obsolete-generations.json"
+          else
+            [[ "$OBSOLETE_SHA" =~ ^[0-9a-f]{40}$ ]]
+            [[ "$OBSOLETE_BUILD_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+            jq -cn \
+              --arg sha "$OBSOLETE_SHA" \
+              --arg build_run_id "$OBSOLETE_BUILD_RUN_ID" \
+              '[{sha: $sha, build_run_id: $build_run_id}]' \
+              > "$WORK_DIR/obsolete-generations.json"
+          fi
+
+          jq -r '.[] | [.sha, .build_run_id] | @tsv' \
+            "$WORK_DIR/obsolete-generations.json" |
+            while IFS=$'\t' read -r obsolete_sha obsolete_run_id; do
+              [[ "$obsolete_run_id" =~ ^[1-9][0-9]*$ ]]
+              git cat-file -e "${obsolete_sha}^{commit}"
+              git merge-base --is-ancestor "$obsolete_sha" "$SOURCE_SHA"
+              [ "$obsolete_sha" != "$SOURCE_SHA" ]
+              [ "$obsolete_sha" != "$DEPLOYED_SHA" ]
+              [ "$obsolete_sha" != "$FALLBACK_SHA" ]
+            done
 
       - name: Download and validate protected image provenance
         env:
@@ -166,6 +214,7 @@ jobs:
             local run_id="$2"
             local event="$3"
             local expected_sha="$4"
+            local conclusion_mode="$5"
             local workflow_id
             local run_json
             workflow_id="$(
@@ -180,7 +229,8 @@ jobs:
               --arg workflow_path ".github/workflows/$workflow_file" \
               --arg event "$event" \
               --arg sha "$expected_sha" \
-              --arg repository "$REPOSITORY" '
+              --arg repository "$REPOSITORY" \
+              --arg conclusion_mode "$conclusion_mode" '
                 .workflow_id == $workflow_id and
                 .path == $workflow_path and
                 .event == $event and
@@ -188,7 +238,13 @@ jobs:
                 .head_branch == "master" and
                 .head_repository.full_name == $repository and
                 .status == "completed" and
-                .conclusion == "success" and
+                (
+                  if $conclusion_mode == "success" then
+                    .conclusion == "success"
+                  else
+                    (.conclusion == "success" or .conclusion == "failure")
+                  end
+                ) and
                 .run_attempt == 1
               ' <<<"$run_json" >/dev/null
           }
@@ -213,25 +269,18 @@ jobs:
 
           validate_run \
             oci-production-build.yml \
-            "$CANDIDATE_BUILD_RUN_ID" workflow_run "$SOURCE_SHA"
-          validate_run \
-            oci-production-build.yml \
-            "$OBSOLETE_BUILD_RUN_ID" workflow_run "$OBSOLETE_SHA"
+            "$CANDIDATE_BUILD_RUN_ID" workflow_run "$SOURCE_SHA" success
           validate_run \
             oci-production-deploy.yml \
-            "$DEPLOYED_RUN_ID" workflow_dispatch "$DEPLOYED_SHA"
+            "$DEPLOYED_RUN_ID" workflow_dispatch "$DEPLOYED_SHA" success
           validate_run \
             oci-production-build.yml \
-            "$FALLBACK_BUILD_RUN_ID" workflow_run "$FALLBACK_SHA"
+            "$FALLBACK_BUILD_RUN_ID" workflow_run "$FALLBACK_SHA" success
 
           download_artifact \
             "$CANDIDATE_BUILD_RUN_ID" \
             "oci-image-provenance-${SOURCE_SHA}-${CANDIDATE_BUILD_RUN_ID}-1" \
             "$WORK_DIR/candidate"
-          download_artifact \
-            "$OBSOLETE_BUILD_RUN_ID" \
-            "oci-image-provenance-${OBSOLETE_SHA}-${OBSOLETE_BUILD_RUN_ID}-1" \
-            "$WORK_DIR/obsolete"
           download_artifact \
             "$DEPLOYED_RUN_ID" \
             "oci-deploy-provenance-${DEPLOYED_RUN_ID}-1" \
@@ -243,7 +292,6 @@ jobs:
 
           for pair in \
             "candidate:$SOURCE_SHA:$CANDIDATE_BUILD_RUN_ID" \
-            "obsolete:$OBSOLETE_SHA:$OBSOLETE_BUILD_RUN_ID" \
             "fallback:$FALLBACK_SHA:$FALLBACK_BUILD_RUN_ID"; do
             IFS=: read -r directory expected_sha expected_run_id <<<"$pair"
             grep -Fxq "source_sha=$expected_sha" \
@@ -254,18 +302,72 @@ jobs:
               "$WORK_DIR/$directory/build-chain.txt"
             test -s "$WORK_DIR/$directory/images.tsv"
           done
-          for pair in "deployed:$DEPLOYED_SHA:$DEPLOYED_RUN_ID"; do
-            IFS=: read -r directory expected_sha expected_run_id <<<"$pair"
-            grep -Fxq "source_sha=$expected_sha" \
-              "$WORK_DIR/$directory/provenance.txt"
-            grep -Fxq "deployment_run_id=$expected_run_id" \
-              "$WORK_DIR/$directory/provenance.txt"
-            grep -Fxq "deployment_run_attempt=1" \
-              "$WORK_DIR/$directory/provenance.txt"
-            test -s "$WORK_DIR/$directory/images.tsv"
-          done
+          grep -Fxq "source_sha=$DEPLOYED_SHA" \
+            "$WORK_DIR/deployed/provenance.txt"
+          grep -Fxq "deployment_run_id=$DEPLOYED_RUN_ID" \
+            "$WORK_DIR/deployed/provenance.txt"
+          grep -Fxq "deployment_run_attempt=1" \
+            "$WORK_DIR/deployed/provenance.txt"
+          test -s "$WORK_DIR/deployed/images.tsv"
 
-          cp "$WORK_DIR/obsolete/images.tsv" "$PROVENANCE_DIR/obsolete.tsv"
+          : > "$PROVENANCE_DIR/target-source-shas.txt"
+          : > "$PROVENANCE_DIR/trusted-target-images.tsv"
+          : > "$PROVENANCE_DIR/obsolete-runs.tsv"
+          while IFS=$'\t' read -r obsolete_sha obsolete_run_id; do
+            validate_run \
+              oci-production-build.yml \
+              "$obsolete_run_id" workflow_run "$obsolete_sha" terminal
+            obsolete_conclusion="$(
+              gh api \
+                "repos/$REPOSITORY/actions/runs/$obsolete_run_id/attempts/1" \
+                --jq '.conclusion'
+            )"
+            artifact_name="oci-image-provenance-${obsolete_sha}-${obsolete_run_id}-1"
+            artifact_count="$(
+              gh api \
+                "repos/$REPOSITORY/actions/runs/$obsolete_run_id/artifacts?per_page=100" \
+                --jq "[.artifacts[] | select(
+                  .name == \"$artifact_name\" and .expired == false
+                )] | length"
+            )"
+            if [ "$obsolete_conclusion" = "success" ]; then
+              [ "$artifact_count" = "1" ]
+            else
+              [ "$obsolete_conclusion" = "failure" ]
+              [ "$artifact_count" = "0" ] || [ "$artifact_count" = "1" ]
+            fi
+
+            artifact_status=absent
+            if [ "$artifact_count" = "1" ]; then
+              destination="$WORK_DIR/obsolete-$obsolete_sha"
+              download_artifact \
+                "$obsolete_run_id" "$artifact_name" "$destination"
+              grep -Fxq "source_sha=$obsolete_sha" \
+                "$destination/build-chain.txt"
+              grep -Fxq "build_run_id=$obsolete_run_id" \
+                "$destination/build-chain.txt"
+              grep -Fxq "build_run_attempt=1" \
+                "$destination/build-chain.txt"
+              test -s "$destination/images.tsv"
+              awk -F '\t' -v sha="$obsolete_sha" '
+                BEGIN { OFS = "\t" }
+                NF != 5 { exit 1 }
+                { print sha, $0 }
+              ' "$destination/images.tsv" \
+                >> "$PROVENANCE_DIR/trusted-target-images.tsv"
+              artifact_status=verified
+            fi
+            printf '%s\t%s\t%s\t%s\n' \
+              "$obsolete_sha" "$obsolete_run_id" \
+              "$obsolete_conclusion" "$artifact_status" \
+              >> "$PROVENANCE_DIR/obsolete-runs.tsv"
+            printf '%s\n' "$obsolete_sha" \
+              >> "$PROVENANCE_DIR/target-source-shas.txt"
+          done < <(
+            jq -r '.[] | [.sha, .build_run_id] | @tsv' \
+              "$WORK_DIR/obsolete-generations.json"
+          )
+
           cat \
             "$WORK_DIR/candidate/images.tsv" \
             "$WORK_DIR/deployed/images.tsv" \
@@ -298,9 +400,9 @@ jobs:
           OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
           OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
           OCI_CLI_REGION: ${{ vars.OCI_REGION }}
-          TARGET_IMAGES_FILE: artifacts/oci-registry-prune/obsolete.tsv
+          TARGET_SOURCE_SHAS_FILE: artifacts/oci-registry-prune/target-source-shas.txt
+          TRUSTED_TARGET_IMAGES_FILE: artifacts/oci-registry-prune/trusted-target-images.tsv
           PROTECTED_IMAGES_FILE: artifacts/oci-registry-prune/protected.tsv
-          TARGET_SOURCE_SHA: ${{ inputs.obsolete_sha }}
           CURRENT_SOURCE_SHA: ${{ inputs.approved_sha }}
           OUTPUT_DIR: artifacts/oci-registry-prune
         run: ./infra/oci/scripts/prune-registry-generation.sh
@@ -309,10 +411,14 @@ jobs:
         run: |
           set -euo pipefail
           test -s "$PROVENANCE_DIR/after-summary.json"
+          expected_targets="$(
+            jq -c '[.[].sha] | sort' \
+              "$WORK_DIR/obsolete-generations.json"
+          )"
           jq -e \
-            --arg obsolete_sha "$OBSOLETE_SHA" \
+            --argjson expected_targets "$expected_targets" \
             --arg source_sha "$SOURCE_SHA" '
-              .target_source_sha == $obsolete_sha and
+              .target_source_shas == $expected_targets and
               .current_source_sha == $source_sha and
               .terminal_status == "PRUNED" and
               .unique_images == 27
@@ -322,6 +428,8 @@ jobs:
             "candidate_build_run_id=$CANDIDATE_BUILD_RUN_ID" \
             "obsolete_sha=$OBSOLETE_SHA" \
             "obsolete_build_run_id=$OBSOLETE_BUILD_RUN_ID" \
+            "obsolete_generation_count=$(jq 'length' "$WORK_DIR/obsolete-generations.json")" \
+            "obsolete_generations_sha256=$(sha256sum "$WORK_DIR/obsolete-generations.json" | awk '{print $1}')" \
             "deployed_sha=$DEPLOYED_SHA" \
             "deployed_run_id=$DEPLOYED_RUN_ID" \
             "fallback_sha=$FALLBACK_SHA" \

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -54,6 +54,13 @@ conversation summaries are not authority.
 - OCI deletion and registry layer reclamation are asynchronous. Wait for
   terminal provider state and accounting instead of assuming a successful
   delete response completed the operation.
+- A build that fails after publishing can leave a complete source-tagged image
+  generation without a provenance artifact. Before pruning accumulated
+  generations, protect the exact candidate, deployed, and fallback digest
+  sets; bind every target to a terminal first-attempt build; and prove that
+  protected plus target rows exhaust the registry before deleting the whole
+  explicit batch. Permit partial target subsets only so an interrupted prune
+  can safely converge.
 - Normalize documented case-insensitive provider enums before comparing them.
   OCI has returned values such as `paravirtualized` in lowercase.
 - A healthy load-balancer control plane does not prove a healthy data plane.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -156,15 +156,20 @@ concurrent retirement fixture isolation without masking failed suites.
 2. `scripts/build-images.sh` builds ARM64 OCI-only images; the production
    workflow records and verifies immutable digests with
    `scripts/verify-images.sh`.
-   If a fresh build creates a fourth complete generation, dispatch
+   If fresh or failed builds leave more than three complete generations,
+   dispatch
    `oci-infrastructure` with phase `prune-registry` before infrastructure
    finalization. Bind the request to the exact current candidate build, the
-   currently deployed release, one compatible fallback build, and one
-   obsolete build. The protected job deletes only when those four
-   nine-service generations are pairwise disjoint and exhaust the registry;
-   it waits until the obsolete digests are absent, all 27 protected digests
-   remain, provider image accounting reaches 27, and retained layers are
-   within the configured Free Tier ceiling.
+   currently deployed release, one compatible fallback build, and a bounded
+   JSON list of explicit obsolete SHA/run pairs. Successful obsolete builds
+   are cross-checked against their immutable artifacts; failed first-attempt
+   builds are eligible only for their source-tagged service rows. The
+   protected job also accepts an explicit target subset left by an interrupted
+   prior deletion, but deletes nothing
+   unless the protected and target sets are pairwise disjoint and exhaust
+   every registry row. It waits until all target digests are absent, all 27
+   protected digests remain, provider image accounting reaches 27, and
+   retained layers are within the configured Free Tier ceiling.
 3. Dispatch `oci-infrastructure` with phase `prepare`.
    `scripts/provision.sh cloud` creates/reconciles only the VCN, Internet
    Gateway, public/restricted subnets, NSGs, and OCI Bastion.

--- a/infra/oci/scripts/prune-registry-generation.sh
+++ b/infra/oci/scripts/prune-registry-generation.sh
@@ -5,17 +5,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
-TARGET_IMAGES_FILE="${TARGET_IMAGES_FILE:-}"
+TARGET_SOURCE_SHAS_FILE="${TARGET_SOURCE_SHAS_FILE:-}"
+TRUSTED_TARGET_IMAGES_FILE="${TRUSTED_TARGET_IMAGES_FILE:-}"
 PROTECTED_IMAGES_FILE="${PROTECTED_IMAGES_FILE:-}"
-TARGET_SOURCE_SHA="${TARGET_SOURCE_SHA:-}"
 CURRENT_SOURCE_SHA="${CURRENT_SOURCE_SHA:-}"
 OUTPUT_DIR="${OUTPUT_DIR:-artifacts/oci-registry-prune}"
 PRUNE_POLL_ATTEMPTS="${PRUNE_POLL_ATTEMPTS:-60}"
 PRUNE_POLL_SECONDS="${PRUNE_POLL_SECONDS:-10}"
 EXPECTED_SERVICES='auth backoffice bet client event gamemaster moderation resulting slip'
-EXPECTED_TARGET_IMAGES=9
 EXPECTED_PROTECTED_IMAGES=27
-EXPECTED_IMAGES_BEFORE=36
+MAX_TARGET_GENERATIONS=10
 
 oci_require_cli_version
 oci_require_command jq
@@ -23,20 +22,18 @@ oci_require_vars \
   OCI_COMPARTMENT_OCID OCI_IMAGE_PREFIX OCI_REGISTRY_MAX_BYTES
 oci_require_ocid OCI_COMPARTMENT_OCID
 
-[[ "$TARGET_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
-  oci_die "TARGET_SOURCE_SHA must be a full commit SHA"
 [[ "$CURRENT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
   oci_die "CURRENT_SOURCE_SHA must be a full commit SHA"
-[[ "$TARGET_SOURCE_SHA" != "$CURRENT_SOURCE_SHA" ]] ||
-  oci_die "current master cannot be pruned"
 [[ "$PRUNE_POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] ||
   oci_die "PRUNE_POLL_ATTEMPTS must be a positive integer"
 [[ "$PRUNE_POLL_SECONDS" =~ ^[0-9]+$ ]] ||
   oci_die "PRUNE_POLL_SECONDS must be a nonnegative integer"
 [[ "$OCI_REGISTRY_MAX_BYTES" =~ ^[1-9][0-9]*$ ]] ||
   oci_die "OCI_REGISTRY_MAX_BYTES must be a positive integer"
-[[ -f "$TARGET_IMAGES_FILE" ]] ||
-  oci_die "TARGET_IMAGES_FILE does not exist"
+[[ -f "$TARGET_SOURCE_SHAS_FILE" ]] ||
+  oci_die "TARGET_SOURCE_SHAS_FILE does not exist"
+[[ -f "$TRUSTED_TARGET_IMAGES_FILE" ]] ||
+  oci_die "TRUSTED_TARGET_IMAGES_FILE does not exist"
 [[ -f "$PROTECTED_IMAGES_FILE" ]] ||
   oci_die "PROTECTED_IMAGES_FILE does not exist"
 
@@ -46,6 +43,29 @@ cleanup() {
   rm -rf "$work_dir"
 }
 trap cleanup EXIT
+
+normalize_target_sources() {
+  awk -v current_sha="$CURRENT_SOURCE_SHA" '
+    function valid_sha(value) {
+      return length(value) == 40 && value ~ /^[0-9a-f]+$/
+    }
+    NF != 1 || !valid_sha($1) || $1 == current_sha || seen[$1]++ {
+      exit 1
+    }
+    {
+      print $1
+    }
+  ' "$TARGET_SOURCE_SHAS_FILE" | LC_ALL=C sort \
+    > "$work_dir/target-source-shas.txt" ||
+    oci_die "target source SHA validation failed"
+}
+
+normalize_target_sources
+target_generation_count="$(
+  wc -l < "$work_dir/target-source-shas.txt" | tr -d ' '
+)"
+((target_generation_count >= 1 && target_generation_count <= MAX_TARGET_GENERATIONS)) ||
+  oci_die "target generation count must be between 1 and $MAX_TARGET_GENERATIONS"
 
 repository="${OCI_IMAGE_PREFIX}_images"
 
@@ -78,19 +98,12 @@ read_provenance_repository() {
 }
 
 provenance_repository="$(
-  read_provenance_repository "$TARGET_IMAGES_FILE"
-)" || oci_die "target provenance does not identify one exact registry repository"
+  read_provenance_repository "$PROTECTED_IMAGES_FILE"
+)" || oci_die "protected provenance does not identify one exact registry repository"
 
-normalize_provenance() {
-  local source_file="$1"
-  local destination_file="$2"
-  local expected_rows="$3"
-  local expected_per_service="$4"
-
+normalize_protected_provenance() {
   awk -F '\t' \
     -v repository="$provenance_repository" \
-    -v expected_rows="$expected_rows" \
-    -v expected_per_service="$expected_per_service" \
     -v expected_services="$EXPECTED_SERVICES" '
       BEGIN {
         split(expected_services, services, " ")
@@ -103,20 +116,8 @@ normalize_provenance() {
           substr(value, 1, 7) == "sha256:" &&
           substr(value, 8) ~ /^[0-9a-f]+$/
       }
-      NF != 5 {
-        print "invalid image provenance column count" > "/dev/stderr"
-        exit 1
-      }
-      !($1 in allowed) {
-        print "unexpected image provenance service: " $1 > "/dev/stderr"
-        exit 1
-      }
-      $2 != repository {
-        print "unexpected image provenance repository" > "/dev/stderr"
-        exit 1
-      }
-      $3 != $2 "@" $4 || $4 != $5 || !valid_digest($4) {
-        print "invalid image provenance digest identity" > "/dev/stderr"
+      NF != 5 || !($1 in allowed) || $2 != repository ||
+        $3 != $2 "@" $4 || $4 != $5 || !valid_digest($4) {
         exit 1
       }
       {
@@ -126,46 +127,81 @@ normalize_provenance() {
         print $1 "\t" $4
       }
       END {
-        if (rows != expected_rows) {
-          print "unexpected image provenance row count" > "/dev/stderr"
+        if (rows != 27) {
           exit 1
         }
         for (service in allowed) {
-          if (service_count[service] != expected_per_service) {
-            print "incomplete image provenance service set" > "/dev/stderr"
+          if (service_count[service] != 3) {
             exit 1
           }
         }
         for (digest in digest_count) {
           if (digest_count[digest] != 1) {
-            print "duplicate image provenance digest" > "/dev/stderr"
             exit 1
           }
         }
       }
-    ' "$source_file" | LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
-      > "$destination_file" ||
-    oci_die "image provenance validation failed"
+    ' "$PROTECTED_IMAGES_FILE" |
+    LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
+      > "$work_dir/protected.tsv" ||
+    oci_die "protected image provenance validation failed"
 }
 
-normalize_provenance \
-  "$TARGET_IMAGES_FILE" "$work_dir/target.tsv" \
-  "$EXPECTED_TARGET_IMAGES" 1
-normalize_provenance \
-  "$PROTECTED_IMAGES_FILE" "$work_dir/protected.tsv" \
-  "$EXPECTED_PROTECTED_IMAGES" 3
+normalize_trusted_target_provenance() {
+  awk -F '\t' \
+    -v repository="$provenance_repository" \
+    -v target_file="$work_dir/target-source-shas.txt" \
+    -v expected_services="$EXPECTED_SERVICES" '
+      BEGIN {
+        while ((getline source < target_file) > 0) {
+          targets[source] = 1
+        }
+        close(target_file)
+        split(expected_services, services, " ")
+        for (service_index in services) {
+          allowed[services[service_index]] = 1
+        }
+      }
+      function valid_digest(value) {
+        return length(value) == 71 &&
+          substr(value, 1, 7) == "sha256:" &&
+          substr(value, 8) ~ /^[0-9a-f]+$/
+      }
+      NF != 6 || !($1 in targets) || !($2 in allowed) ||
+        $3 != repository || $4 != $3 "@" $5 || $5 != $6 ||
+        !valid_digest($5) || seen[$1 SUBSEP $2]++ || digest_seen[$5]++ {
+        exit 1
+      }
+      {
+        source_count[$1]++
+        print $1 "\t" $2 "\t" $5
+      }
+      END {
+        for (source in source_count) {
+          if (source_count[source] != 9) {
+            exit 1
+          }
+          for (service in allowed) {
+            if (!seen[source SUBSEP service]) {
+              exit 1
+            }
+          }
+        }
+      }
+    ' "$TRUSTED_TARGET_IMAGES_FILE" |
+    LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
+      > "$work_dir/trusted-targets.tsv" ||
+    oci_die "trusted target image provenance validation failed"
+}
 
-cut -f2 "$work_dir/target.tsv" | LC_ALL=C sort -u > "$work_dir/target-digests.txt"
-cut -f2 "$work_dir/protected.tsv" | LC_ALL=C sort -u > "$work_dir/protected-digests.txt"
-if comm -12 "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
-    grep -q .; then
-  oci_die "obsolete generation overlaps a protected generation"
-fi
-cat "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
-  LC_ALL=C sort -u > "$work_dir/expected-before-digests.txt"
-[[ "$(wc -l < "$work_dir/expected-before-digests.txt" | tr -d ' ')" == \
-  "$EXPECTED_IMAGES_BEFORE" ]] ||
-  oci_die "expected registry generations are not pairwise disjoint"
+normalize_protected_provenance
+normalize_trusted_target_provenance
+
+cut -f2 "$work_dir/protected.tsv" |
+  LC_ALL=C sort -u > "$work_dir/protected-digests.txt"
+[[ "$(wc -l < "$work_dir/protected-digests.txt" | tr -d ' ')" == \
+  "$EXPECTED_PROTECTED_IMAGES" ]] ||
+  oci_die "protected image provenance is not digest-unique"
 
 list_images() {
   local destination="$1"
@@ -239,6 +275,31 @@ registry_digest_set() {
   ' "$inventory_file" | LC_ALL=C sort -u > "$destination"
 }
 
+registry_service_digest_set() {
+  local inventory_file="$1"
+  local destination="$2"
+
+  jq -r '
+    def parsed_tag:
+      (.version // "")
+      | try capture(
+          "^oci-(?<service>auth|backoffice|bet|client|event|gamemaster|moderation|resulting|slip)-(?<source_sha>[0-9a-f]{40})$"
+        ) catch null;
+    .data.items[]?
+    | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+    | parsed_tag as $tag
+    | [$tag.service, .digest]
+    | @tsv
+  ' "$inventory_file" | LC_ALL=C sort -u > "$destination"
+}
+
+active_registry_row_count() {
+  jq -r '[
+    .data.items[]?
+    | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+  ] | length' "$1"
+}
+
 registry_accounting() {
   local destination="$1"
   local raw="$work_dir/repositories-raw.json"
@@ -280,72 +341,159 @@ registry_accounting() {
 
 list_images "$work_dir/before.json"
 validate_registry_rows "$work_dir/before.json" AVAILABLE
+
+jq -r \
+  --rawfile target_sources "$work_dir/target-source-shas.txt" '
+    def parsed_tag:
+      (.version // "")
+      | try capture(
+          "^oci-(?<service>auth|backoffice|bet|client|event|gamemaster|moderation|resulting|slip)-(?<source_sha>[0-9a-f]{40})$"
+        ) catch null;
+    ($target_sources | split("\n") | map(select(length > 0))) as $targets
+    | .data.items[]?
+    | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+    | parsed_tag as $tag
+    | select($tag != null and ($targets | index($tag.source_sha)) != null)
+    | [$tag.source_sha, $tag.service, .digest, .id]
+    | @tsv
+  ' "$work_dir/before.json" |
+  awk -F '\t' \
+    -v target_file="$work_dir/target-source-shas.txt" \
+    -v expected_services="$EXPECTED_SERVICES" '
+      BEGIN {
+        while ((getline source < target_file) > 0) {
+          targets[source] = 1
+        }
+        close(target_file)
+        split(expected_services, services, " ")
+        for (service_index in services) {
+          allowed[services[service_index]] = 1
+        }
+      }
+      NF != 4 || !($1 in targets) || !($2 in allowed) ||
+        seen_service[$1 SUBSEP $2]++ || seen_digest[$3]++ ||
+        seen_image_id[$4]++ {
+        exit 1
+      }
+      {
+        source_count[$1]++
+        print
+      }
+      END {
+        for (source in targets) {
+          if (source_count[source] > 9) {
+            exit 1
+          }
+        }
+      }
+    ' |
+  LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
+    > "$work_dir/target-registry.tsv" ||
+  oci_die "target registry rows are ambiguous or exceed one service set"
+
+cut -f1 "$work_dir/target-registry.tsv" |
+  LC_ALL=C sort -u > "$work_dir/present-target-sources.txt"
+present_target_generation_count="$(
+  wc -l < "$work_dir/present-target-sources.txt" | tr -d ' '
+)"
+present_target_image_count="$(
+  wc -l < "$work_dir/target-registry.tsv" | tr -d ' '
+)"
+cut -f1 "$work_dir/trusted-targets.tsv" |
+  LC_ALL=C sort -u > "$work_dir/trusted-target-sources.txt"
+
+while IFS=$'\t' read -r source service digest _image_id; do
+  if grep -Fxq "$source" "$work_dir/trusted-target-sources.txt"; then
+    expected_row="${source}"$'\t'"${service}"$'\t'"${digest}"
+    grep -Fqx "$expected_row" "$work_dir/trusted-targets.tsv" ||
+      oci_die "registry target differs from trusted successful-build provenance"
+  fi
+done < "$work_dir/target-registry.tsv"
+
+cut -f3 "$work_dir/target-registry.tsv" |
+  LC_ALL=C sort -u > "$work_dir/target-digests.txt"
+if comm -12 "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
+    grep -q .; then
+  oci_die "obsolete generations overlap a protected generation"
+fi
+
+cat "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
+  LC_ALL=C sort -u > "$work_dir/expected-before-digests.txt"
+expected_images_before="$(
+  wc -l < "$work_dir/expected-before-digests.txt" | tr -d ' '
+)"
+[[ "$expected_images_before" == \
+  "$((EXPECTED_PROTECTED_IMAGES + present_target_image_count))" ]] ||
+  oci_die "expected registry generations are not pairwise disjoint"
+
+{
+  cut -f2,3 "$work_dir/target-registry.tsv"
+  cat "$work_dir/protected.tsv"
+} | LC_ALL=C sort -u > "$work_dir/expected-service-digests.tsv"
+
 registry_digest_set "$work_dir/before.json" "$work_dir/before-digests.txt"
-deletion_required=true
-if cmp -s "$work_dir/expected-before-digests.txt" "$work_dir/before-digests.txt"; then
-  before_image_count="$EXPECTED_IMAGES_BEFORE"
-elif cmp -s "$work_dir/protected-digests.txt" "$work_dir/before-digests.txt"; then
-  deletion_required=false
-  before_image_count="$EXPECTED_PROTECTED_IMAGES"
-else
+registry_service_digest_set \
+  "$work_dir/before.json" "$work_dir/before-service-digests.tsv"
+[[ "$(active_registry_row_count "$work_dir/before.json")" == \
+  "$expected_images_before" ]] ||
+  oci_die "registry contains duplicate or aliased image rows"
+cmp -s \
+  "$work_dir/expected-before-digests.txt" "$work_dir/before-digests.txt" ||
   oci_die "registry contains an unknown, missing, or unexpected image generation"
+cmp -s \
+  "$work_dir/expected-service-digests.tsv" "$work_dir/before-service-digests.tsv" ||
+  oci_die "registry service and digest mappings differ from trusted provenance"
+
+deletion_required=true
+if [[ "$present_target_generation_count" == "0" ]]; then
+  deletion_required=false
 fi
 
 : > "$OUTPUT_DIR/deletion-plan.tsv"
 if [[ "$deletion_required" == "true" ]]; then
-  while IFS=$'\t' read -r service digest; do
-    version="oci-${service}-${TARGET_SOURCE_SHA}"
-    image_ids="$(
-      jq -r \
-        --arg digest "$digest" \
-        --arg version "$version" '
-          [
-            .data.items[]?
-            | select(
-                .digest == $digest and
-                .version == $version and
-                (."lifecycle-state" // "" | ascii_upcase) == "AVAILABLE"
-              )
-            | .id
-          ]
-          | unique[]
-        ' "$work_dir/before.json"
-    )"
-    [[ "$(awk 'NF {count++} END {print count+0}' <<<"$image_ids")" == "1" ]] ||
-      oci_die "target digest does not map to one exact source-tagged image"
-    image_id="$(awk 'NF {print; exit}' <<<"$image_ids")"
-    printf '%s\t%s\t%s\n' "$service" "$digest" "$image_id" \
-      >> "$OUTPUT_DIR/deletion-plan.tsv"
-  done < "$work_dir/target.tsv"
-
+  cp "$work_dir/target-registry.tsv" "$OUTPUT_DIR/deletion-plan.tsv"
+  expected_target_images="$present_target_image_count"
   [[ "$(wc -l < "$OUTPUT_DIR/deletion-plan.tsv" | tr -d ' ')" == \
-    "$EXPECTED_TARGET_IMAGES" ]] ||
+    "$expected_target_images" ]] ||
     oci_die "registry deletion plan is incomplete"
-  [[ "$(cut -f3 "$OUTPUT_DIR/deletion-plan.tsv" | LC_ALL=C sort -u | wc -l |
-    tr -d ' ')" == "$EXPECTED_TARGET_IMAGES" ]] ||
+  [[ "$(cut -f4 "$OUTPUT_DIR/deletion-plan.tsv" | LC_ALL=C sort -u | wc -l |
+    tr -d ' ')" == "$expected_target_images" ]] ||
     oci_die "registry deletion plan reuses an image OCID"
 fi
 
-target_sha256="$(oci_sha256 < "$work_dir/target.tsv")"
+target_sources_json="$(
+  jq -Rsc 'split("\n") | map(select(length > 0))' \
+    "$work_dir/target-source-shas.txt"
+)"
+target_sources_sha256="$(oci_sha256 < "$work_dir/target-source-shas.txt")"
+target_images_sha256="$(oci_sha256 < "$work_dir/target-registry.tsv")"
 protected_sha256="$(oci_sha256 < "$work_dir/protected.tsv")"
 jq -n \
-  --arg target_source_sha "$TARGET_SOURCE_SHA" \
+  --argjson target_source_shas "$target_sources_json" \
   --arg current_source_sha "$CURRENT_SOURCE_SHA" \
-  --arg target_sha256 "$target_sha256" \
+  --arg target_sources_sha256 "$target_sources_sha256" \
+  --arg target_images_sha256 "$target_images_sha256" \
   --arg protected_sha256 "$protected_sha256" \
   --arg deletion_required "$deletion_required" \
-  --argjson unique_images "$before_image_count" \
+  --argjson requested_target_generations "$target_generation_count" \
+  --argjson present_target_generations "$present_target_generation_count" \
+  --argjson present_target_images "$present_target_image_count" \
+  --argjson unique_images "$expected_images_before" \
   '{
-    target_source_sha: $target_source_sha,
+    target_source_shas: $target_source_shas,
     current_source_sha: $current_source_sha,
-    target_generation_sha256: $target_sha256,
+    target_sources_sha256: $target_sources_sha256,
+    target_images_sha256: $target_images_sha256,
     protected_generations_sha256: $protected_sha256,
+    requested_target_generations: $requested_target_generations,
+    present_target_generations: $present_target_generations,
+    present_target_images: $present_target_images,
     unique_images: $unique_images,
     deletion_required: ($deletion_required == "true")
   }' > "$OUTPUT_DIR/before-summary.json"
 
 if [[ "$deletion_required" == "true" ]]; then
-  while IFS=$'\t' read -r _service _digest image_id; do
+  while IFS=$'\t' read -r _source _service _digest image_id; do
     oci artifacts container image delete \
       --image-id "$image_id" \
       --force >/dev/null
@@ -385,24 +533,35 @@ done
   oci_die "OCI registry pruning did not reach the exact protected digest set"
 
 validate_registry_rows "$work_dir/after.json" AVAILABLE
+[[ "$(active_registry_row_count "$work_dir/after.json")" == \
+  "$EXPECTED_PROTECTED_IMAGES" ]] ||
+  oci_die "OCI registry retained duplicate or aliased image rows"
+registry_service_digest_set \
+  "$work_dir/after.json" "$work_dir/after-service-digests.tsv"
+cmp -s "$work_dir/protected.tsv" "$work_dir/after-service-digests.tsv" ||
+  oci_die "OCI registry retained an unexpected service or digest mapping"
 if comm -12 "$work_dir/target-digests.txt" "$work_dir/after-digests.txt" |
     grep -q .; then
   oci_die "obsolete registry digests remain after pruning"
 fi
 
-cp "$work_dir/target.tsv" "$OUTPUT_DIR/deleted-images.tsv"
+cp "$work_dir/target-registry.tsv" "$OUTPUT_DIR/deleted-images.tsv"
 jq -e . "$work_dir/accounting.json" > "$OUTPUT_DIR/registry-accounting.json"
 jq -n \
-  --arg target_source_sha "$TARGET_SOURCE_SHA" \
+  --argjson target_source_shas "$target_sources_json" \
   --arg current_source_sha "$CURRENT_SOURCE_SHA" \
   --arg protected_sha256 "$protected_sha256" \
+  --argjson requested_target_generations "$target_generation_count" \
+  --argjson pruned_target_generations "$present_target_generation_count" \
   --argjson unique_images "$EXPECTED_PROTECTED_IMAGES" \
   '{
-    target_source_sha: $target_source_sha,
+    target_source_shas: $target_source_shas,
     current_source_sha: $current_source_sha,
     protected_generations_sha256: $protected_sha256,
+    requested_target_generations: $requested_target_generations,
+    pruned_target_generations: $pruned_target_generations,
     unique_images: $unique_images,
     terminal_status: "PRUNED"
   }' > "$OUTPUT_DIR/after-summary.json"
 
-echo "registry_generation_pruned=$TARGET_SOURCE_SHA"
+echo "registry_generations_pruned=$(paste -sd, "$work_dir/target-source-shas.txt")"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -545,17 +545,21 @@ grep -Fq 'incomplete_tag_generation_count' "$inventory" ||
   fail "OCI inventory must reject incomplete service tag generations"
 grep -Fq 'digest_service_conflict_count' "$inventory" ||
   fail "OCI inventory must reject cross-service digest identities"
-grep -Fq 'EXPECTED_IMAGES_BEFORE=36' "$registry_pruner" ||
-  fail "registry pruning must require exactly four complete generations"
+grep -Fq 'MAX_TARGET_GENERATIONS=10' "$registry_pruner" ||
+  fail "registry pruning must bound the explicit obsolete generation set"
 grep -Fq 'EXPECTED_PROTECTED_IMAGES=27' "$registry_pruner" ||
   fail "registry pruning must retain exactly three complete generations"
-grep -Fq 'obsolete generation overlaps a protected generation' "$registry_pruner" ||
+grep -Fq 'obsolete generations overlap a protected generation' "$registry_pruner" ||
   fail "registry pruning does not reject protected digest overlap"
 grep -Fq 'registry contains an unknown, missing, or unexpected image generation' \
   "$registry_pruner" ||
   fail "registry pruning does not fail closed on unknown images"
-grep -Fq 'read_provenance_repository "$TARGET_IMAGES_FILE"' "$registry_pruner" ||
-  fail "registry pruning does not derive one exact provenance repository"
+grep -Fq 'read_provenance_repository "$PROTECTED_IMAGES_FILE"' "$registry_pruner" ||
+  fail "registry pruning does not derive one exact protected repository"
+grep -Fq 'TRUSTED_TARGET_IMAGES_FILE' "$registry_pruner" ||
+  fail "registry pruning does not cross-check successful obsolete builds"
+grep -Fq 'registry contains duplicate or aliased image rows' "$registry_pruner" ||
+  fail "registry pruning does not reject unaccounted image aliases"
 grep -Fq 'OCI registry pruning did not reach the exact protected digest set' \
   "$registry_pruner" ||
   fail "registry pruning does not wait for asynchronous deletion"
@@ -750,8 +754,14 @@ grep -Fq 'PROVISION OCI ZERO COST' "$infra_workflow"
 grep -Fq -- '- prune-registry' "$infra_workflow"
 grep -Fq 'PRUNE OBSOLETE OCI IMAGE GENERATION' "$infra_workflow"
 grep -Fq 'prune-registry-generation.sh' "$infra_workflow"
-grep -Fq 'oci-image-provenance-${OBSOLETE_SHA}-${OBSOLETE_BUILD_RUN_ID}-1' \
+grep -Fq 'obsolete_generations:' "$infra_workflow"
+grep -Fq 'length <= 10' "$infra_workflow"
+grep -Fq '(.conclusion == "success" or .conclusion == "failure")' \
   "$infra_workflow"
+grep -Fq 'oci-image-provenance-${obsolete_sha}-${obsolete_run_id}-1' \
+  "$infra_workflow"
+grep -Fq 'target-source-shas.txt' "$infra_workflow"
+grep -Fq 'trusted-target-images.tsv' "$infra_workflow"
 grep -Fq 'oci-image-provenance-${FALLBACK_SHA}-${FALLBACK_BUILD_RUN_ID}-1' \
   "$infra_workflow"
 grep -Fq 'oci-deploy-provenance-${DEPLOYED_RUN_ID}-1' "$infra_workflow"

--- a/infra/oci/tests/test-registry-prune-contract.sh
+++ b/infra/oci/tests/test-registry-prune-contract.sh
@@ -5,10 +5,12 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 OCI_DIR="$ROOT_DIR/infra/oci"
 WORK_DIR="$OCI_DIR/tests/.registry-prune-work"
 SERVICES=(auth backoffice bet client event gamemaster moderation resulting slip)
-TARGET_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+TARGET_ONE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 DEPLOYED_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 ROLLBACK_SHA="cccccccccccccccccccccccccccccccccccccccc"
 CURRENT_SHA="dddddddddddddddddddddddddddddddddddddddd"
+TARGET_TWO_SHA="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+FAILED_TARGET_SHA="ffffffffffffffffffffffffffffffffffffffff"
 REPOSITORY="fra.ocir.io/example/betstan_images"
 
 fail() {
@@ -27,9 +29,8 @@ digest_for() {
 }
 
 write_generation() {
-  local source_sha="$1"
-  local generation="$2"
-  local output_file="$3"
+  local generation="$1"
+  local output_file="$2"
   local service_index service digest
 
   : > "$output_file"
@@ -42,21 +43,38 @@ write_generation() {
   done
 }
 
-write_generation "$TARGET_SHA" 0 "$WORK_DIR/target.tsv"
-write_generation "$DEPLOYED_SHA" 1 "$WORK_DIR/deployed.tsv"
-write_generation "$ROLLBACK_SHA" 2 "$WORK_DIR/rollback.tsv"
-write_generation "$CURRENT_SHA" 3 "$WORK_DIR/current.tsv"
+write_generation 0 "$WORK_DIR/target-one.tsv"
+write_generation 1 "$WORK_DIR/deployed.tsv"
+write_generation 2 "$WORK_DIR/rollback.tsv"
+write_generation 3 "$WORK_DIR/current.tsv"
+write_generation 4 "$WORK_DIR/target-two.tsv"
+write_generation 5 "$WORK_DIR/failed-target.tsv"
 cat \
   "$WORK_DIR/current.tsv" \
   "$WORK_DIR/deployed.tsv" \
   "$WORK_DIR/rollback.tsv" \
   > "$WORK_DIR/protected.tsv"
+printf '%s\n' \
+  "$TARGET_ONE_SHA" \
+  "$TARGET_TWO_SHA" \
+  "$FAILED_TARGET_SHA" \
+  > "$WORK_DIR/target-source-shas.txt"
+{
+  awk -F '\t' -v sha="$TARGET_ONE_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/target-one.tsv"
+  awk -F '\t' -v sha="$TARGET_TWO_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/target-two.tsv"
+} > "$WORK_DIR/trusted-target-images.tsv"
 
 jq -n \
-  --arg target_sha "$TARGET_SHA" \
+  --arg target_one_sha "$TARGET_ONE_SHA" \
   --arg deployed_sha "$DEPLOYED_SHA" \
   --arg rollback_sha "$ROLLBACK_SHA" \
-  --arg current_sha "$CURRENT_SHA" '
+  --arg current_sha "$CURRENT_SHA" \
+  --arg target_two_sha "$TARGET_TWO_SHA" \
+  --arg failed_target_sha "$FAILED_TARGET_SHA" '
     def services: [
       "auth", "backoffice", "bet", "client", "event", "gamemaster",
       "moderation", "resulting", "slip"
@@ -65,10 +83,12 @@ jq -n \
       ($value | tostring) as $text
       | ("0" * ($width - ($text | length))) + $text;
     [
-      [$target_sha, 0],
+      [$target_one_sha, 0],
       [$deployed_sha, 1],
       [$rollback_sha, 2],
-      [$current_sha, 3]
+      [$current_sha, 3],
+      [$target_two_sha, 4],
+      [$failed_target_sha, 5]
     ] as $generations
     | {
         data: {
@@ -94,6 +114,7 @@ jq -n \
         }
       }
   ' > "$WORK_DIR/state/images.json"
+cp "$WORK_DIR/state/images.json" "$WORK_DIR/state/images-original.json"
 
 cat > "$WORK_DIR/bin/oci" <<'MOCK'
 #!/usr/bin/env bash
@@ -146,6 +167,9 @@ MOCK
 chmod +x "$WORK_DIR/bin/oci"
 
 run_prune() {
+  local protected_file="${TEST_PROTECTED_IMAGES_FILE:-$WORK_DIR/protected.tsv}"
+  local trusted_target_file="${TEST_TRUSTED_TARGET_IMAGES_FILE:-$WORK_DIR/trusted-target-images.tsv}"
+
   env \
     PATH="$WORK_DIR/bin:$PATH" \
     MOCK_OCI_LOG="$WORK_DIR/oci.log" \
@@ -154,9 +178,9 @@ run_prune() {
     OCI_COMPARTMENT_OCID=ocid1.compartment.oc1..fixture \
     OCI_IMAGE_PREFIX=betstan \
     OCI_REGISTRY_MAX_BYTES=500000000 \
-    TARGET_IMAGES_FILE="$WORK_DIR/target.tsv" \
-    PROTECTED_IMAGES_FILE="$WORK_DIR/protected.tsv" \
-    TARGET_SOURCE_SHA="$TARGET_SHA" \
+    TARGET_SOURCE_SHAS_FILE="$WORK_DIR/target-source-shas.txt" \
+    TRUSTED_TARGET_IMAGES_FILE="$trusted_target_file" \
+    PROTECTED_IMAGES_FILE="$protected_file" \
     CURRENT_SOURCE_SHA="$CURRENT_SHA" \
     OUTPUT_DIR="$WORK_DIR/evidence" \
     PRUNE_POLL_ATTEMPTS=1 \
@@ -164,69 +188,109 @@ run_prune() {
     "$OCI_DIR/scripts/prune-registry-generation.sh"
 }
 
+: > "$WORK_DIR/oci.log"
 run_prune
-[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "9" ]] ||
-  fail "prune did not delete exactly one complete generation"
-jq -e '
-  .terminal_status == "PRUNED" and
-  .unique_images == 27
-' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
-  fail "prune did not emit terminal evidence"
-[[ "$(wc -l < "$WORK_DIR/evidence/deleted-images.tsv" | tr -d ' ')" == "9" ]] ||
-  fail "prune evidence does not contain nine deleted service images"
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "27" ]] ||
+  fail "batch prune did not delete exactly three complete generations"
+jq -e \
+  --arg one "$TARGET_ONE_SHA" \
+  --arg two "$TARGET_TWO_SHA" \
+  --arg failed "$FAILED_TARGET_SHA" '
+    .terminal_status == "PRUNED" and
+    .target_source_shas == [$one, $two, $failed] and
+    .requested_target_generations == 3 and
+    .pruned_target_generations == 3 and
+    .unique_images == 27
+  ' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
+  fail "batch prune did not emit terminal evidence"
+[[ "$(wc -l < "$WORK_DIR/evidence/deleted-images.tsv" | tr -d ' ')" == "27" ]] ||
+  fail "batch prune evidence does not contain 27 deleted service images"
 [[ "$(
   jq -c '[.data.items | length, ([.[] | .digest] | unique | length)]' \
     "$WORK_DIR/state/images.json"
 )" == "[27,27]" ]] ||
-  fail "prune did not retain exactly three complete generations"
+  fail "batch prune did not retain exactly three complete generations"
 
 rm -rf "$WORK_DIR/evidence"
 : > "$WORK_DIR/oci.log"
 run_prune
 [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
-  fail "an already-pruned generation was deleted again"
+  fail "an already-pruned target generation was deleted again"
 jq -e '
   .deletion_required == false and
+  .present_target_generations == 0 and
   .unique_images == 27
 ' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
-  fail "an already-pruned generation was not resumed idempotently"
+  fail "an already-pruned batch was not resumed idempotently"
 
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
 rm -rf "$WORK_DIR/evidence"
 : > "$WORK_DIR/oci.log"
-cp "$WORK_DIR/current.tsv" "$WORK_DIR/protected-overlap.tsv"
 cat \
+  "$WORK_DIR/current.tsv" \
   "$WORK_DIR/deployed.tsv" \
-  "$WORK_DIR/target.tsv" \
-  >> "$WORK_DIR/protected-overlap.tsv"
-if env \
-  PATH="$WORK_DIR/bin:$PATH" \
-  MOCK_OCI_LOG="$WORK_DIR/oci.log" \
-  MOCK_OCI_STATE="$WORK_DIR/state" \
-  OCI_CLI_VERSION=3.90.0 \
-  OCI_COMPARTMENT_OCID=ocid1.compartment.oc1..fixture \
-  OCI_IMAGE_PREFIX=betstan \
-  OCI_REGISTRY_MAX_BYTES=500000000 \
-  TARGET_IMAGES_FILE="$WORK_DIR/target.tsv" \
-  PROTECTED_IMAGES_FILE="$WORK_DIR/protected-overlap.tsv" \
-  TARGET_SOURCE_SHA="$TARGET_SHA" \
-  CURRENT_SOURCE_SHA="$CURRENT_SHA" \
-  OUTPUT_DIR="$WORK_DIR/evidence" \
-  PRUNE_POLL_ATTEMPTS=1 \
-  PRUNE_POLL_SECONDS=0 \
-  "$OCI_DIR/scripts/prune-registry-generation.sh" >/dev/null 2>&1; then
+  "$WORK_DIR/target-one.tsv" \
+  > "$WORK_DIR/protected-overlap.tsv"
+if TEST_PROTECTED_IMAGES_FILE="$WORK_DIR/protected-overlap.tsv" run_prune \
+  >/dev/null 2>&1; then
   fail "overlapping protected and target generations were accepted"
 fi
 [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
   fail "overlap rejection happened after a delete"
 
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+cp "$WORK_DIR/trusted-target-images.tsv" "$WORK_DIR/trusted-target-images-mismatch.tsv"
+sed '1s/sha256:[0-9a-f]\{64\}/sha256:9999999999999999999999999999999999999999999999999999999999999999/g' \
+  "$WORK_DIR/trusted-target-images-mismatch.tsv" \
+  > "$WORK_DIR/trusted-target-images-mismatch.tmp"
+mv \
+  "$WORK_DIR/trusted-target-images-mismatch.tmp" \
+  "$WORK_DIR/trusted-target-images-mismatch.tsv"
+if TEST_TRUSTED_TARGET_IMAGES_FILE="$WORK_DIR/trusted-target-images-mismatch.tsv" \
+  run_prune >/dev/null 2>&1; then
+  fail "registry drift from trusted target provenance was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "trusted target mismatch was rejected after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+jq \
+  --arg trusted_sha "$TARGET_ONE_SHA" \
+  --arg failed_sha "$FAILED_TARGET_SHA" '
+  .data.items |= (
+    map(select(
+      .version != ("oci-auth-" + $trusted_sha) and
+      .version != ("oci-auth-" + $failed_sha)
+    ))
+  )
+' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+run_prune
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "25" ]] ||
+  fail "partial batch recovery did not delete every remaining target image"
+jq -e '
+  .deletion_required == true and
+  .present_target_generations == 3 and
+  .present_target_images == 25 and
+  .unique_images == 52
+' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
+  fail "partial batch recovery did not record its exact starting state"
+[[ "$(jq '[.data.items[]] | length' "$WORK_DIR/state/images.json")" == "27" ]] ||
+  fail "partial batch recovery did not retain exactly the protected images"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
 rm -rf "$WORK_DIR/evidence"
 : > "$WORK_DIR/oci.log"
 jq '
   .data.items += [{
     id: "ocid1.containerimage.oc1..fixture999",
     "repository-name": "betstan_images",
-    version: "oci-auth-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-    digest: ("sha256:" + ("f" * 64)),
+    version: "oci-auth-9999999999999999999999999999999999999999",
+    digest: ("sha256:" + ("9" * 64)),
     "lifecycle-state": "AVAILABLE"
   }]
 ' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"


### PR DESCRIPTION
## Summary
Promote the guarded multi-generation OCI registry recovery path after the exact 54-image production lineage exceeded the three-generation allowlist.

## Safety
- protects candidate, deployed, and fallback digest sets
- deletes only explicit first-attempt target runs after exhaustive registry validation
- supports bounded partial-delete convergence
- complete OCI contract suite passed