### PR TITLE
chore: promote registry prune validation

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -51,7 +51,11 @@ inactive. Fail closed when either query is incomplete or fails.
 - Normal changes enter `dev`. Only an up-to-date pull request from `dev` may promote to `master`.
 - For a PR created and labelled `copilot-cli-managed` by the active Copilot CLI workflow, continue without a separate human prompt only after the exact-SHA automated approval gates pass. Work without that provenance requires explicit user approval for the exact target SHA and complete production-capable workflow set.
 - Automatic approval never waives required checks, trusted workflow provenance, resolved review threads, production-run exclusivity, immutable image identity, rollback readiness, or post-deploy verification.
-- Use `copilot-cli-run-approval-stan.sh` for protected build/deploy environments in automatic mode. Never auto-approve rollback, migration, infrastructure, stale-master, rerun, unlabelled, or competing workflow activity.
+- Use `copilot-cli-run-approval-stan.sh` for protected build/deploy
+  environments in automatic mode. The only infrastructure exceptions are an
+  exact-title `validate-registry` or `prune-registry` run on current
+  CLI-managed `master`; never auto-approve other infrastructure, rollback,
+  migration, stale-master, rerun, unlabelled, or competing workflow activity.
 - Keep changes on a focused branch and integrate them into `dev` before production promotion.
 - After a squash promotion, immediately merge the new `master` commit back into `dev` and verify ancestry.
 - Do not amend, rewrite, reset, or force-push history unless explicitly requested.
@@ -99,6 +103,13 @@ inactive. Fail closed when either query is incomplete or fails.
   Allow canonical protected source generations to share a complete
   nine-image OCID/digest set after reuse, but reject partial protected
   overlap.
+- Require a successful exact-master `validate-registry` artifact before
+  approving `prune-registry`. The apply run must receive that validation run
+  ID and prove its complete live before-summary is byte-identical before any
+  delete; a new alias, OCID, digest, lineage, or accounting value requires a
+  fresh validation. Bind the artifact to the exact candidate, deployed,
+  fallback, and every obsolete SHA/run pair; matching SHAs with different run
+  IDs are not interchangeable.
 
 ## Deployment gates
 

--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -82,6 +82,13 @@ inactive. Fail closed when either query is incomplete or fails.
 - Do not deploy `latest` as the source of truth.
 - Verify every application Deployment uses the intended SHA after rollout.
 - If several commits were built, state whether an older SHA was skipped or superseded.
+- Treat a failed OCI build that published before verification as registry
+  state, not reusable release provenance. Before approving a batch prune,
+  require terminal first-attempt run bindings for every explicit target,
+  immutable artifacts for successful targets, source-tagged service rows for
+  failed targets, and exhaustive preservation of the candidate, deployed, and
+  fallback digest sets. Accept a partial target subset only as bounded
+  convergence after an interrupted prune.
 
 ## Deployment gates
 

--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -89,6 +89,16 @@ inactive. Fail closed when either query is incomplete or fails.
   failed targets, and exhaustive preservation of the candidate, deployed, and
   fallback digest sets. Accept a partial target subset only as bounded
   convergence after an interrupted prune.
+- Treat OCIR list rows as tag aliases, not unique images. Before any delete,
+  group by image OCID and digest, prove their one-to-one service mapping,
+  require every alias source set to match one trusted protected or target
+  generation, and require the canonical candidate, deployed, and fallback
+  tags. Approve deletion only for the exact unique target OCIDs and require
+  before/after alias evidence, equality of the exact protected OCID set, and
+  terminal unique-image accounting; matching counts alone are insufficient.
+  Allow canonical protected source generations to share a complete
+  nine-image OCID/digest set after reuse, but reject partial protected
+  overlap.
 
 ## Deployment gates
 

--- a/.github/workflows/oci-infrastructure.yml
+++ b/.github/workflows/oci-infrastructure.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       phase:
-        description: Prepare/finalize zero-cost infrastructure or prune one obsolete image generation
+        description: Prepare/finalize zero-cost infrastructure or prune obsolete image generations
         required: true
         default: prepare
         type: choice
@@ -27,12 +27,17 @@ on:
         default: ""
         type: string
       obsolete_sha:
-        description: Obsolete source SHA whose complete image generation may be pruned
+        description: Legacy single obsolete source SHA
         required: false
         default: ""
         type: string
       obsolete_build_run_id:
-        description: First-attempt OCI build provenance for the obsolete generation
+        description: Legacy single-generation first-attempt OCI build run
+        required: false
+        default: ""
+        type: string
+      obsolete_generations:
+        description: JSON array of obsolete first-attempt build SHA/run pairs
         required: false
         default: ""
         type: string
@@ -78,6 +83,7 @@ jobs:
       CANDIDATE_BUILD_RUN_ID: ${{ inputs.candidate_build_run_id }}
       OBSOLETE_SHA: ${{ inputs.obsolete_sha }}
       OBSOLETE_BUILD_RUN_ID: ${{ inputs.obsolete_build_run_id }}
+      OBSOLETE_GENERATIONS: ${{ inputs.obsolete_generations }}
       DEPLOYED_SHA: ${{ inputs.deployed_sha }}
       DEPLOYED_RUN_ID: ${{ inputs.deployed_run_id }}
       FALLBACK_SHA: ${{ inputs.fallback_sha }}
@@ -132,14 +138,13 @@ jobs:
           set -euo pipefail
           [ "$GITHUB_REF_NAME" = "master" ]
           [ "$CONFIRMATION" = "PRUNE OBSOLETE OCI IMAGE GENERATION" ]
-          for sha in \
-            "$SOURCE_SHA" "$OBSOLETE_SHA" "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
+          for sha in "$SOURCE_SHA" "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
             [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
             git cat-file -e "${sha}^{commit}"
           done
           for run_id in \
-            "$CANDIDATE_BUILD_RUN_ID" "$OBSOLETE_BUILD_RUN_ID" \
-            "$DEPLOYED_RUN_ID" "$FALLBACK_BUILD_RUN_ID"; do
+            "$CANDIDATE_BUILD_RUN_ID" "$DEPLOYED_RUN_ID" \
+            "$FALLBACK_BUILD_RUN_ID"; do
             [[ "$run_id" =~ ^[1-9][0-9]*$ ]]
           done
           [ "$GITHUB_RUN_ATTEMPT" = "1" ]
@@ -147,13 +152,56 @@ jobs:
           [ "$SOURCE_SHA" = "$(git rev-parse HEAD)" ]
           git fetch --quiet origin master:refs/remotes/origin/master
           [ "$SOURCE_SHA" = "$(git rev-parse origin/master)" ]
-          [ "$OBSOLETE_SHA" != "$SOURCE_SHA" ]
-          [ "$OBSOLETE_SHA" != "$DEPLOYED_SHA" ]
-          [ "$OBSOLETE_SHA" != "$FALLBACK_SHA" ]
+          [ "$SOURCE_SHA" != "$DEPLOYED_SHA" ]
+          [ "$SOURCE_SHA" != "$FALLBACK_SHA" ]
           [ "$DEPLOYED_SHA" != "$FALLBACK_SHA" ]
-          for ancestor in "$OBSOLETE_SHA" "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
+          for ancestor in "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
             git merge-base --is-ancestor "$ancestor" "$SOURCE_SHA"
           done
+
+          if [ -n "$OBSOLETE_GENERATIONS" ]; then
+            [ -z "$OBSOLETE_SHA" ]
+            [ -z "$OBSOLETE_BUILD_RUN_ID" ]
+            jq -ceS '
+              . as $rows
+              | select(
+                  type == "array"
+                  and length >= 1
+                  and length <= 10
+                  and all(
+                    .[];
+                    type == "object"
+                    and (keys | sort) == ["build_run_id", "sha"]
+                    and (.sha | type) == "string"
+                    and (.sha | test("^[0-9a-f]{40}$"))
+                    and (.build_run_id | type) == "string"
+                    and (.build_run_id | test("^[1-9][0-9]*$"))
+                  )
+                  and ([$rows[].sha] | unique | length) == ($rows | length)
+                  and ([$rows[].build_run_id] | unique | length) == ($rows | length)
+                )
+            ' <<<"$OBSOLETE_GENERATIONS" \
+              > "$WORK_DIR/obsolete-generations.json"
+          else
+            [[ "$OBSOLETE_SHA" =~ ^[0-9a-f]{40}$ ]]
+            [[ "$OBSOLETE_BUILD_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+            jq -cn \
+              --arg sha "$OBSOLETE_SHA" \
+              --arg build_run_id "$OBSOLETE_BUILD_RUN_ID" \
+              '[{sha: $sha, build_run_id: $build_run_id}]' \
+              > "$WORK_DIR/obsolete-generations.json"
+          fi
+
+          jq -r '.[] | [.sha, .build_run_id] | @tsv' \
+            "$WORK_DIR/obsolete-generations.json" |
+            while IFS=$'\t' read -r obsolete_sha obsolete_run_id; do
+              [[ "$obsolete_run_id" =~ ^[1-9][0-9]*$ ]]
+              git cat-file -e "${obsolete_sha}^{commit}"
+              git merge-base --is-ancestor "$obsolete_sha" "$SOURCE_SHA"
+              [ "$obsolete_sha" != "$SOURCE_SHA" ]
+              [ "$obsolete_sha" != "$DEPLOYED_SHA" ]
+              [ "$obsolete_sha" != "$FALLBACK_SHA" ]
+            done
 
       - name: Download and validate protected image provenance
         env:
@@ -166,6 +214,7 @@ jobs:
             local run_id="$2"
             local event="$3"
             local expected_sha="$4"
+            local conclusion_mode="$5"
             local workflow_id
             local run_json
             workflow_id="$(
@@ -180,7 +229,8 @@ jobs:
               --arg workflow_path ".github/workflows/$workflow_file" \
               --arg event "$event" \
               --arg sha "$expected_sha" \
-              --arg repository "$REPOSITORY" '
+              --arg repository "$REPOSITORY" \
+              --arg conclusion_mode "$conclusion_mode" '
                 .workflow_id == $workflow_id and
                 .path == $workflow_path and
                 .event == $event and
@@ -188,7 +238,13 @@ jobs:
                 .head_branch == "master" and
                 .head_repository.full_name == $repository and
                 .status == "completed" and
-                .conclusion == "success" and
+                (
+                  if $conclusion_mode == "success" then
+                    .conclusion == "success"
+                  else
+                    (.conclusion == "success" or .conclusion == "failure")
+                  end
+                ) and
                 .run_attempt == 1
               ' <<<"$run_json" >/dev/null
           }
@@ -213,25 +269,18 @@ jobs:
 
           validate_run \
             oci-production-build.yml \
-            "$CANDIDATE_BUILD_RUN_ID" workflow_run "$SOURCE_SHA"
-          validate_run \
-            oci-production-build.yml \
-            "$OBSOLETE_BUILD_RUN_ID" workflow_run "$OBSOLETE_SHA"
+            "$CANDIDATE_BUILD_RUN_ID" workflow_run "$SOURCE_SHA" success
           validate_run \
             oci-production-deploy.yml \
-            "$DEPLOYED_RUN_ID" workflow_dispatch "$DEPLOYED_SHA"
+            "$DEPLOYED_RUN_ID" workflow_dispatch "$DEPLOYED_SHA" success
           validate_run \
             oci-production-build.yml \
-            "$FALLBACK_BUILD_RUN_ID" workflow_run "$FALLBACK_SHA"
+            "$FALLBACK_BUILD_RUN_ID" workflow_run "$FALLBACK_SHA" success
 
           download_artifact \
             "$CANDIDATE_BUILD_RUN_ID" \
             "oci-image-provenance-${SOURCE_SHA}-${CANDIDATE_BUILD_RUN_ID}-1" \
             "$WORK_DIR/candidate"
-          download_artifact \
-            "$OBSOLETE_BUILD_RUN_ID" \
-            "oci-image-provenance-${OBSOLETE_SHA}-${OBSOLETE_BUILD_RUN_ID}-1" \
-            "$WORK_DIR/obsolete"
           download_artifact \
             "$DEPLOYED_RUN_ID" \
             "oci-deploy-provenance-${DEPLOYED_RUN_ID}-1" \
@@ -243,7 +292,6 @@ jobs:
 
           for pair in \
             "candidate:$SOURCE_SHA:$CANDIDATE_BUILD_RUN_ID" \
-            "obsolete:$OBSOLETE_SHA:$OBSOLETE_BUILD_RUN_ID" \
             "fallback:$FALLBACK_SHA:$FALLBACK_BUILD_RUN_ID"; do
             IFS=: read -r directory expected_sha expected_run_id <<<"$pair"
             grep -Fxq "source_sha=$expected_sha" \
@@ -254,18 +302,72 @@ jobs:
               "$WORK_DIR/$directory/build-chain.txt"
             test -s "$WORK_DIR/$directory/images.tsv"
           done
-          for pair in "deployed:$DEPLOYED_SHA:$DEPLOYED_RUN_ID"; do
-            IFS=: read -r directory expected_sha expected_run_id <<<"$pair"
-            grep -Fxq "source_sha=$expected_sha" \
-              "$WORK_DIR/$directory/provenance.txt"
-            grep -Fxq "deployment_run_id=$expected_run_id" \
-              "$WORK_DIR/$directory/provenance.txt"
-            grep -Fxq "deployment_run_attempt=1" \
-              "$WORK_DIR/$directory/provenance.txt"
-            test -s "$WORK_DIR/$directory/images.tsv"
-          done
+          grep -Fxq "source_sha=$DEPLOYED_SHA" \
+            "$WORK_DIR/deployed/provenance.txt"
+          grep -Fxq "deployment_run_id=$DEPLOYED_RUN_ID" \
+            "$WORK_DIR/deployed/provenance.txt"
+          grep -Fxq "deployment_run_attempt=1" \
+            "$WORK_DIR/deployed/provenance.txt"
+          test -s "$WORK_DIR/deployed/images.tsv"
 
-          cp "$WORK_DIR/obsolete/images.tsv" "$PROVENANCE_DIR/obsolete.tsv"
+          : > "$PROVENANCE_DIR/target-source-shas.txt"
+          : > "$PROVENANCE_DIR/trusted-target-images.tsv"
+          : > "$PROVENANCE_DIR/obsolete-runs.tsv"
+          while IFS=$'\t' read -r obsolete_sha obsolete_run_id; do
+            validate_run \
+              oci-production-build.yml \
+              "$obsolete_run_id" workflow_run "$obsolete_sha" terminal
+            obsolete_conclusion="$(
+              gh api \
+                "repos/$REPOSITORY/actions/runs/$obsolete_run_id/attempts/1" \
+                --jq '.conclusion'
+            )"
+            artifact_name="oci-image-provenance-${obsolete_sha}-${obsolete_run_id}-1"
+            artifact_count="$(
+              gh api \
+                "repos/$REPOSITORY/actions/runs/$obsolete_run_id/artifacts?per_page=100" \
+                --jq "[.artifacts[] | select(
+                  .name == \"$artifact_name\" and .expired == false
+                )] | length"
+            )"
+            if [ "$obsolete_conclusion" = "success" ]; then
+              [ "$artifact_count" = "1" ]
+            else
+              [ "$obsolete_conclusion" = "failure" ]
+              [ "$artifact_count" = "0" ] || [ "$artifact_count" = "1" ]
+            fi
+
+            artifact_status=absent
+            if [ "$artifact_count" = "1" ]; then
+              destination="$WORK_DIR/obsolete-$obsolete_sha"
+              download_artifact \
+                "$obsolete_run_id" "$artifact_name" "$destination"
+              grep -Fxq "source_sha=$obsolete_sha" \
+                "$destination/build-chain.txt"
+              grep -Fxq "build_run_id=$obsolete_run_id" \
+                "$destination/build-chain.txt"
+              grep -Fxq "build_run_attempt=1" \
+                "$destination/build-chain.txt"
+              test -s "$destination/images.tsv"
+              awk -F '\t' -v sha="$obsolete_sha" '
+                BEGIN { OFS = "\t" }
+                NF != 5 { exit 1 }
+                { print sha, $0 }
+              ' "$destination/images.tsv" \
+                >> "$PROVENANCE_DIR/trusted-target-images.tsv"
+              artifact_status=verified
+            fi
+            printf '%s\t%s\t%s\t%s\n' \
+              "$obsolete_sha" "$obsolete_run_id" \
+              "$obsolete_conclusion" "$artifact_status" \
+              >> "$PROVENANCE_DIR/obsolete-runs.tsv"
+            printf '%s\n' "$obsolete_sha" \
+              >> "$PROVENANCE_DIR/target-source-shas.txt"
+          done < <(
+            jq -r '.[] | [.sha, .build_run_id] | @tsv' \
+              "$WORK_DIR/obsolete-generations.json"
+          )
+
           cat \
             "$WORK_DIR/candidate/images.tsv" \
             "$WORK_DIR/deployed/images.tsv" \
@@ -298,9 +400,9 @@ jobs:
           OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
           OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
           OCI_CLI_REGION: ${{ vars.OCI_REGION }}
-          TARGET_IMAGES_FILE: artifacts/oci-registry-prune/obsolete.tsv
+          TARGET_SOURCE_SHAS_FILE: artifacts/oci-registry-prune/target-source-shas.txt
+          TRUSTED_TARGET_IMAGES_FILE: artifacts/oci-registry-prune/trusted-target-images.tsv
           PROTECTED_IMAGES_FILE: artifacts/oci-registry-prune/protected.tsv
-          TARGET_SOURCE_SHA: ${{ inputs.obsolete_sha }}
           CURRENT_SOURCE_SHA: ${{ inputs.approved_sha }}
           OUTPUT_DIR: artifacts/oci-registry-prune
         run: ./infra/oci/scripts/prune-registry-generation.sh
@@ -309,10 +411,14 @@ jobs:
         run: |
           set -euo pipefail
           test -s "$PROVENANCE_DIR/after-summary.json"
+          expected_targets="$(
+            jq -c '[.[].sha] | sort' \
+              "$WORK_DIR/obsolete-generations.json"
+          )"
           jq -e \
-            --arg obsolete_sha "$OBSOLETE_SHA" \
+            --argjson expected_targets "$expected_targets" \
             --arg source_sha "$SOURCE_SHA" '
-              .target_source_sha == $obsolete_sha and
+              .target_source_shas == $expected_targets and
               .current_source_sha == $source_sha and
               .terminal_status == "PRUNED" and
               .unique_images == 27
@@ -322,6 +428,8 @@ jobs:
             "candidate_build_run_id=$CANDIDATE_BUILD_RUN_ID" \
             "obsolete_sha=$OBSOLETE_SHA" \
             "obsolete_build_run_id=$OBSOLETE_BUILD_RUN_ID" \
+            "obsolete_generation_count=$(jq 'length' "$WORK_DIR/obsolete-generations.json")" \
+            "obsolete_generations_sha256=$(sha256sum "$WORK_DIR/obsolete-generations.json" | awk '{print $1}')" \
             "deployed_sha=$DEPLOYED_SHA" \
             "deployed_run_id=$DEPLOYED_RUN_ID" \
             "fallback_sha=$FALLBACK_SHA" \

--- a/.github/workflows/oci-infrastructure.yml
+++ b/.github/workflows/oci-infrastructure.yml
@@ -368,11 +368,22 @@ jobs:
               "$WORK_DIR/obsolete-generations.json"
           )
 
-          cat \
-            "$WORK_DIR/candidate/images.tsv" \
-            "$WORK_DIR/deployed/images.tsv" \
-            "$WORK_DIR/fallback/images.tsv" \
-            > "$PROVENANCE_DIR/protected.tsv"
+          : > "$PROVENANCE_DIR/protected.tsv"
+          : > "$PROVENANCE_DIR/trusted-protected-images.tsv"
+          for protected in \
+            "candidate:$SOURCE_SHA" \
+            "deployed:$DEPLOYED_SHA" \
+            "fallback:$FALLBACK_SHA"; do
+            IFS=: read -r directory expected_sha <<<"$protected"
+            cat "$WORK_DIR/$directory/images.tsv" \
+              >> "$PROVENANCE_DIR/protected.tsv"
+            awk -F '\t' -v sha="$expected_sha" '
+              BEGIN { OFS = "\t" }
+              NF != 5 { exit 1 }
+              { print sha, $0 }
+            ' "$WORK_DIR/$directory/images.tsv" \
+              >> "$PROVENANCE_DIR/trusted-protected-images.tsv"
+          done
 
       - name: Install pinned OCI CLI and verify identity
         env:
@@ -393,7 +404,7 @@ jobs:
           )"
           [ "$home_region" = "$OCI_CLI_REGION" ]
 
-      - name: Prune only the obsolete complete generation
+      - name: Prune only obsolete unique image IDs
         env:
           OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
           OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
@@ -403,6 +414,7 @@ jobs:
           TARGET_SOURCE_SHAS_FILE: artifacts/oci-registry-prune/target-source-shas.txt
           TRUSTED_TARGET_IMAGES_FILE: artifacts/oci-registry-prune/trusted-target-images.tsv
           PROTECTED_IMAGES_FILE: artifacts/oci-registry-prune/protected.tsv
+          TRUSTED_PROTECTED_IMAGES_FILE: artifacts/oci-registry-prune/trusted-protected-images.tsv
           CURRENT_SOURCE_SHA: ${{ inputs.approved_sha }}
           OUTPUT_DIR: artifacts/oci-registry-prune
         run: ./infra/oci/scripts/prune-registry-generation.sh
@@ -410,18 +422,52 @@ jobs:
       - name: Record registry prune provenance
         run: |
           set -euo pipefail
+          test -s "$PROVENANCE_DIR/before-summary.json"
           test -s "$PROVENANCE_DIR/after-summary.json"
+          test -s "$PROVENANCE_DIR/before-aliases.tsv"
+          test -s "$PROVENANCE_DIR/after-aliases.tsv"
+          test -s "$PROVENANCE_DIR/protected-image-ids.txt"
+          protected_image_ids_sha256="$(
+            jq -er '.protected_image_ids_sha256' \
+              "$PROVENANCE_DIR/before-summary.json"
+          )"
+          [[ "$protected_image_ids_sha256" =~ ^[0-9a-f]{64}$ ]]
+          protected_image_id_count="$(
+            wc -l < "$PROVENANCE_DIR/protected-image-ids.txt" |
+              tr -d ' '
+          )"
+          [ "$protected_image_id_count" = "9" ] ||
+            [ "$protected_image_id_count" = "18" ] ||
+            [ "$protected_image_id_count" = "27" ]
+          [ "$protected_image_ids_sha256" = "$(
+            sha256sum "$PROVENANCE_DIR/protected-image-ids.txt" |
+              awk '{ print $1 }'
+          )" ]
           expected_targets="$(
             jq -c '[.[].sha] | sort' \
               "$WORK_DIR/obsolete-generations.json"
           )"
           jq -e \
             --argjson expected_targets "$expected_targets" \
-            --arg source_sha "$SOURCE_SHA" '
+            --arg source_sha "$SOURCE_SHA" \
+            --arg protected_image_ids_sha256 \
+              "$protected_image_ids_sha256" \
+            --argjson protected_image_id_count \
+              "$protected_image_id_count" '
               .target_source_shas == $expected_targets and
               .current_source_sha == $source_sha and
+              .protected_image_ids_sha256 ==
+                $protected_image_ids_sha256 and
               .terminal_status == "PRUNED" and
-              .unique_images == 27
+              .protected_unique_generations >= 1 and
+              .protected_unique_generations <= 3 and
+              .unique_images ==
+                (.protected_unique_generations * 9) and
+              .unique_images == $protected_image_id_count and
+              .unique_image_ids == .unique_images and
+              .tag_rows >= .unique_images and
+              .alias_rows == (.tag_rows - .unique_images) and
+              .tag_generations >= 3
             ' "$PROVENANCE_DIR/after-summary.json" >/dev/null
           printf '%s\n' \
             "source_sha=$SOURCE_SHA" \

--- a/.github/workflows/oci-infrastructure.yml
+++ b/.github/workflows/oci-infrastructure.yml
@@ -13,13 +13,14 @@ on:
         required: true
         type: string
       phase:
-        description: Prepare/finalize zero-cost infrastructure or prune obsolete image generations
+        description: Prepare/finalize infrastructure or validate/prune image generations
         required: true
         default: prepare
         type: choice
         options:
           - prepare
           - finalize
+          - validate-registry
           - prune-registry
       candidate_build_run_id:
         description: Current-master OCI build run protected during registry pruning
@@ -61,6 +62,11 @@ on:
         required: false
         default: ""
         type: string
+      validation_run_id:
+        description: Successful exact-state registry validation required before pruning
+        required: false
+        default: ""
+        type: string
 
 permissions:
   actions: read
@@ -72,7 +78,9 @@ concurrency:
 
 jobs:
   prune-registry:
-    if: github.run_attempt == 1 && inputs.phase == 'prune-registry'
+    if: >-
+      github.run_attempt == 1 &&
+      (inputs.phase == 'validate-registry' || inputs.phase == 'prune-registry')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:
@@ -88,6 +96,8 @@ jobs:
       DEPLOYED_RUN_ID: ${{ inputs.deployed_run_id }}
       FALLBACK_SHA: ${{ inputs.fallback_sha }}
       FALLBACK_BUILD_RUN_ID: ${{ inputs.fallback_build_run_id }}
+      PHASE: ${{ inputs.phase }}
+      VALIDATION_RUN_ID: ${{ inputs.validation_run_id }}
       OCI_CLI_VERSION: "3.90.0"
       OCI_REGION: ${{ vars.OCI_REGION }}
       OCI_TENANCY_OCID: ${{ vars.OCI_TENANCY_OCID }}
@@ -129,6 +139,8 @@ jobs:
             "deployed_run_id=$DEPLOYED_RUN_ID" \
             "fallback_sha=$FALLBACK_SHA" \
             "fallback_build_run_id=$FALLBACK_BUILD_RUN_ID" \
+            "phase=$PHASE" \
+            "validation_run_id=$VALIDATION_RUN_ID" \
             "workflow_run_id=$GITHUB_RUN_ID" \
             "workflow_run_attempt=$GITHUB_RUN_ATTEMPT" \
             > "$PROVENANCE_DIR/dispatch.env"
@@ -137,7 +149,20 @@ jobs:
         run: |
           set -euo pipefail
           [ "$GITHUB_REF_NAME" = "master" ]
-          [ "$CONFIRMATION" = "PRUNE OBSOLETE OCI IMAGE GENERATION" ]
+          case "$PHASE" in
+            validate-registry)
+              [ "$CONFIRMATION" = "VALIDATE OCI IMAGE GENERATIONS" ]
+              [ -z "$VALIDATION_RUN_ID" ]
+              ;;
+            prune-registry)
+              [ "$CONFIRMATION" = "PRUNE OBSOLETE OCI IMAGE GENERATION" ]
+              [[ "$VALIDATION_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+              [ "$VALIDATION_RUN_ID" != "$GITHUB_RUN_ID" ]
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
           for sha in "$SOURCE_SHA" "$DEPLOYED_SHA" "$FALLBACK_SHA"; do
             [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
             git cat-file -e "${sha}^{commit}"
@@ -384,6 +409,56 @@ jobs:
             ' "$WORK_DIR/$directory/images.tsv" \
               >> "$PROVENANCE_DIR/trusted-protected-images.tsv"
           done
+          jq -cnS \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg candidate_build_run_id "$CANDIDATE_BUILD_RUN_ID" \
+            --arg deployed_sha "$DEPLOYED_SHA" \
+            --arg deployed_run_id "$DEPLOYED_RUN_ID" \
+            --arg fallback_sha "$FALLBACK_SHA" \
+            --arg fallback_build_run_id "$FALLBACK_BUILD_RUN_ID" \
+            --slurpfile obsolete "$WORK_DIR/obsolete-generations.json" '
+              {
+                schema: "betstan.oci-registry-prune-request.v1",
+                source_sha: $source_sha,
+                candidate_build_run_id: $candidate_build_run_id,
+                deployed_sha: $deployed_sha,
+                deployed_run_id: $deployed_run_id,
+                fallback_sha: $fallback_sha,
+                fallback_build_run_id: $fallback_build_run_id,
+                obsolete_generations: (
+                  $obsolete[0] |
+                  sort_by(.sha + ":" + .build_run_id)
+                )
+              }
+            ' > "$PROVENANCE_DIR/request-provenance.json"
+
+          if [ "$PHASE" = "prune-registry" ]; then
+            validate_run \
+              oci-infrastructure.yml \
+              "$VALIDATION_RUN_ID" workflow_dispatch "$SOURCE_SHA" success
+            download_artifact \
+              "$VALIDATION_RUN_ID" \
+              "oci-registry-prune-${VALIDATION_RUN_ID}-1" \
+              "$WORK_DIR/validated-registry"
+            test -s "$WORK_DIR/validated-registry/before-summary.json"
+            test -s "$WORK_DIR/validated-registry/validation-summary.json"
+            test -s "$WORK_DIR/validated-registry/request-provenance.json"
+            cmp -s \
+              "$PROVENANCE_DIR/request-provenance.json" \
+              "$WORK_DIR/validated-registry/request-provenance.json"
+            expected_targets="$(
+              jq -c '[.[].sha] | sort' \
+                "$WORK_DIR/obsolete-generations.json"
+            )"
+            jq -e \
+              --arg source_sha "$SOURCE_SHA" \
+              --argjson expected_targets "$expected_targets" '
+                .current_source_sha == $source_sha and
+                .target_source_shas == $expected_targets and
+                .terminal_status == "VALIDATED"
+              ' "$WORK_DIR/validated-registry/validation-summary.json" \
+              >/dev/null
+          fi
 
       - name: Install pinned OCI CLI and verify identity
         env:
@@ -404,7 +479,7 @@ jobs:
           )"
           [ "$home_region" = "$OCI_CLI_REGION" ]
 
-      - name: Prune only obsolete unique image IDs
+      - name: Validate or prune unique image IDs
         env:
           OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
           OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
@@ -415,11 +490,74 @@ jobs:
           TRUSTED_TARGET_IMAGES_FILE: artifacts/oci-registry-prune/trusted-target-images.tsv
           PROTECTED_IMAGES_FILE: artifacts/oci-registry-prune/protected.tsv
           TRUSTED_PROTECTED_IMAGES_FILE: artifacts/oci-registry-prune/trusted-protected-images.tsv
+          REQUEST_PROVENANCE_FILE: artifacts/oci-registry-prune/request-provenance.json
           CURRENT_SOURCE_SHA: ${{ inputs.approved_sha }}
           OUTPUT_DIR: artifacts/oci-registry-prune
-        run: ./infra/oci/scripts/prune-registry-generation.sh
+          PRUNE_MODE: ${{ inputs.phase == 'prune-registry' && 'apply' || 'validate' }}
+        run: |
+          set -euo pipefail
+          if [ "$PRUNE_MODE" = "apply" ]; then
+            export VALIDATED_BEFORE_SUMMARY_FILE="$WORK_DIR/validated-registry/before-summary.json"
+          fi
+          ./infra/oci/scripts/prune-registry-generation.sh
+
+      - name: Record registry validation provenance
+        if: inputs.phase == 'validate-registry'
+        run: |
+          set -euo pipefail
+          for evidence in \
+            before-summary.json validation-summary.json before-aliases.tsv \
+            protected-image-ids.txt registry-accounting.json \
+            request-provenance.json; do
+            test -s "$PROVENANCE_DIR/$evidence"
+          done
+          test -f "$PROVENANCE_DIR/planned-images.tsv"
+          expected_targets="$(
+            jq -c '[.[].sha] | sort' \
+              "$WORK_DIR/obsolete-generations.json"
+          )"
+          registry_aliases_sha256="$(
+            sha256sum "$PROVENANCE_DIR/before-aliases.tsv" |
+              awk '{ print $1 }'
+          )"
+          protected_image_ids_sha256="$(
+            sha256sum "$PROVENANCE_DIR/protected-image-ids.txt" |
+              awk '{ print $1 }'
+          )"
+          request_provenance_sha256="$(
+            sha256sum "$PROVENANCE_DIR/request-provenance.json" |
+              awk '{ print $1 }'
+          )"
+          jq -e \
+            --arg source_sha "$SOURCE_SHA" \
+            --argjson expected_targets "$expected_targets" \
+            --arg registry_aliases_sha256 "$registry_aliases_sha256" \
+            --arg protected_image_ids_sha256 \
+              "$protected_image_ids_sha256" \
+            --arg request_provenance_sha256 \
+              "$request_provenance_sha256" '
+              .current_source_sha == $source_sha and
+              .target_source_shas == $expected_targets and
+              .terminal_status == "VALIDATED" and
+              .registry_aliases_sha256 == $registry_aliases_sha256 and
+              .protected_image_ids_sha256 ==
+                $protected_image_ids_sha256 and
+              .request_provenance_sha256 ==
+                $request_provenance_sha256 and
+              .unique_images == .unique_image_ids and
+              .tag_rows >= .unique_images and
+              .alias_rows == (.tag_rows - .unique_images)
+            ' "$PROVENANCE_DIR/validation-summary.json" >/dev/null
+          printf '%s\n' \
+            "source_sha=$SOURCE_SHA" \
+            "candidate_build_run_id=$CANDIDATE_BUILD_RUN_ID" \
+            "validation_run_id=$GITHUB_RUN_ID" \
+            "workflow_run_attempt=$GITHUB_RUN_ATTEMPT" \
+            "terminal_status=VALIDATED" \
+            > "$PROVENANCE_DIR/provenance.env"
 
       - name: Record registry prune provenance
+        if: inputs.phase == 'prune-registry'
         run: |
           set -euo pipefail
           test -s "$PROVENANCE_DIR/before-summary.json"
@@ -427,6 +565,12 @@ jobs:
           test -s "$PROVENANCE_DIR/before-aliases.tsv"
           test -s "$PROVENANCE_DIR/after-aliases.tsv"
           test -s "$PROVENANCE_DIR/protected-image-ids.txt"
+          test -s "$PROVENANCE_DIR/validated-before-summary.json"
+          test -s "$PROVENANCE_DIR/request-provenance.json"
+          validated_before_summary_sha256="$(
+            sha256sum "$PROVENANCE_DIR/validated-before-summary.json" |
+              awk '{ print $1 }'
+          )"
           protected_image_ids_sha256="$(
             jq -er '.protected_image_ids_sha256' \
               "$PROVENANCE_DIR/before-summary.json"
@@ -443,6 +587,10 @@ jobs:
             sha256sum "$PROVENANCE_DIR/protected-image-ids.txt" |
               awk '{ print $1 }'
           )" ]
+          request_provenance_sha256="$(
+            sha256sum "$PROVENANCE_DIR/request-provenance.json" |
+              awk '{ print $1 }'
+          )"
           expected_targets="$(
             jq -c '[.[].sha] | sort' \
               "$WORK_DIR/obsolete-generations.json"
@@ -452,12 +600,20 @@ jobs:
             --arg source_sha "$SOURCE_SHA" \
             --arg protected_image_ids_sha256 \
               "$protected_image_ids_sha256" \
+            --arg validated_before_summary_sha256 \
+              "$validated_before_summary_sha256" \
+            --arg request_provenance_sha256 \
+              "$request_provenance_sha256" \
             --argjson protected_image_id_count \
               "$protected_image_id_count" '
               .target_source_shas == $expected_targets and
               .current_source_sha == $source_sha and
               .protected_image_ids_sha256 ==
                 $protected_image_ids_sha256 and
+              .validated_before_summary_sha256 ==
+                $validated_before_summary_sha256 and
+              .request_provenance_sha256 ==
+                $request_provenance_sha256 and
               .terminal_status == "PRUNED" and
               .protected_unique_generations >= 1 and
               .protected_unique_generations <= 3 and
@@ -480,6 +636,7 @@ jobs:
             "deployed_run_id=$DEPLOYED_RUN_ID" \
             "fallback_sha=$FALLBACK_SHA" \
             "fallback_build_run_id=$FALLBACK_BUILD_RUN_ID" \
+            "validation_run_id=$VALIDATION_RUN_ID" \
             "workflow_run_id=$GITHUB_RUN_ID" \
             "workflow_run_attempt=$GITHUB_RUN_ATTEMPT" \
             "terminal_status=PRUNED" \
@@ -499,7 +656,9 @@ jobs:
         run: rm -rf "$HOME" "$WORK_DIR"
 
   provision:
-    if: github.run_attempt == 1 && inputs.phase != 'prune-registry'
+    if: >-
+      github.run_attempt == 1 &&
+      (inputs.phase == 'prepare' || inputs.phase == 'finalize')
     runs-on: ubuntu-latest
     timeout-minutes: 150
     environment:

--- a/infra/azure/agents/copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/copilot-cli-run-approval-stan.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 #     ./infra/azure/agents/copilot-cli-run-approval-stan.sh <run-id>
 #   COPILOT_CLI_AUTO_APPROVE=true ... \
 #     ./infra/azure/agents/copilot-cli-run-approval-stan.sh <run-id> --approve
+#   EXPECTED_SHA=<sha> EXPECTED_WORKFLOW=oci-infrastructure.yml \
+#     EXPECTED_ENVIRONMENT=oci-infrastructure \
+#     EXPECTED_DISPLAY_TITLE="oci-infrastructure validate-registry <sha>" \
+#     ./infra/azure/agents/copilot-cli-run-approval-stan.sh <run-id>
 
 REPO="${REPO:-vasilyevstan/betstan}"
 RUN_ID="${1:-${RUN_ID:-}}"
@@ -16,6 +20,7 @@ ACTION="${2:-}"
 EXPECTED_SHA="${EXPECTED_SHA:-}"
 EXPECTED_WORKFLOW="${EXPECTED_WORKFLOW:-}"
 EXPECTED_ENVIRONMENT="${EXPECTED_ENVIRONMENT:-}"
+EXPECTED_DISPLAY_TITLE="${EXPECTED_DISPLAY_TITLE:-}"
 CLI_MANAGED_LABEL="${COPILOT_CLI_MANAGED_LABEL:-copilot-cli-managed}"
 AUTO_APPROVE="${COPILOT_CLI_AUTO_APPROVE:-false}"
 PRODUCTION_RUN_EXCLUSIVITY="${PRODUCTION_RUN_EXCLUSIVITY:-./infra/azure/agents/production-run-exclusivity-stan.sh}"
@@ -56,6 +61,17 @@ case "$EXPECTED_WORKFLOW:$EXPECTED_ENVIRONMENT" in
   oci-live-betting-disable.yml:oci-production)
     expected_event="workflow_dispatch"
     ;;
+  oci-infrastructure.yml:oci-infrastructure)
+    expected_event="workflow_dispatch"
+    case "$EXPECTED_DISPLAY_TITLE" in
+      "oci-infrastructure validate-registry $EXPECTED_SHA" | \
+        "oci-infrastructure prune-registry $EXPECTED_SHA")
+        ;;
+      *)
+        fail "OCI infrastructure approval requires an exact validation or prune run title"
+        ;;
+    esac
+    ;;
   *)
     fail "workflow/environment pair is not eligible for automatic approval"
     ;;
@@ -82,12 +98,12 @@ read_pending() {
 
 validate_run() {
   python3 - "$1" "$RUN_ID" "$REPO" "$EXPECTED_SHA" \
-    "$EXPECTED_WORKFLOW" "$expected_event" <<'PY'
+    "$EXPECTED_WORKFLOW" "$expected_event" "$EXPECTED_DISPLAY_TITLE" <<'PY'
 import json
 import sys
 
 payload = json.loads(sys.argv[1])
-run_id, repository, sha, workflow, event = sys.argv[2:]
+run_id, repository, sha, workflow, event, display_title = sys.argv[2:]
 failures = []
 if str(payload.get("id", "")) != run_id:
     failures.append("run ID changed")
@@ -95,6 +111,8 @@ if payload.get("path") != f".github/workflows/{workflow}":
     failures.append("workflow path mismatch")
 if payload.get("event") != event:
     failures.append("workflow event mismatch")
+if display_title and payload.get("display_title") != display_title:
+    failures.append("workflow display title mismatch")
 if payload.get("head_sha") != sha:
     failures.append("run SHA mismatch")
 if payload.get("head_branch") != "master":

--- a/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
+++ b/infra/azure/agents/test-copilot-cli-run-approval-stan.sh
@@ -32,7 +32,7 @@ gh() {
       "[{\"environment\":{\"id\":456,\"name\":\"${STUB_ENVIRONMENT:-production-emergency}\"},\"current_user_can_approve\":true}]"
   elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID" ]]; then
     printf '%s\n' \
-      "{\"id\":$RUN_ID,\"path\":\".github/workflows/${STUB_WORKFLOW:-production-build.yml}\",\"event\":\"${STUB_EVENT:-push}\",\"head_sha\":\"$SHA\",\"head_branch\":\"master\",\"head_repository\":{\"full_name\":\"example/repo\"},\"run_attempt\":${STUB_ATTEMPT:-1},\"status\":\"waiting\"}"
+      "{\"id\":$RUN_ID,\"path\":\".github/workflows/${STUB_WORKFLOW:-production-build.yml}\",\"display_title\":\"${STUB_DISPLAY_TITLE:-production-build}\",\"event\":\"${STUB_EVENT:-push}\",\"head_sha\":\"$SHA\",\"head_branch\":\"master\",\"head_repository\":{\"full_name\":\"example/repo\"},\"run_attempt\":${STUB_ATTEMPT:-1},\"status\":\"waiting\"}"
   elif [[ "$1" == "api" && "$2" == *"/commits/$SHA/pulls"* ]]; then
     local labels='[{"name":"copilot-cli-managed"}]'
     if [[ "${STUB_LABEL:-present}" == "missing" ]]; then
@@ -79,6 +79,37 @@ env \
   STUB_EVENT=workflow_dispatch \
   STUB_ENVIRONMENT=oci-production \
     "$APPROVER" "$RUN_ID" >/dev/null
+
+for phase in validate-registry prune-registry; do
+  env \
+    REPO=example/repo \
+    EXPECTED_SHA="$SHA" \
+    EXPECTED_WORKFLOW=oci-infrastructure.yml \
+    EXPECTED_ENVIRONMENT=oci-infrastructure \
+    EXPECTED_DISPLAY_TITLE="oci-infrastructure $phase $SHA" \
+    PRODUCTION_RUN_EXCLUSIVITY="$tmp_dir/production-exclusivity" \
+    STUB_WORKFLOW=oci-infrastructure.yml \
+    STUB_EVENT=workflow_dispatch \
+    STUB_ENVIRONMENT=oci-infrastructure \
+    STUB_DISPLAY_TITLE="oci-infrastructure $phase $SHA" \
+      "$APPROVER" "$RUN_ID" >/dev/null
+done
+
+if env \
+  REPO=example/repo \
+  EXPECTED_SHA="$SHA" \
+  EXPECTED_WORKFLOW=oci-infrastructure.yml \
+  EXPECTED_ENVIRONMENT=oci-infrastructure \
+  EXPECTED_DISPLAY_TITLE="oci-infrastructure validate-registry $SHA" \
+  PRODUCTION_RUN_EXCLUSIVITY="$tmp_dir/production-exclusivity" \
+  STUB_WORKFLOW=oci-infrastructure.yml \
+  STUB_EVENT=workflow_dispatch \
+  STUB_ENVIRONMENT=oci-infrastructure \
+  STUB_DISPLAY_TITLE="oci-infrastructure prune-registry $SHA" \
+    "$APPROVER" "$RUN_ID" >/dev/null 2>&1; then
+  echo "run approver accepted a different infrastructure phase" >&2
+  exit 1
+fi
 
 env "${common_env[@]}" COPILOT_CLI_AUTO_APPROVE=true \
   "$APPROVER" "$RUN_ID" --approve >/dev/null

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -71,6 +71,11 @@ conversation summaries are not authority.
   and fallback source tags may legitimately share one complete nine-image set
   after reuse; permit exact whole-generation aliases but reject partial
   protected overlap.
+- A destructive run should not be the first consumer of live provider
+  evidence. Capture a read-only registry validation artifact first, then make
+  apply require byte-for-byte equality of the live before-summary (all aliases,
+  OCIDs, digests, lineage, and accounting) with that artifact before issuing
+  any delete.
 - Normalize documented case-insensitive provider enums before comparing them.
   OCI has returned values such as `paravirtualized` in lowercase.
 - A healthy load-balancer control plane does not prove a healthy data plane.

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -58,9 +58,19 @@ conversation summaries are not authority.
   generation without a provenance artifact. Before pruning accumulated
   generations, protect the exact candidate, deployed, and fallback digest
   sets; bind every target to a terminal first-attempt build; and prove that
-  protected plus target rows exhaust the registry before deleting the whole
+  protected plus target identities exhaust the registry before deleting the
   explicit batch. Permit partial target subsets only so an interrupted prune
   can safely converge.
+- OCIR lists one row per tag, not necessarily one row per stored image.
+  `imagetools create` reuse adds exact-SHA aliases that share an image OCID and
+  digest. Destructive checks must validate every alias while counting and
+  deleting unique image IDs: require one service and digest per ID, one
+  service and ID per digest, complete trusted alias generations, canonical
+  protected tags, and equality of the exact protected OCID set before and
+  after deletion rather than relying on counts alone. Candidate, deployed,
+  and fallback source tags may legitimately share one complete nine-image set
+  after reuse; permit exact whole-generation aliases but reject partial
+  protected overlap.
 - Normalize documented case-insensitive provider enums before comparing them.
   OCI has returned values such as `paravirtualized` in lowercase.
 - A healthy load-balancer control plane does not prove a healthy data plane.

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -54,6 +54,13 @@ conversation summaries are not authority.
 - OCI deletion and registry layer reclamation are asynchronous. Wait for
   terminal provider state and accounting instead of assuming a successful
   delete response completed the operation.
+- A build that fails after publishing can leave a complete source-tagged image
+  generation without a provenance artifact. Before pruning accumulated
+  generations, protect the exact candidate, deployed, and fallback digest
+  sets; bind every target to a terminal first-attempt build; and prove that
+  protected plus target rows exhaust the registry before deleting the whole
+  explicit batch. Permit partial target subsets only so an interrupted prune
+  can safely converge.
 - Normalize documented case-insensitive provider enums before comparing them.
   OCI has returned values such as `paravirtualized` in lowercase.
 - A healthy load-balancer control plane does not prove a healthy data plane.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -160,26 +160,32 @@ concurrent retirement fixture isolation without masking failed suites.
    workflow records and verifies immutable digests with
    `scripts/verify-images.sh`.
    If fresh or failed builds leave more than three complete generations,
-   dispatch
-   `oci-infrastructure` with phase `prune-registry` before infrastructure
-   finalization. Bind the request to the exact current candidate build, the
-   currently deployed release, one compatible fallback build, and a bounded
-   JSON list of explicit obsolete SHA/run pairs. Successful obsolete builds
-   are cross-checked against their immutable artifacts; failed first-attempt
-   builds are eligible only for their source-tagged service rows. The
-   protected job also accepts an explicit target subset left by an interrupted
-   prior deletion, but deletes nothing unless the protected and target sets
-   are pairwise disjoint and exhaust every unique image ID/digest. All tag
-   aliases must map consistently to one trusted protected or target
-   generation, and each canonical candidate, deployed, and fallback tag must
-   remain present. Complete protected source generations may alias the same
-   nine immutable images after reuse; partial protected overlap is rejected.
-   The workflow rechecks an unchanged alias snapshot immediately before
-   deletion, deletes each target image ID once, records the complete
-   before/after alias inventory, and waits until all target digests are
-   absent, the exact pre-delete protected set of 9, 18, or 27 image
-   OCIDs/digests remains, provider image accounting matches that set, and
-   retained layers are within the configured Free Tier ceiling.
+   first dispatch `oci-infrastructure` with phase `validate-registry` and the
+   exact confirmation `VALIDATE OCI IMAGE GENERATIONS`. Bind the request to
+   the exact current candidate build, the currently deployed release, one
+   compatible fallback build, and a bounded JSON list of explicit obsolete
+   SHA/run pairs. The successful validation artifact contains the complete
+   live alias inventory, exact protected OCIDs, target deletion plan, digest
+   lineage, and provider accounting without issuing a delete. Dispatch phase
+   `prune-registry` only with that validation run ID and identical inputs; the
+   apply run requires its freshly observed before-summary to match the
+   validated summary byte for byte.
+
+   Successful obsolete builds are cross-checked against their immutable
+   artifacts; failed first-attempt builds are eligible only for their
+   source-tagged service rows. The protected job also accepts an explicit
+   target subset left by an interrupted prior deletion, but deletes nothing
+   unless the protected and target sets are pairwise disjoint and exhaust
+   every unique image ID/digest. All tag aliases must map consistently to one
+   trusted protected or target generation, and each canonical candidate,
+   deployed, and fallback tag must remain present. Complete protected source
+   generations may alias the same nine immutable images after reuse; partial
+   protected overlap is rejected. The apply run rechecks an unchanged alias
+   snapshot immediately before deletion, deletes each target image ID once,
+   records the complete before/after alias inventory, and waits until all
+   target digests are absent, the exact pre-delete protected set of 9, 18, or
+   27 image OCIDs/digests remains, provider image accounting matches that set,
+   and retained layers are within the configured Free Tier ceiling.
 3. Dispatch `oci-infrastructure` with phase `prepare`.
    `scripts/provision.sh cloud` creates/reconciles only the VCN, Internet
    Gateway, public/restricted subnets, NSGs, and OCI Bastion.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -156,15 +156,20 @@ concurrent retirement fixture isolation without masking failed suites.
 2. `scripts/build-images.sh` builds ARM64 OCI-only images; the production
    workflow records and verifies immutable digests with
    `scripts/verify-images.sh`.
-   If a fresh build creates a fourth complete generation, dispatch
+   If fresh or failed builds leave more than three complete generations,
+   dispatch
    `oci-infrastructure` with phase `prune-registry` before infrastructure
    finalization. Bind the request to the exact current candidate build, the
-   currently deployed release, one compatible fallback build, and one
-   obsolete build. The protected job deletes only when those four
-   nine-service generations are pairwise disjoint and exhaust the registry;
-   it waits until the obsolete digests are absent, all 27 protected digests
-   remain, provider image accounting reaches 27, and retained layers are
-   within the configured Free Tier ceiling.
+   currently deployed release, one compatible fallback build, and a bounded
+   JSON list of explicit obsolete SHA/run pairs. Successful obsolete builds
+   are cross-checked against their immutable artifacts; failed first-attempt
+   builds are eligible only for their source-tagged service rows. The
+   protected job also accepts an explicit target subset left by an interrupted
+   prior deletion, but deletes nothing
+   unless the protected and target sets are pairwise disjoint and exhaust
+   every registry row. It waits until all target digests are absent, all 27
+   protected digests remain, provider image accounting reaches 27, and
+   retained layers are within the configured Free Tier ceiling.
 3. Dispatch `oci-infrastructure` with phase `prepare`.
    `scripts/provision.sh cloud` creates/reconciles only the VCN, Internet
    Gateway, public/restricted subnets, NSGs, and OCI Bastion.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -32,7 +32,10 @@ remains an explicit fallback selected with `OCI_RUNTIME_MODE=oke`.
   `OCI_REGISTRY_MAX_BYTES=500000000`. The inventory accepts only one to three
   complete nine-image generations: the exact candidate and up to two retained
   rollback generations. It verifies complete service tag sets and unique
-  service/digest mappings; partial or fourth generations fail closed.
+  service/digest mappings; partial or fourth unique generations fail closed.
+  Exact-SHA tags created by image reuse are aliases and do not increase the
+  provider's unique image count, but every alias must resolve to one complete
+  trusted generation.
 - Frankfurt OCIR does not currently support repository-level immutability.
   One private `${OCI_IMAGE_PREFIX}_images` repository is precreated so the
   eight backend images share their identical Node layers instead of charging
@@ -165,10 +168,17 @@ concurrent retirement fixture isolation without masking failed suites.
    are cross-checked against their immutable artifacts; failed first-attempt
    builds are eligible only for their source-tagged service rows. The
    protected job also accepts an explicit target subset left by an interrupted
-   prior deletion, but deletes nothing
-   unless the protected and target sets are pairwise disjoint and exhaust
-   every registry row. It waits until all target digests are absent, all 27
-   protected digests remain, provider image accounting reaches 27, and
+   prior deletion, but deletes nothing unless the protected and target sets
+   are pairwise disjoint and exhaust every unique image ID/digest. All tag
+   aliases must map consistently to one trusted protected or target
+   generation, and each canonical candidate, deployed, and fallback tag must
+   remain present. Complete protected source generations may alias the same
+   nine immutable images after reuse; partial protected overlap is rejected.
+   The workflow rechecks an unchanged alias snapshot immediately before
+   deletion, deletes each target image ID once, records the complete
+   before/after alias inventory, and waits until all target digests are
+   absent, the exact pre-delete protected set of 9, 18, or 27 image
+   OCIDs/digests remains, provider image accounting matches that set, and
    retained layers are within the configured Free Tier ceiling.
 3. Dispatch `oci-infrastructure` with phase `prepare`.
    `scripts/provision.sh cloud` creates/reconciles only the VCN, Internet

--- a/infra/oci/scripts/prune-registry-generation.sh
+++ b/infra/oci/scripts/prune-registry-generation.sh
@@ -8,13 +8,18 @@ source "$SCRIPT_DIR/lib.sh"
 TARGET_SOURCE_SHAS_FILE="${TARGET_SOURCE_SHAS_FILE:-}"
 TRUSTED_TARGET_IMAGES_FILE="${TRUSTED_TARGET_IMAGES_FILE:-}"
 PROTECTED_IMAGES_FILE="${PROTECTED_IMAGES_FILE:-}"
+TRUSTED_PROTECTED_IMAGES_FILE="${TRUSTED_PROTECTED_IMAGES_FILE:-}"
 CURRENT_SOURCE_SHA="${CURRENT_SOURCE_SHA:-}"
 OUTPUT_DIR="${OUTPUT_DIR:-artifacts/oci-registry-prune}"
 PRUNE_POLL_ATTEMPTS="${PRUNE_POLL_ATTEMPTS:-60}"
 PRUNE_POLL_SECONDS="${PRUNE_POLL_SECONDS:-10}"
 EXPECTED_SERVICES='auth backoffice bet client event gamemaster moderation resulting slip'
-EXPECTED_PROTECTED_IMAGES=27
+IMAGES_PER_GENERATION=9
+EXPECTED_PROTECTED_PROVENANCE_ROWS=27
+MAX_PROTECTED_IMAGES=27
 MAX_TARGET_GENERATIONS=10
+MAX_REGISTRY_TAG_ROWS=900
+MAX_REGISTRY_TAG_GENERATIONS=100
 
 oci_require_cli_version
 oci_require_command jq
@@ -36,6 +41,8 @@ oci_require_ocid OCI_COMPARTMENT_OCID
   oci_die "TRUSTED_TARGET_IMAGES_FILE does not exist"
 [[ -f "$PROTECTED_IMAGES_FILE" ]] ||
   oci_die "PROTECTED_IMAGES_FILE does not exist"
+[[ -f "$TRUSTED_PROTECTED_IMAGES_FILE" ]] ||
+  oci_die "TRUSTED_PROTECTED_IMAGES_FILE does not exist"
 
 mkdir -p "$OUTPUT_DIR"
 work_dir="$(mktemp -d)"
@@ -104,8 +111,11 @@ provenance_repository="$(
 normalize_protected_provenance() {
   awk -F '\t' \
     -v repository="$provenance_repository" \
+    -v expected_rows="$EXPECTED_PROTECTED_PROVENANCE_ROWS" \
+    -v images_per_generation="$IMAGES_PER_GENERATION" \
     -v expected_services="$EXPECTED_SERVICES" '
       BEGIN {
+        expected_service_count = expected_rows / images_per_generation
         split(expected_services, services, " ")
         for (service_index in services) {
           allowed[services[service_index]] = 1
@@ -117,32 +127,28 @@ normalize_protected_provenance() {
           substr(value, 8) ~ /^[0-9a-f]+$/
       }
       NF != 5 || !($1 in allowed) || $2 != repository ||
-        $3 != $2 "@" $4 || $4 != $5 || !valid_digest($4) {
+        $3 != $2 "@" $4 || $4 != $5 || !valid_digest($4) ||
+        ($4 in digest_service && digest_service[$4] != $1) {
         exit 1
       }
       {
         rows++
         service_count[$1]++
-        digest_count[$4]++
+        digest_service[$4] = $1
         print $1 "\t" $4
       }
       END {
-        if (rows != 27) {
+        if (rows != expected_rows) {
           exit 1
         }
         for (service in allowed) {
-          if (service_count[service] != 3) {
-            exit 1
-          }
-        }
-        for (digest in digest_count) {
-          if (digest_count[digest] != 1) {
+          if (service_count[service] != expected_service_count) {
             exit 1
           }
         }
       }
     ' "$PROTECTED_IMAGES_FILE" |
-    LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
+    LC_ALL=C sort -u -t $'\t' -k1,1 -k2,2 \
       > "$work_dir/protected.tsv" ||
     oci_die "protected image provenance validation failed"
 }
@@ -194,14 +200,112 @@ normalize_trusted_target_provenance() {
     oci_die "trusted target image provenance validation failed"
 }
 
+normalize_trusted_protected_provenance() {
+  awk -F '\t' \
+    -v repository="$provenance_repository" \
+    -v current_sha="$CURRENT_SOURCE_SHA" \
+    -v expected_rows="$EXPECTED_PROTECTED_PROVENANCE_ROWS" \
+    -v images_per_generation="$IMAGES_PER_GENERATION" \
+    -v expected_services="$EXPECTED_SERVICES" '
+      BEGIN {
+        split(expected_services, services, " ")
+        for (service_index in services) {
+          allowed[services[service_index]] = 1
+        }
+      }
+      function valid_sha(value) {
+        return length(value) == 40 && value ~ /^[0-9a-f]+$/
+      }
+      function valid_digest(value) {
+        return length(value) == 71 &&
+          substr(value, 1, 7) == "sha256:" &&
+          substr(value, 8) ~ /^[0-9a-f]+$/
+      }
+      NF != 6 || !valid_sha($1) || !($2 in allowed) ||
+        $3 != repository || $4 != $3 "@" $5 || $5 != $6 ||
+        !valid_digest($5) || seen[$1 SUBSEP $2]++ ||
+        ($5 in digest_service && digest_service[$5] != $2) {
+        exit 1
+      }
+      {
+        rows++
+        source_count[$1]++
+        source_digest[$1 SUBSEP $2] = $5
+        digest_service[$5] = $2
+        print $1 "\t" $2 "\t" $5
+      }
+      END {
+        if (rows != expected_rows) {
+          exit 1
+        }
+        for (source in source_count) {
+          sources++
+          if (source_count[source] != images_per_generation) {
+            exit 1
+          }
+          for (service in allowed) {
+            if (!seen[source SUBSEP service]) {
+              exit 1
+            }
+          }
+        }
+        if (sources != expected_rows / images_per_generation) {
+          exit 1
+        }
+        if (source_count[current_sha] != images_per_generation) {
+          exit 1
+        }
+        for (left in source_count) {
+          for (right in source_count) {
+            if (left == right) {
+              continue
+            }
+            shared = 0
+            equal = 1
+            for (service in allowed) {
+              left_digest = source_digest[left SUBSEP service]
+              right_digest = source_digest[right SUBSEP service]
+              if (left_digest == right_digest) {
+                shared++
+              } else {
+                equal = 0
+              }
+            }
+            if (shared > 0 && !equal) {
+              exit 1
+            }
+          }
+        }
+      }
+    ' "$TRUSTED_PROTECTED_IMAGES_FILE" |
+    LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
+      > "$work_dir/trusted-protected.tsv" ||
+    oci_die "trusted protected image provenance validation failed"
+}
+
 normalize_protected_provenance
 normalize_trusted_target_provenance
+normalize_trusted_protected_provenance
 
 cut -f2 "$work_dir/protected.tsv" |
   LC_ALL=C sort -u > "$work_dir/protected-digests.txt"
-[[ "$(wc -l < "$work_dir/protected-digests.txt" | tr -d ' ')" == \
-  "$EXPECTED_PROTECTED_IMAGES" ]] ||
-  oci_die "protected image provenance is not digest-unique"
+protected_image_count="$(
+  wc -l < "$work_dir/protected-digests.txt" | tr -d ' '
+)"
+((protected_image_count >= IMAGES_PER_GENERATION &&
+  protected_image_count <= MAX_PROTECTED_IMAGES &&
+  protected_image_count % IMAGES_PER_GENERATION == 0)) ||
+  oci_die "protected provenance is not one to three complete unique image generations"
+protected_unique_generation_count="$(
+  printf '%s\n' "$((protected_image_count / IMAGES_PER_GENERATION))"
+)"
+cut -f2,3 "$work_dir/trusted-protected.tsv" |
+  LC_ALL=C sort -u -t $'\t' -k1,1 -k2,2 \
+    > "$work_dir/trusted-protected-service-digests.tsv"
+cmp -s \
+  "$work_dir/protected.tsv" \
+  "$work_dir/trusted-protected-service-digests.tsv" ||
+  oci_die "trusted protected source tags do not match protected digest provenance"
 
 list_images() {
   local destination="$1"
@@ -257,11 +361,25 @@ validate_registry_rows() {
         )
       )
       and ([
+        ($rows | group_by(.version))[]
+        | select(length != 1)
+      ] | length) == 0
+      and ([
         ($rows | group_by(.digest))[]
-        | select(([.[].parsed_tag.service] | unique | length) != 1)
+        | select(
+            ([.[].parsed_tag.service] | unique | length) != 1 or
+            ([.[].id] | unique | length) != 1
+          )
+      ] | length) == 0
+      and ([
+        ($rows | group_by(.id))[]
+        | select(
+            ([.[].parsed_tag.service] | unique | length) != 1 or
+            ([.[].digest] | unique | length) != 1
+          )
       ] | length) == 0
     ' "$inventory_file" >/dev/null ||
-    oci_die "OCI registry rows violate the exact tag, digest, or lifecycle contract"
+    oci_die "OCI registry aliases violate the exact tag, identity, digest, or lifecycle contract"
 }
 
 registry_digest_set() {
@@ -272,6 +390,17 @@ registry_digest_set() {
     .data.items[]?
     | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
     | .digest
+  ' "$inventory_file" | LC_ALL=C sort -u > "$destination"
+}
+
+registry_image_id_set() {
+  local inventory_file="$1"
+  local destination="$2"
+
+  jq -r '
+    .data.items[]?
+    | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+    | .id
   ' "$inventory_file" | LC_ALL=C sort -u > "$destination"
 }
 
@@ -293,11 +422,85 @@ registry_service_digest_set() {
   ' "$inventory_file" | LC_ALL=C sort -u > "$destination"
 }
 
+registry_alias_inventory() {
+  local inventory_file="$1"
+  local destination="$2"
+
+  jq -r '
+    def parsed_tag:
+      (.version // "")
+      | capture(
+          "^oci-(?<service>auth|backoffice|bet|client|event|gamemaster|moderation|resulting|slip)-(?<source_sha>[0-9a-f]{40})$"
+        );
+    .data.items[]?
+    | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+    | parsed_tag as $tag
+    | [$tag.source_sha, $tag.service, .digest, .id, .version]
+    | @tsv
+  ' "$inventory_file" |
+    LC_ALL=C sort -t $'\t' -k1,1 -k2,2 > "$destination"
+}
+
 active_registry_row_count() {
   jq -r '[
     .data.items[]?
     | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
   ] | length' "$1"
+}
+
+validate_alias_generations() {
+  local membership_file="$1"
+  local alias_file="$2"
+
+  awk -F '\t' -v expected_services="$EXPECTED_SERVICES" '
+    FNR == NR {
+      kind[$2] = $1
+      canonical[$2 SUBSEP $3] = $4
+      canonical_count[$2]++
+      canonical_sources[$2] = 1
+      next
+    }
+    NF != 5 || alias_seen[$1 SUBSEP $2]++ {
+      failed = 1
+      exit
+    }
+    {
+      alias[$1 SUBSEP $2] = $3
+      alias_count[$1]++
+      alias_sources[$1] = 1
+    }
+    END {
+      split(expected_services, services, " ")
+      for (source in alias_sources) {
+        matched = 0
+        for (candidate in canonical_sources) {
+          if (alias_count[source] > canonical_count[candidate]) {
+            continue
+          }
+          compatible = 1
+          for (service_index in services) {
+            service = services[service_index]
+            alias_key = source SUBSEP service
+            canonical_key = candidate SUBSEP service
+            if ((alias_key in alias) &&
+              alias[alias_key] != canonical[canonical_key]) {
+              compatible = 0
+            }
+          }
+          if (compatible) {
+            if (alias_count[source] == canonical_count[candidate] ||
+              kind[candidate] == "target") {
+              matched = 1
+            }
+          }
+        }
+        if (!matched) {
+          failed = 1
+        }
+      }
+      exit failed
+    }
+  ' "$membership_file" "$alias_file"
 }
 
 registry_accounting() {
@@ -341,6 +544,16 @@ registry_accounting() {
 
 list_images "$work_dir/before.json"
 validate_registry_rows "$work_dir/before.json" AVAILABLE
+registry_alias_inventory "$work_dir/before.json" "$work_dir/before-aliases.tsv"
+before_row_count="$(active_registry_row_count "$work_dir/before.json")"
+before_tag_generation_count="$(
+  cut -f1 "$work_dir/before-aliases.tsv" | LC_ALL=C sort -u | wc -l |
+    tr -d ' '
+)"
+((before_row_count <= MAX_REGISTRY_TAG_ROWS)) ||
+  oci_die "registry tag row count exceeds the bounded alias contract"
+((before_tag_generation_count <= MAX_REGISTRY_TAG_GENERATIONS)) ||
+  oci_die "registry tag generation count exceeds the bounded alias contract"
 
 jq -r \
   --rawfile target_sources "$work_dir/target-source-shas.txt" '
@@ -423,7 +636,7 @@ expected_images_before="$(
   wc -l < "$work_dir/expected-before-digests.txt" | tr -d ' '
 )"
 [[ "$expected_images_before" == \
-  "$((EXPECTED_PROTECTED_IMAGES + present_target_image_count))" ]] ||
+  "$((protected_image_count + present_target_image_count))" ]] ||
   oci_die "expected registry generations are not pairwise disjoint"
 
 {
@@ -431,12 +644,57 @@ expected_images_before="$(
   cat "$work_dir/protected.tsv"
 } | LC_ALL=C sort -u > "$work_dir/expected-service-digests.tsv"
 
+{
+  awk -F '\t' '{ print "protected\t" $1 "\t" $2 "\t" $3 }' \
+    "$work_dir/trusted-protected.tsv"
+  awk -F '\t' '{ print "target\t" $1 "\t" $2 "\t" $3 }' \
+    "$work_dir/target-registry.tsv"
+} > "$work_dir/known-generation-memberships.tsv"
+validate_alias_generations \
+  "$work_dir/known-generation-memberships.tsv" \
+  "$work_dir/before-aliases.tsv" ||
+  oci_die "registry alias generations do not match a complete protected or remaining target generation"
+
+cut -f1,2,3 "$work_dir/before-aliases.tsv" |
+  LC_ALL=C sort -u > "$work_dir/before-source-service-digests.tsv"
+if comm -23 \
+    "$work_dir/trusted-protected.tsv" \
+    "$work_dir/before-source-service-digests.tsv" |
+    grep -q .; then
+  oci_die "a canonical protected source tag is missing or has an unexpected digest"
+fi
+
 registry_digest_set "$work_dir/before.json" "$work_dir/before-digests.txt"
+registry_image_id_set "$work_dir/before.json" "$work_dir/before-image-ids.txt"
 registry_service_digest_set \
   "$work_dir/before.json" "$work_dir/before-service-digests.tsv"
-[[ "$(active_registry_row_count "$work_dir/before.json")" == \
-  "$expected_images_before" ]] ||
-  oci_die "registry contains duplicate or aliased image rows"
+before_image_id_count="$(
+  wc -l < "$work_dir/before-image-ids.txt" | tr -d ' '
+)"
+[[ "$before_image_id_count" == "$expected_images_before" ]] ||
+  oci_die "registry image IDs are not one-to-one with the expected unique digests"
+awk -F '\t' '
+  FNR == NR {
+    protected[$1] = 1
+    next
+  }
+  $3 in protected {
+    print $4
+  }
+' \
+  "$work_dir/protected-digests.txt" \
+  "$work_dir/before-aliases.tsv" |
+  LC_ALL=C sort -u > "$work_dir/protected-image-ids.txt"
+[[ "$(wc -l < "$work_dir/protected-image-ids.txt" | tr -d ' ')" == \
+  "$protected_image_count" ]] ||
+  oci_die "protected digests do not map one-to-one to immutable image OCIDs"
+cut -f4 "$work_dir/target-registry.tsv" |
+  LC_ALL=C sort -u > "$work_dir/target-image-ids.txt"
+if comm -12 \
+    "$work_dir/protected-image-ids.txt" "$work_dir/target-image-ids.txt" |
+    grep -q .; then
+  oci_die "obsolete generations overlap a protected image OCID"
+fi
 cmp -s \
   "$work_dir/expected-before-digests.txt" "$work_dir/before-digests.txt" ||
   oci_die "registry contains an unknown, missing, or unexpected image generation"
@@ -468,37 +726,69 @@ target_sources_json="$(
 target_sources_sha256="$(oci_sha256 < "$work_dir/target-source-shas.txt")"
 target_images_sha256="$(oci_sha256 < "$work_dir/target-registry.tsv")"
 protected_sha256="$(oci_sha256 < "$work_dir/protected.tsv")"
+protected_sources_sha256="$(
+  oci_sha256 < "$work_dir/trusted-protected.tsv"
+)"
+protected_image_ids_sha256="$(
+  oci_sha256 < "$work_dir/protected-image-ids.txt"
+)"
+before_alias_count="$((before_row_count - expected_images_before))"
 jq -n \
   --argjson target_source_shas "$target_sources_json" \
   --arg current_source_sha "$CURRENT_SOURCE_SHA" \
   --arg target_sources_sha256 "$target_sources_sha256" \
   --arg target_images_sha256 "$target_images_sha256" \
   --arg protected_sha256 "$protected_sha256" \
+  --arg protected_sources_sha256 "$protected_sources_sha256" \
+  --arg protected_image_ids_sha256 "$protected_image_ids_sha256" \
   --arg deletion_required "$deletion_required" \
   --argjson requested_target_generations "$target_generation_count" \
   --argjson present_target_generations "$present_target_generation_count" \
   --argjson present_target_images "$present_target_image_count" \
+  --argjson protected_unique_generations "$protected_unique_generation_count" \
   --argjson unique_images "$expected_images_before" \
+  --argjson unique_image_ids "$before_image_id_count" \
+  --argjson tag_rows "$before_row_count" \
+  --argjson alias_rows "$before_alias_count" \
+  --argjson tag_generations "$before_tag_generation_count" \
   '{
     target_source_shas: $target_source_shas,
     current_source_sha: $current_source_sha,
     target_sources_sha256: $target_sources_sha256,
     target_images_sha256: $target_images_sha256,
     protected_generations_sha256: $protected_sha256,
+    protected_source_tags_sha256: $protected_sources_sha256,
+    protected_image_ids_sha256: $protected_image_ids_sha256,
     requested_target_generations: $requested_target_generations,
     present_target_generations: $present_target_generations,
     present_target_images: $present_target_images,
+    protected_unique_generations: $protected_unique_generations,
     unique_images: $unique_images,
+    unique_image_ids: $unique_image_ids,
+    tag_rows: $tag_rows,
+    alias_rows: $alias_rows,
+    tag_generations: $tag_generations,
     deletion_required: ($deletion_required == "true")
   }' > "$OUTPUT_DIR/before-summary.json"
 
 if [[ "$deletion_required" == "true" ]]; then
+  list_images "$work_dir/pre-delete.json"
+  validate_registry_rows "$work_dir/pre-delete.json" AVAILABLE
+  registry_alias_inventory \
+    "$work_dir/pre-delete.json" "$work_dir/pre-delete-aliases.tsv"
+  cmp -s \
+    "$work_dir/before-aliases.tsv" "$work_dir/pre-delete-aliases.tsv" ||
+    oci_die "registry aliases changed after validation and before deletion"
+
   while IFS=$'\t' read -r _source _service _digest image_id; do
     oci artifacts container image delete \
       --image-id "$image_id" \
       --force >/dev/null
   done < "$OUTPUT_DIR/deletion-plan.tsv"
 fi
+
+grep '^protected' "$work_dir/known-generation-memberships.tsv" \
+  > "$work_dir/protected-generation-memberships.tsv"
 
 pruned=false
 for ((attempt = 1; attempt <= PRUNE_POLL_ATTEMPTS; attempt++)); do
@@ -510,9 +800,39 @@ for ((attempt = 1; attempt <= PRUNE_POLL_ATTEMPTS; attempt++)); do
       grep -q .; then
     if cmp -s \
       "$work_dir/protected-digests.txt" "$work_dir/after-digests.txt"; then
+      validate_registry_rows "$work_dir/after.json" AVAILABLE
+      registry_image_id_set \
+        "$work_dir/after.json" "$work_dir/after-image-ids.txt"
+      [[ "$(wc -l < "$work_dir/after-image-ids.txt" | tr -d ' ')" == \
+        "$protected_image_count" ]] ||
+        oci_die "protected digests no longer have one-to-one image IDs"
+      cmp -s \
+        "$work_dir/protected-image-ids.txt" \
+        "$work_dir/after-image-ids.txt" ||
+        oci_die "the exact protected image OCID set changed during pruning"
+      registry_service_digest_set \
+        "$work_dir/after.json" "$work_dir/after-service-digests.tsv"
+      cmp -s \
+        "$work_dir/protected.tsv" \
+        "$work_dir/after-service-digests.tsv" ||
+        oci_die "OCI registry retained an unexpected service or digest mapping"
+      registry_alias_inventory \
+        "$work_dir/after.json" "$work_dir/after-aliases.tsv"
+      validate_alias_generations \
+        "$work_dir/protected-generation-memberships.tsv" \
+        "$work_dir/after-aliases.tsv" ||
+        oci_die "OCI registry retained an incomplete or unknown protected alias generation"
+      cut -f1,2,3 "$work_dir/after-aliases.tsv" |
+        LC_ALL=C sort -u > "$work_dir/after-source-service-digests.tsv"
+      if comm -23 \
+        "$work_dir/trusted-protected.tsv" \
+        "$work_dir/after-source-service-digests.tsv" |
+        grep -q .; then
+        oci_die "a canonical protected source tag disappeared during pruning"
+      fi
       registry_accounting "$work_dir/accounting.json"
       if jq -e \
-        --argjson expected_images "$EXPECTED_PROTECTED_IMAGES" \
+        --argjson expected_images "$protected_image_count" \
         --argjson max_bytes "$OCI_REGISTRY_MAX_BYTES" '
           .image_count == $expected_images and
           .layers_size_bytes <= $max_bytes
@@ -532,35 +852,50 @@ done
 [[ "$pruned" == "true" ]] ||
   oci_die "OCI registry pruning did not reach the exact protected digest set"
 
-validate_registry_rows "$work_dir/after.json" AVAILABLE
-[[ "$(active_registry_row_count "$work_dir/after.json")" == \
-  "$EXPECTED_PROTECTED_IMAGES" ]] ||
-  oci_die "OCI registry retained duplicate or aliased image rows"
-registry_service_digest_set \
-  "$work_dir/after.json" "$work_dir/after-service-digests.tsv"
-cmp -s "$work_dir/protected.tsv" "$work_dir/after-service-digests.tsv" ||
-  oci_die "OCI registry retained an unexpected service or digest mapping"
 if comm -12 "$work_dir/target-digests.txt" "$work_dir/after-digests.txt" |
     grep -q .; then
   oci_die "obsolete registry digests remain after pruning"
 fi
 
 cp "$work_dir/target-registry.tsv" "$OUTPUT_DIR/deleted-images.tsv"
+cp "$work_dir/protected-image-ids.txt" "$OUTPUT_DIR/protected-image-ids.txt"
+cp "$work_dir/before-aliases.tsv" "$OUTPUT_DIR/before-aliases.tsv"
+cp "$work_dir/after-aliases.tsv" "$OUTPUT_DIR/after-aliases.tsv"
 jq -e . "$work_dir/accounting.json" > "$OUTPUT_DIR/registry-accounting.json"
+after_row_count="$(active_registry_row_count "$work_dir/after.json")"
+after_alias_count="$((after_row_count - protected_image_count))"
+after_tag_generation_count="$(
+  cut -f1 "$work_dir/after-aliases.tsv" | LC_ALL=C sort -u | wc -l |
+    tr -d ' '
+)"
 jq -n \
   --argjson target_source_shas "$target_sources_json" \
   --arg current_source_sha "$CURRENT_SOURCE_SHA" \
   --arg protected_sha256 "$protected_sha256" \
+  --arg protected_sources_sha256 "$protected_sources_sha256" \
+  --arg protected_image_ids_sha256 "$protected_image_ids_sha256" \
   --argjson requested_target_generations "$target_generation_count" \
   --argjson pruned_target_generations "$present_target_generation_count" \
-  --argjson unique_images "$EXPECTED_PROTECTED_IMAGES" \
+  --argjson protected_unique_generations "$protected_unique_generation_count" \
+  --argjson unique_images "$protected_image_count" \
+  --argjson unique_image_ids "$protected_image_count" \
+  --argjson tag_rows "$after_row_count" \
+  --argjson alias_rows "$after_alias_count" \
+  --argjson tag_generations "$after_tag_generation_count" \
   '{
     target_source_shas: $target_source_shas,
     current_source_sha: $current_source_sha,
     protected_generations_sha256: $protected_sha256,
+    protected_source_tags_sha256: $protected_sources_sha256,
+    protected_image_ids_sha256: $protected_image_ids_sha256,
     requested_target_generations: $requested_target_generations,
     pruned_target_generations: $pruned_target_generations,
+    protected_unique_generations: $protected_unique_generations,
     unique_images: $unique_images,
+    unique_image_ids: $unique_image_ids,
+    tag_rows: $tag_rows,
+    alias_rows: $alias_rows,
+    tag_generations: $tag_generations,
     terminal_status: "PRUNED"
   }' > "$OUTPUT_DIR/after-summary.json"
 

--- a/infra/oci/scripts/prune-registry-generation.sh
+++ b/infra/oci/scripts/prune-registry-generation.sh
@@ -9,8 +9,11 @@ TARGET_SOURCE_SHAS_FILE="${TARGET_SOURCE_SHAS_FILE:-}"
 TRUSTED_TARGET_IMAGES_FILE="${TRUSTED_TARGET_IMAGES_FILE:-}"
 PROTECTED_IMAGES_FILE="${PROTECTED_IMAGES_FILE:-}"
 TRUSTED_PROTECTED_IMAGES_FILE="${TRUSTED_PROTECTED_IMAGES_FILE:-}"
+VALIDATED_BEFORE_SUMMARY_FILE="${VALIDATED_BEFORE_SUMMARY_FILE:-}"
+REQUEST_PROVENANCE_FILE="${REQUEST_PROVENANCE_FILE:-}"
 CURRENT_SOURCE_SHA="${CURRENT_SOURCE_SHA:-}"
 OUTPUT_DIR="${OUTPUT_DIR:-artifacts/oci-registry-prune}"
+PRUNE_MODE="${PRUNE_MODE:-apply}"
 PRUNE_POLL_ATTEMPTS="${PRUNE_POLL_ATTEMPTS:-60}"
 PRUNE_POLL_SECONDS="${PRUNE_POLL_SECONDS:-10}"
 EXPECTED_SERVICES='auth backoffice bet client event gamemaster moderation resulting slip'
@@ -35,6 +38,8 @@ oci_require_ocid OCI_COMPARTMENT_OCID
   oci_die "PRUNE_POLL_SECONDS must be a nonnegative integer"
 [[ "$OCI_REGISTRY_MAX_BYTES" =~ ^[1-9][0-9]*$ ]] ||
   oci_die "OCI_REGISTRY_MAX_BYTES must be a positive integer"
+[[ "$PRUNE_MODE" == "validate" || "$PRUNE_MODE" == "apply" ]] ||
+  oci_die "PRUNE_MODE must be validate or apply"
 [[ -f "$TARGET_SOURCE_SHAS_FILE" ]] ||
   oci_die "TARGET_SOURCE_SHAS_FILE does not exist"
 [[ -f "$TRUSTED_TARGET_IMAGES_FILE" ]] ||
@@ -43,6 +48,17 @@ oci_require_ocid OCI_COMPARTMENT_OCID
   oci_die "PROTECTED_IMAGES_FILE does not exist"
 [[ -f "$TRUSTED_PROTECTED_IMAGES_FILE" ]] ||
   oci_die "TRUSTED_PROTECTED_IMAGES_FILE does not exist"
+[[ -f "$REQUEST_PROVENANCE_FILE" && ! -L "$REQUEST_PROVENANCE_FILE" ]] ||
+  oci_die "REQUEST_PROVENANCE_FILE must be a regular file"
+jq -e 'type == "object"' "$REQUEST_PROVENANCE_FILE" >/dev/null ||
+  oci_die "request provenance is not valid JSON"
+if [[ "$PRUNE_MODE" == "apply" ]]; then
+  [[ -f "$VALIDATED_BEFORE_SUMMARY_FILE" &&
+    ! -L "$VALIDATED_BEFORE_SUMMARY_FILE" ]] ||
+    oci_die "apply mode requires a regular validated before-summary file"
+  jq -e 'type == "object"' "$VALIDATED_BEFORE_SUMMARY_FILE" >/dev/null ||
+    oci_die "validated before-summary is not valid JSON"
+fi
 
 mkdir -p "$OUTPUT_DIR"
 work_dir="$(mktemp -d)"
@@ -701,6 +717,17 @@ cmp -s \
 cmp -s \
   "$work_dir/expected-service-digests.tsv" "$work_dir/before-service-digests.tsv" ||
   oci_die "registry service and digest mappings differ from trusted provenance"
+registry_accounting "$work_dir/before-accounting.json"
+jq -e \
+  --argjson expected_images "$expected_images_before" \
+  --argjson max_bytes "$OCI_REGISTRY_MAX_BYTES" '
+    .image_count == $expected_images and
+    .layers_size_bytes <= $max_bytes
+  ' "$work_dir/before-accounting.json" >/dev/null ||
+  oci_die "registry accounting does not match validated unique identities"
+before_layers_size_bytes="$(
+  jq -r '.layers_size_bytes' "$work_dir/before-accounting.json"
+)"
 
 deletion_required=true
 if [[ "$present_target_generation_count" == "0" ]]; then
@@ -732,6 +759,12 @@ protected_sources_sha256="$(
 protected_image_ids_sha256="$(
   oci_sha256 < "$work_dir/protected-image-ids.txt"
 )"
+registry_aliases_sha256="$(
+  oci_sha256 < "$work_dir/before-aliases.tsv"
+)"
+request_provenance_sha256="$(
+  oci_sha256 < "$REQUEST_PROVENANCE_FILE"
+)"
 before_alias_count="$((before_row_count - expected_images_before))"
 jq -n \
   --argjson target_source_shas "$target_sources_json" \
@@ -741,6 +774,8 @@ jq -n \
   --arg protected_sha256 "$protected_sha256" \
   --arg protected_sources_sha256 "$protected_sources_sha256" \
   --arg protected_image_ids_sha256 "$protected_image_ids_sha256" \
+  --arg registry_aliases_sha256 "$registry_aliases_sha256" \
+  --arg request_provenance_sha256 "$request_provenance_sha256" \
   --arg deletion_required "$deletion_required" \
   --argjson requested_target_generations "$target_generation_count" \
   --argjson present_target_generations "$present_target_generation_count" \
@@ -751,6 +786,7 @@ jq -n \
   --argjson tag_rows "$before_row_count" \
   --argjson alias_rows "$before_alias_count" \
   --argjson tag_generations "$before_tag_generation_count" \
+  --argjson registry_layers_size_bytes "$before_layers_size_bytes" \
   '{
     target_source_shas: $target_source_shas,
     current_source_sha: $current_source_sha,
@@ -759,6 +795,8 @@ jq -n \
     protected_generations_sha256: $protected_sha256,
     protected_source_tags_sha256: $protected_sources_sha256,
     protected_image_ids_sha256: $protected_image_ids_sha256,
+    registry_aliases_sha256: $registry_aliases_sha256,
+    request_provenance_sha256: $request_provenance_sha256,
     requested_target_generations: $requested_target_generations,
     present_target_generations: $present_target_generations,
     present_target_images: $present_target_images,
@@ -768,8 +806,32 @@ jq -n \
     tag_rows: $tag_rows,
     alias_rows: $alias_rows,
     tag_generations: $tag_generations,
+    registry_layers_size_bytes: $registry_layers_size_bytes,
     deletion_required: ($deletion_required == "true")
   }' > "$OUTPUT_DIR/before-summary.json"
+
+if [[ "$PRUNE_MODE" == "validate" ]]; then
+  cp "$work_dir/target-registry.tsv" "$OUTPUT_DIR/planned-images.tsv"
+  cp "$work_dir/protected-image-ids.txt" \
+    "$OUTPUT_DIR/protected-image-ids.txt"
+  cp "$work_dir/before-aliases.tsv" "$OUTPUT_DIR/before-aliases.tsv"
+  jq -e . "$work_dir/before-accounting.json" \
+    > "$OUTPUT_DIR/registry-accounting.json"
+  jq '. + {terminal_status: "VALIDATED"}' \
+    "$OUTPUT_DIR/before-summary.json" \
+    > "$OUTPUT_DIR/validation-summary.json"
+  echo "registry_generations_validated=$(paste -sd, "$work_dir/target-source-shas.txt")"
+  exit 0
+fi
+
+cmp -s \
+  "$VALIDATED_BEFORE_SUMMARY_FILE" "$OUTPUT_DIR/before-summary.json" ||
+  oci_die "live registry or trusted provenance changed since validation"
+cp "$VALIDATED_BEFORE_SUMMARY_FILE" \
+  "$OUTPUT_DIR/validated-before-summary.json"
+validated_before_summary_sha256="$(
+  oci_sha256 < "$VALIDATED_BEFORE_SUMMARY_FILE"
+)"
 
 if [[ "$deletion_required" == "true" ]]; then
   list_images "$work_dir/pre-delete.json"
@@ -779,6 +841,11 @@ if [[ "$deletion_required" == "true" ]]; then
   cmp -s \
     "$work_dir/before-aliases.tsv" "$work_dir/pre-delete-aliases.tsv" ||
     oci_die "registry aliases changed after validation and before deletion"
+  registry_accounting "$work_dir/pre-delete-accounting.json"
+  cmp -s \
+    "$work_dir/before-accounting.json" \
+    "$work_dir/pre-delete-accounting.json" ||
+    oci_die "registry accounting changed after validation and before deletion"
 
   while IFS=$'\t' read -r _source _service _digest image_id; do
     oci artifacts container image delete \
@@ -874,6 +941,10 @@ jq -n \
   --arg protected_sha256 "$protected_sha256" \
   --arg protected_sources_sha256 "$protected_sources_sha256" \
   --arg protected_image_ids_sha256 "$protected_image_ids_sha256" \
+  --arg registry_aliases_sha256 "$registry_aliases_sha256" \
+  --arg request_provenance_sha256 "$request_provenance_sha256" \
+  --arg validated_before_summary_sha256 \
+    "$validated_before_summary_sha256" \
   --argjson requested_target_generations "$target_generation_count" \
   --argjson pruned_target_generations "$present_target_generation_count" \
   --argjson protected_unique_generations "$protected_unique_generation_count" \
@@ -888,6 +959,9 @@ jq -n \
     protected_generations_sha256: $protected_sha256,
     protected_source_tags_sha256: $protected_sources_sha256,
     protected_image_ids_sha256: $protected_image_ids_sha256,
+    registry_aliases_sha256: $registry_aliases_sha256,
+    request_provenance_sha256: $request_provenance_sha256,
+    validated_before_summary_sha256: $validated_before_summary_sha256,
     requested_target_generations: $requested_target_generations,
     pruned_target_generations: $pruned_target_generations,
     protected_unique_generations: $protected_unique_generations,

--- a/infra/oci/scripts/prune-registry-generation.sh
+++ b/infra/oci/scripts/prune-registry-generation.sh
@@ -5,17 +5,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
-TARGET_IMAGES_FILE="${TARGET_IMAGES_FILE:-}"
+TARGET_SOURCE_SHAS_FILE="${TARGET_SOURCE_SHAS_FILE:-}"
+TRUSTED_TARGET_IMAGES_FILE="${TRUSTED_TARGET_IMAGES_FILE:-}"
 PROTECTED_IMAGES_FILE="${PROTECTED_IMAGES_FILE:-}"
-TARGET_SOURCE_SHA="${TARGET_SOURCE_SHA:-}"
 CURRENT_SOURCE_SHA="${CURRENT_SOURCE_SHA:-}"
 OUTPUT_DIR="${OUTPUT_DIR:-artifacts/oci-registry-prune}"
 PRUNE_POLL_ATTEMPTS="${PRUNE_POLL_ATTEMPTS:-60}"
 PRUNE_POLL_SECONDS="${PRUNE_POLL_SECONDS:-10}"
 EXPECTED_SERVICES='auth backoffice bet client event gamemaster moderation resulting slip'
-EXPECTED_TARGET_IMAGES=9
 EXPECTED_PROTECTED_IMAGES=27
-EXPECTED_IMAGES_BEFORE=36
+MAX_TARGET_GENERATIONS=10
 
 oci_require_cli_version
 oci_require_command jq
@@ -23,20 +22,18 @@ oci_require_vars \
   OCI_COMPARTMENT_OCID OCI_IMAGE_PREFIX OCI_REGISTRY_MAX_BYTES
 oci_require_ocid OCI_COMPARTMENT_OCID
 
-[[ "$TARGET_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
-  oci_die "TARGET_SOURCE_SHA must be a full commit SHA"
 [[ "$CURRENT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] ||
   oci_die "CURRENT_SOURCE_SHA must be a full commit SHA"
-[[ "$TARGET_SOURCE_SHA" != "$CURRENT_SOURCE_SHA" ]] ||
-  oci_die "current master cannot be pruned"
 [[ "$PRUNE_POLL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] ||
   oci_die "PRUNE_POLL_ATTEMPTS must be a positive integer"
 [[ "$PRUNE_POLL_SECONDS" =~ ^[0-9]+$ ]] ||
   oci_die "PRUNE_POLL_SECONDS must be a nonnegative integer"
 [[ "$OCI_REGISTRY_MAX_BYTES" =~ ^[1-9][0-9]*$ ]] ||
   oci_die "OCI_REGISTRY_MAX_BYTES must be a positive integer"
-[[ -f "$TARGET_IMAGES_FILE" ]] ||
-  oci_die "TARGET_IMAGES_FILE does not exist"
+[[ -f "$TARGET_SOURCE_SHAS_FILE" ]] ||
+  oci_die "TARGET_SOURCE_SHAS_FILE does not exist"
+[[ -f "$TRUSTED_TARGET_IMAGES_FILE" ]] ||
+  oci_die "TRUSTED_TARGET_IMAGES_FILE does not exist"
 [[ -f "$PROTECTED_IMAGES_FILE" ]] ||
   oci_die "PROTECTED_IMAGES_FILE does not exist"
 
@@ -46,6 +43,29 @@ cleanup() {
   rm -rf "$work_dir"
 }
 trap cleanup EXIT
+
+normalize_target_sources() {
+  awk -v current_sha="$CURRENT_SOURCE_SHA" '
+    function valid_sha(value) {
+      return length(value) == 40 && value ~ /^[0-9a-f]+$/
+    }
+    NF != 1 || !valid_sha($1) || $1 == current_sha || seen[$1]++ {
+      exit 1
+    }
+    {
+      print $1
+    }
+  ' "$TARGET_SOURCE_SHAS_FILE" | LC_ALL=C sort \
+    > "$work_dir/target-source-shas.txt" ||
+    oci_die "target source SHA validation failed"
+}
+
+normalize_target_sources
+target_generation_count="$(
+  wc -l < "$work_dir/target-source-shas.txt" | tr -d ' '
+)"
+((target_generation_count >= 1 && target_generation_count <= MAX_TARGET_GENERATIONS)) ||
+  oci_die "target generation count must be between 1 and $MAX_TARGET_GENERATIONS"
 
 repository="${OCI_IMAGE_PREFIX}_images"
 
@@ -78,19 +98,12 @@ read_provenance_repository() {
 }
 
 provenance_repository="$(
-  read_provenance_repository "$TARGET_IMAGES_FILE"
-)" || oci_die "target provenance does not identify one exact registry repository"
+  read_provenance_repository "$PROTECTED_IMAGES_FILE"
+)" || oci_die "protected provenance does not identify one exact registry repository"
 
-normalize_provenance() {
-  local source_file="$1"
-  local destination_file="$2"
-  local expected_rows="$3"
-  local expected_per_service="$4"
-
+normalize_protected_provenance() {
   awk -F '\t' \
     -v repository="$provenance_repository" \
-    -v expected_rows="$expected_rows" \
-    -v expected_per_service="$expected_per_service" \
     -v expected_services="$EXPECTED_SERVICES" '
       BEGIN {
         split(expected_services, services, " ")
@@ -103,20 +116,8 @@ normalize_provenance() {
           substr(value, 1, 7) == "sha256:" &&
           substr(value, 8) ~ /^[0-9a-f]+$/
       }
-      NF != 5 {
-        print "invalid image provenance column count" > "/dev/stderr"
-        exit 1
-      }
-      !($1 in allowed) {
-        print "unexpected image provenance service: " $1 > "/dev/stderr"
-        exit 1
-      }
-      $2 != repository {
-        print "unexpected image provenance repository" > "/dev/stderr"
-        exit 1
-      }
-      $3 != $2 "@" $4 || $4 != $5 || !valid_digest($4) {
-        print "invalid image provenance digest identity" > "/dev/stderr"
+      NF != 5 || !($1 in allowed) || $2 != repository ||
+        $3 != $2 "@" $4 || $4 != $5 || !valid_digest($4) {
         exit 1
       }
       {
@@ -126,46 +127,81 @@ normalize_provenance() {
         print $1 "\t" $4
       }
       END {
-        if (rows != expected_rows) {
-          print "unexpected image provenance row count" > "/dev/stderr"
+        if (rows != 27) {
           exit 1
         }
         for (service in allowed) {
-          if (service_count[service] != expected_per_service) {
-            print "incomplete image provenance service set" > "/dev/stderr"
+          if (service_count[service] != 3) {
             exit 1
           }
         }
         for (digest in digest_count) {
           if (digest_count[digest] != 1) {
-            print "duplicate image provenance digest" > "/dev/stderr"
             exit 1
           }
         }
       }
-    ' "$source_file" | LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
-      > "$destination_file" ||
-    oci_die "image provenance validation failed"
+    ' "$PROTECTED_IMAGES_FILE" |
+    LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
+      > "$work_dir/protected.tsv" ||
+    oci_die "protected image provenance validation failed"
 }
 
-normalize_provenance \
-  "$TARGET_IMAGES_FILE" "$work_dir/target.tsv" \
-  "$EXPECTED_TARGET_IMAGES" 1
-normalize_provenance \
-  "$PROTECTED_IMAGES_FILE" "$work_dir/protected.tsv" \
-  "$EXPECTED_PROTECTED_IMAGES" 3
+normalize_trusted_target_provenance() {
+  awk -F '\t' \
+    -v repository="$provenance_repository" \
+    -v target_file="$work_dir/target-source-shas.txt" \
+    -v expected_services="$EXPECTED_SERVICES" '
+      BEGIN {
+        while ((getline source < target_file) > 0) {
+          targets[source] = 1
+        }
+        close(target_file)
+        split(expected_services, services, " ")
+        for (service_index in services) {
+          allowed[services[service_index]] = 1
+        }
+      }
+      function valid_digest(value) {
+        return length(value) == 71 &&
+          substr(value, 1, 7) == "sha256:" &&
+          substr(value, 8) ~ /^[0-9a-f]+$/
+      }
+      NF != 6 || !($1 in targets) || !($2 in allowed) ||
+        $3 != repository || $4 != $3 "@" $5 || $5 != $6 ||
+        !valid_digest($5) || seen[$1 SUBSEP $2]++ || digest_seen[$5]++ {
+        exit 1
+      }
+      {
+        source_count[$1]++
+        print $1 "\t" $2 "\t" $5
+      }
+      END {
+        for (source in source_count) {
+          if (source_count[source] != 9) {
+            exit 1
+          }
+          for (service in allowed) {
+            if (!seen[source SUBSEP service]) {
+              exit 1
+            }
+          }
+        }
+      }
+    ' "$TRUSTED_TARGET_IMAGES_FILE" |
+    LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
+      > "$work_dir/trusted-targets.tsv" ||
+    oci_die "trusted target image provenance validation failed"
+}
 
-cut -f2 "$work_dir/target.tsv" | LC_ALL=C sort -u > "$work_dir/target-digests.txt"
-cut -f2 "$work_dir/protected.tsv" | LC_ALL=C sort -u > "$work_dir/protected-digests.txt"
-if comm -12 "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
-    grep -q .; then
-  oci_die "obsolete generation overlaps a protected generation"
-fi
-cat "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
-  LC_ALL=C sort -u > "$work_dir/expected-before-digests.txt"
-[[ "$(wc -l < "$work_dir/expected-before-digests.txt" | tr -d ' ')" == \
-  "$EXPECTED_IMAGES_BEFORE" ]] ||
-  oci_die "expected registry generations are not pairwise disjoint"
+normalize_protected_provenance
+normalize_trusted_target_provenance
+
+cut -f2 "$work_dir/protected.tsv" |
+  LC_ALL=C sort -u > "$work_dir/protected-digests.txt"
+[[ "$(wc -l < "$work_dir/protected-digests.txt" | tr -d ' ')" == \
+  "$EXPECTED_PROTECTED_IMAGES" ]] ||
+  oci_die "protected image provenance is not digest-unique"
 
 list_images() {
   local destination="$1"
@@ -239,6 +275,31 @@ registry_digest_set() {
   ' "$inventory_file" | LC_ALL=C sort -u > "$destination"
 }
 
+registry_service_digest_set() {
+  local inventory_file="$1"
+  local destination="$2"
+
+  jq -r '
+    def parsed_tag:
+      (.version // "")
+      | try capture(
+          "^oci-(?<service>auth|backoffice|bet|client|event|gamemaster|moderation|resulting|slip)-(?<source_sha>[0-9a-f]{40})$"
+        ) catch null;
+    .data.items[]?
+    | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+    | parsed_tag as $tag
+    | [$tag.service, .digest]
+    | @tsv
+  ' "$inventory_file" | LC_ALL=C sort -u > "$destination"
+}
+
+active_registry_row_count() {
+  jq -r '[
+    .data.items[]?
+    | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+  ] | length' "$1"
+}
+
 registry_accounting() {
   local destination="$1"
   local raw="$work_dir/repositories-raw.json"
@@ -280,72 +341,159 @@ registry_accounting() {
 
 list_images "$work_dir/before.json"
 validate_registry_rows "$work_dir/before.json" AVAILABLE
+
+jq -r \
+  --rawfile target_sources "$work_dir/target-source-shas.txt" '
+    def parsed_tag:
+      (.version // "")
+      | try capture(
+          "^oci-(?<service>auth|backoffice|bet|client|event|gamemaster|moderation|resulting|slip)-(?<source_sha>[0-9a-f]{40})$"
+        ) catch null;
+    ($target_sources | split("\n") | map(select(length > 0))) as $targets
+    | .data.items[]?
+    | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+    | parsed_tag as $tag
+    | select($tag != null and ($targets | index($tag.source_sha)) != null)
+    | [$tag.source_sha, $tag.service, .digest, .id]
+    | @tsv
+  ' "$work_dir/before.json" |
+  awk -F '\t' \
+    -v target_file="$work_dir/target-source-shas.txt" \
+    -v expected_services="$EXPECTED_SERVICES" '
+      BEGIN {
+        while ((getline source < target_file) > 0) {
+          targets[source] = 1
+        }
+        close(target_file)
+        split(expected_services, services, " ")
+        for (service_index in services) {
+          allowed[services[service_index]] = 1
+        }
+      }
+      NF != 4 || !($1 in targets) || !($2 in allowed) ||
+        seen_service[$1 SUBSEP $2]++ || seen_digest[$3]++ ||
+        seen_image_id[$4]++ {
+        exit 1
+      }
+      {
+        source_count[$1]++
+        print
+      }
+      END {
+        for (source in targets) {
+          if (source_count[source] > 9) {
+            exit 1
+          }
+        }
+      }
+    ' |
+  LC_ALL=C sort -t $'\t' -k1,1 -k2,2 \
+    > "$work_dir/target-registry.tsv" ||
+  oci_die "target registry rows are ambiguous or exceed one service set"
+
+cut -f1 "$work_dir/target-registry.tsv" |
+  LC_ALL=C sort -u > "$work_dir/present-target-sources.txt"
+present_target_generation_count="$(
+  wc -l < "$work_dir/present-target-sources.txt" | tr -d ' '
+)"
+present_target_image_count="$(
+  wc -l < "$work_dir/target-registry.tsv" | tr -d ' '
+)"
+cut -f1 "$work_dir/trusted-targets.tsv" |
+  LC_ALL=C sort -u > "$work_dir/trusted-target-sources.txt"
+
+while IFS=$'\t' read -r source service digest _image_id; do
+  if grep -Fxq "$source" "$work_dir/trusted-target-sources.txt"; then
+    expected_row="${source}"$'\t'"${service}"$'\t'"${digest}"
+    grep -Fqx "$expected_row" "$work_dir/trusted-targets.tsv" ||
+      oci_die "registry target differs from trusted successful-build provenance"
+  fi
+done < "$work_dir/target-registry.tsv"
+
+cut -f3 "$work_dir/target-registry.tsv" |
+  LC_ALL=C sort -u > "$work_dir/target-digests.txt"
+if comm -12 "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
+    grep -q .; then
+  oci_die "obsolete generations overlap a protected generation"
+fi
+
+cat "$work_dir/target-digests.txt" "$work_dir/protected-digests.txt" |
+  LC_ALL=C sort -u > "$work_dir/expected-before-digests.txt"
+expected_images_before="$(
+  wc -l < "$work_dir/expected-before-digests.txt" | tr -d ' '
+)"
+[[ "$expected_images_before" == \
+  "$((EXPECTED_PROTECTED_IMAGES + present_target_image_count))" ]] ||
+  oci_die "expected registry generations are not pairwise disjoint"
+
+{
+  cut -f2,3 "$work_dir/target-registry.tsv"
+  cat "$work_dir/protected.tsv"
+} | LC_ALL=C sort -u > "$work_dir/expected-service-digests.tsv"
+
 registry_digest_set "$work_dir/before.json" "$work_dir/before-digests.txt"
-deletion_required=true
-if cmp -s "$work_dir/expected-before-digests.txt" "$work_dir/before-digests.txt"; then
-  before_image_count="$EXPECTED_IMAGES_BEFORE"
-elif cmp -s "$work_dir/protected-digests.txt" "$work_dir/before-digests.txt"; then
-  deletion_required=false
-  before_image_count="$EXPECTED_PROTECTED_IMAGES"
-else
+registry_service_digest_set \
+  "$work_dir/before.json" "$work_dir/before-service-digests.tsv"
+[[ "$(active_registry_row_count "$work_dir/before.json")" == \
+  "$expected_images_before" ]] ||
+  oci_die "registry contains duplicate or aliased image rows"
+cmp -s \
+  "$work_dir/expected-before-digests.txt" "$work_dir/before-digests.txt" ||
   oci_die "registry contains an unknown, missing, or unexpected image generation"
+cmp -s \
+  "$work_dir/expected-service-digests.tsv" "$work_dir/before-service-digests.tsv" ||
+  oci_die "registry service and digest mappings differ from trusted provenance"
+
+deletion_required=true
+if [[ "$present_target_generation_count" == "0" ]]; then
+  deletion_required=false
 fi
 
 : > "$OUTPUT_DIR/deletion-plan.tsv"
 if [[ "$deletion_required" == "true" ]]; then
-  while IFS=$'\t' read -r service digest; do
-    version="oci-${service}-${TARGET_SOURCE_SHA}"
-    image_ids="$(
-      jq -r \
-        --arg digest "$digest" \
-        --arg version "$version" '
-          [
-            .data.items[]?
-            | select(
-                .digest == $digest and
-                .version == $version and
-                (."lifecycle-state" // "" | ascii_upcase) == "AVAILABLE"
-              )
-            | .id
-          ]
-          | unique[]
-        ' "$work_dir/before.json"
-    )"
-    [[ "$(awk 'NF {count++} END {print count+0}' <<<"$image_ids")" == "1" ]] ||
-      oci_die "target digest does not map to one exact source-tagged image"
-    image_id="$(awk 'NF {print; exit}' <<<"$image_ids")"
-    printf '%s\t%s\t%s\n' "$service" "$digest" "$image_id" \
-      >> "$OUTPUT_DIR/deletion-plan.tsv"
-  done < "$work_dir/target.tsv"
-
+  cp "$work_dir/target-registry.tsv" "$OUTPUT_DIR/deletion-plan.tsv"
+  expected_target_images="$present_target_image_count"
   [[ "$(wc -l < "$OUTPUT_DIR/deletion-plan.tsv" | tr -d ' ')" == \
-    "$EXPECTED_TARGET_IMAGES" ]] ||
+    "$expected_target_images" ]] ||
     oci_die "registry deletion plan is incomplete"
-  [[ "$(cut -f3 "$OUTPUT_DIR/deletion-plan.tsv" | LC_ALL=C sort -u | wc -l |
-    tr -d ' ')" == "$EXPECTED_TARGET_IMAGES" ]] ||
+  [[ "$(cut -f4 "$OUTPUT_DIR/deletion-plan.tsv" | LC_ALL=C sort -u | wc -l |
+    tr -d ' ')" == "$expected_target_images" ]] ||
     oci_die "registry deletion plan reuses an image OCID"
 fi
 
-target_sha256="$(oci_sha256 < "$work_dir/target.tsv")"
+target_sources_json="$(
+  jq -Rsc 'split("\n") | map(select(length > 0))' \
+    "$work_dir/target-source-shas.txt"
+)"
+target_sources_sha256="$(oci_sha256 < "$work_dir/target-source-shas.txt")"
+target_images_sha256="$(oci_sha256 < "$work_dir/target-registry.tsv")"
 protected_sha256="$(oci_sha256 < "$work_dir/protected.tsv")"
 jq -n \
-  --arg target_source_sha "$TARGET_SOURCE_SHA" \
+  --argjson target_source_shas "$target_sources_json" \
   --arg current_source_sha "$CURRENT_SOURCE_SHA" \
-  --arg target_sha256 "$target_sha256" \
+  --arg target_sources_sha256 "$target_sources_sha256" \
+  --arg target_images_sha256 "$target_images_sha256" \
   --arg protected_sha256 "$protected_sha256" \
   --arg deletion_required "$deletion_required" \
-  --argjson unique_images "$before_image_count" \
+  --argjson requested_target_generations "$target_generation_count" \
+  --argjson present_target_generations "$present_target_generation_count" \
+  --argjson present_target_images "$present_target_image_count" \
+  --argjson unique_images "$expected_images_before" \
   '{
-    target_source_sha: $target_source_sha,
+    target_source_shas: $target_source_shas,
     current_source_sha: $current_source_sha,
-    target_generation_sha256: $target_sha256,
+    target_sources_sha256: $target_sources_sha256,
+    target_images_sha256: $target_images_sha256,
     protected_generations_sha256: $protected_sha256,
+    requested_target_generations: $requested_target_generations,
+    present_target_generations: $present_target_generations,
+    present_target_images: $present_target_images,
     unique_images: $unique_images,
     deletion_required: ($deletion_required == "true")
   }' > "$OUTPUT_DIR/before-summary.json"
 
 if [[ "$deletion_required" == "true" ]]; then
-  while IFS=$'\t' read -r _service _digest image_id; do
+  while IFS=$'\t' read -r _source _service _digest image_id; do
     oci artifacts container image delete \
       --image-id "$image_id" \
       --force >/dev/null
@@ -385,24 +533,35 @@ done
   oci_die "OCI registry pruning did not reach the exact protected digest set"
 
 validate_registry_rows "$work_dir/after.json" AVAILABLE
+[[ "$(active_registry_row_count "$work_dir/after.json")" == \
+  "$EXPECTED_PROTECTED_IMAGES" ]] ||
+  oci_die "OCI registry retained duplicate or aliased image rows"
+registry_service_digest_set \
+  "$work_dir/after.json" "$work_dir/after-service-digests.tsv"
+cmp -s "$work_dir/protected.tsv" "$work_dir/after-service-digests.tsv" ||
+  oci_die "OCI registry retained an unexpected service or digest mapping"
 if comm -12 "$work_dir/target-digests.txt" "$work_dir/after-digests.txt" |
     grep -q .; then
   oci_die "obsolete registry digests remain after pruning"
 fi
 
-cp "$work_dir/target.tsv" "$OUTPUT_DIR/deleted-images.tsv"
+cp "$work_dir/target-registry.tsv" "$OUTPUT_DIR/deleted-images.tsv"
 jq -e . "$work_dir/accounting.json" > "$OUTPUT_DIR/registry-accounting.json"
 jq -n \
-  --arg target_source_sha "$TARGET_SOURCE_SHA" \
+  --argjson target_source_shas "$target_sources_json" \
   --arg current_source_sha "$CURRENT_SOURCE_SHA" \
   --arg protected_sha256 "$protected_sha256" \
+  --argjson requested_target_generations "$target_generation_count" \
+  --argjson pruned_target_generations "$present_target_generation_count" \
   --argjson unique_images "$EXPECTED_PROTECTED_IMAGES" \
   '{
-    target_source_sha: $target_source_sha,
+    target_source_shas: $target_source_shas,
     current_source_sha: $current_source_sha,
     protected_generations_sha256: $protected_sha256,
+    requested_target_generations: $requested_target_generations,
+    pruned_target_generations: $pruned_target_generations,
     unique_images: $unique_images,
     terminal_status: "PRUNED"
   }' > "$OUTPUT_DIR/after-summary.json"
 
-echo "registry_generation_pruned=$TARGET_SOURCE_SHA"
+echo "registry_generations_pruned=$(paste -sd, "$work_dir/target-source-shas.txt")"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -547,8 +547,11 @@ grep -Fq 'digest_service_conflict_count' "$inventory" ||
   fail "OCI inventory must reject cross-service digest identities"
 grep -Fq 'MAX_TARGET_GENERATIONS=10' "$registry_pruner" ||
   fail "registry pruning must bound the explicit obsolete generation set"
-grep -Fq 'EXPECTED_PROTECTED_IMAGES=27' "$registry_pruner" ||
-  fail "registry pruning must retain exactly three complete generations"
+grep -Fq 'EXPECTED_PROTECTED_PROVENANCE_ROWS=27' "$registry_pruner" ||
+  fail "registry pruning must bind three canonical protected source generations"
+grep -Fq 'protected_image_count % IMAGES_PER_GENERATION == 0' \
+  "$registry_pruner" ||
+  fail "registry pruning must retain only complete unique protected generations"
 grep -Fq 'obsolete generations overlap a protected generation' "$registry_pruner" ||
   fail "registry pruning does not reject protected digest overlap"
 grep -Fq 'registry contains an unknown, missing, or unexpected image generation' \
@@ -558,8 +561,22 @@ grep -Fq 'read_provenance_repository "$PROTECTED_IMAGES_FILE"' "$registry_pruner
   fail "registry pruning does not derive one exact protected repository"
 grep -Fq 'TRUSTED_TARGET_IMAGES_FILE' "$registry_pruner" ||
   fail "registry pruning does not cross-check successful obsolete builds"
-grep -Fq 'registry contains duplicate or aliased image rows' "$registry_pruner" ||
-  fail "registry pruning does not reject unaccounted image aliases"
+grep -Fq 'TRUSTED_PROTECTED_IMAGES_FILE' "$registry_pruner" ||
+  fail "registry pruning does not cross-check canonical protected source tags"
+grep -Fq 'validate_alias_generations' "$registry_pruner" ||
+  fail "registry pruning does not validate complete image alias generations"
+grep -Fq 'registry_image_id_set' "$registry_pruner" ||
+  fail "registry pruning does not separate unique image IDs from tag aliases"
+grep -Fq 'before-aliases.tsv' "$registry_pruner" ||
+  fail "registry pruning does not retain pre-delete alias evidence"
+grep -Fq 'registry aliases changed after validation and before deletion' \
+  "$registry_pruner" ||
+  fail "registry pruning does not revalidate its alias snapshot before deletion"
+grep -Fq 'the exact protected image OCID set changed during pruning' \
+  "$registry_pruner" ||
+  fail "registry pruning does not preserve the exact protected image OCID set"
+grep -Fq 'protected_image_ids_sha256' "$registry_pruner" ||
+  fail "registry pruning does not bind protected image OCIDs into evidence"
 grep -Fq 'OCI registry pruning did not reach the exact protected digest set' \
   "$registry_pruner" ||
   fail "registry pruning does not wait for asynchronous deletion"
@@ -762,6 +779,9 @@ grep -Fq 'oci-image-provenance-${obsolete_sha}-${obsolete_run_id}-1' \
   "$infra_workflow"
 grep -Fq 'target-source-shas.txt' "$infra_workflow"
 grep -Fq 'trusted-target-images.tsv' "$infra_workflow"
+grep -Fq 'trusted-protected-images.tsv' "$infra_workflow"
+grep -Fq '.unique_image_ids == .unique_images' "$infra_workflow"
+grep -Fq '.protected_image_ids_sha256 ==' "$infra_workflow"
 grep -Fq 'oci-image-provenance-${FALLBACK_SHA}-${FALLBACK_BUILD_RUN_ID}-1' \
   "$infra_workflow"
 grep -Fq 'oci-deploy-provenance-${DEPLOYED_RUN_ID}-1' "$infra_workflow"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -572,11 +572,23 @@ grep -Fq 'before-aliases.tsv' "$registry_pruner" ||
 grep -Fq 'registry aliases changed after validation and before deletion' \
   "$registry_pruner" ||
   fail "registry pruning does not revalidate its alias snapshot before deletion"
+grep -Fq 'registry accounting changed after validation and before deletion' \
+  "$registry_pruner" ||
+  fail "registry pruning does not revalidate accounting before deletion"
 grep -Fq 'the exact protected image OCID set changed during pruning' \
   "$registry_pruner" ||
   fail "registry pruning does not preserve the exact protected image OCID set"
 grep -Fq 'protected_image_ids_sha256' "$registry_pruner" ||
   fail "registry pruning does not bind protected image OCIDs into evidence"
+grep -Fq 'PRUNE_MODE must be validate or apply' "$registry_pruner" ||
+  fail "registry pruning does not separate read-only validation from apply"
+grep -Fq 'live registry or trusted provenance changed since validation' \
+  "$registry_pruner" ||
+  fail "registry pruning does not require the exact validated live snapshot"
+grep -Fq 'registry_aliases_sha256' "$registry_pruner" ||
+  fail "registry pruning does not bind the complete alias inventory"
+grep -Fq 'request_provenance_sha256' "$registry_pruner" ||
+  fail "registry pruning does not bind exact build and deployment run IDs"
 grep -Fq 'OCI registry pruning did not reach the exact protected digest set' \
   "$registry_pruner" ||
   fail "registry pruning does not wait for asynchronous deletion"
@@ -770,6 +782,15 @@ grep -Fq 'name: oci-infrastructure' "$infra_workflow"
 grep -Fq 'PROVISION OCI ZERO COST' "$infra_workflow"
 grep -Fq -- '- prune-registry' "$infra_workflow"
 grep -Fq 'PRUNE OBSOLETE OCI IMAGE GENERATION' "$infra_workflow"
+grep -Fq -- '- validate-registry' "$infra_workflow"
+grep -Fq 'VALIDATE OCI IMAGE GENERATIONS' "$infra_workflow"
+grep -Fq 'validation_run_id:' "$infra_workflow"
+grep -Fq 'validated-registry/before-summary.json' "$infra_workflow"
+grep -Fq 'betstan.oci-registry-prune-request.v1' "$infra_workflow"
+grep -Fq 'validated-registry/request-provenance.json' "$infra_workflow"
+grep -Fq "(inputs.phase == 'prepare' || inputs.phase == 'finalize')" \
+  "$infra_workflow" ||
+  fail "read-only registry validation can enter the provisioning job"
 grep -Fq 'prune-registry-generation.sh' "$infra_workflow"
 grep -Fq 'obsolete_generations:' "$infra_workflow"
 grep -Fq 'length <= 10' "$infra_workflow"

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -545,17 +545,21 @@ grep -Fq 'incomplete_tag_generation_count' "$inventory" ||
   fail "OCI inventory must reject incomplete service tag generations"
 grep -Fq 'digest_service_conflict_count' "$inventory" ||
   fail "OCI inventory must reject cross-service digest identities"
-grep -Fq 'EXPECTED_IMAGES_BEFORE=36' "$registry_pruner" ||
-  fail "registry pruning must require exactly four complete generations"
+grep -Fq 'MAX_TARGET_GENERATIONS=10' "$registry_pruner" ||
+  fail "registry pruning must bound the explicit obsolete generation set"
 grep -Fq 'EXPECTED_PROTECTED_IMAGES=27' "$registry_pruner" ||
   fail "registry pruning must retain exactly three complete generations"
-grep -Fq 'obsolete generation overlaps a protected generation' "$registry_pruner" ||
+grep -Fq 'obsolete generations overlap a protected generation' "$registry_pruner" ||
   fail "registry pruning does not reject protected digest overlap"
 grep -Fq 'registry contains an unknown, missing, or unexpected image generation' \
   "$registry_pruner" ||
   fail "registry pruning does not fail closed on unknown images"
-grep -Fq 'read_provenance_repository "$TARGET_IMAGES_FILE"' "$registry_pruner" ||
-  fail "registry pruning does not derive one exact provenance repository"
+grep -Fq 'read_provenance_repository "$PROTECTED_IMAGES_FILE"' "$registry_pruner" ||
+  fail "registry pruning does not derive one exact protected repository"
+grep -Fq 'TRUSTED_TARGET_IMAGES_FILE' "$registry_pruner" ||
+  fail "registry pruning does not cross-check successful obsolete builds"
+grep -Fq 'registry contains duplicate or aliased image rows' "$registry_pruner" ||
+  fail "registry pruning does not reject unaccounted image aliases"
 grep -Fq 'OCI registry pruning did not reach the exact protected digest set' \
   "$registry_pruner" ||
   fail "registry pruning does not wait for asynchronous deletion"
@@ -750,8 +754,14 @@ grep -Fq 'PROVISION OCI ZERO COST' "$infra_workflow"
 grep -Fq -- '- prune-registry' "$infra_workflow"
 grep -Fq 'PRUNE OBSOLETE OCI IMAGE GENERATION' "$infra_workflow"
 grep -Fq 'prune-registry-generation.sh' "$infra_workflow"
-grep -Fq 'oci-image-provenance-${OBSOLETE_SHA}-${OBSOLETE_BUILD_RUN_ID}-1' \
+grep -Fq 'obsolete_generations:' "$infra_workflow"
+grep -Fq 'length <= 10' "$infra_workflow"
+grep -Fq '(.conclusion == "success" or .conclusion == "failure")' \
   "$infra_workflow"
+grep -Fq 'oci-image-provenance-${obsolete_sha}-${obsolete_run_id}-1' \
+  "$infra_workflow"
+grep -Fq 'target-source-shas.txt' "$infra_workflow"
+grep -Fq 'trusted-target-images.tsv' "$infra_workflow"
 grep -Fq 'oci-image-provenance-${FALLBACK_SHA}-${FALLBACK_BUILD_RUN_ID}-1' \
   "$infra_workflow"
 grep -Fq 'oci-deploy-provenance-${DEPLOYED_RUN_ID}-1' "$infra_workflow"

--- a/infra/oci/tests/test-registry-prune-contract.sh
+++ b/infra/oci/tests/test-registry-prune-contract.sh
@@ -5,10 +5,12 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 OCI_DIR="$ROOT_DIR/infra/oci"
 WORK_DIR="$OCI_DIR/tests/.registry-prune-work"
 SERVICES=(auth backoffice bet client event gamemaster moderation resulting slip)
-TARGET_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+TARGET_ONE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 DEPLOYED_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 ROLLBACK_SHA="cccccccccccccccccccccccccccccccccccccccc"
 CURRENT_SHA="dddddddddddddddddddddddddddddddddddddddd"
+TARGET_TWO_SHA="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+FAILED_TARGET_SHA="ffffffffffffffffffffffffffffffffffffffff"
 REPOSITORY="fra.ocir.io/example/betstan_images"
 
 fail() {
@@ -27,9 +29,8 @@ digest_for() {
 }
 
 write_generation() {
-  local source_sha="$1"
-  local generation="$2"
-  local output_file="$3"
+  local generation="$1"
+  local output_file="$2"
   local service_index service digest
 
   : > "$output_file"
@@ -42,21 +43,38 @@ write_generation() {
   done
 }
 
-write_generation "$TARGET_SHA" 0 "$WORK_DIR/target.tsv"
-write_generation "$DEPLOYED_SHA" 1 "$WORK_DIR/deployed.tsv"
-write_generation "$ROLLBACK_SHA" 2 "$WORK_DIR/rollback.tsv"
-write_generation "$CURRENT_SHA" 3 "$WORK_DIR/current.tsv"
+write_generation 0 "$WORK_DIR/target-one.tsv"
+write_generation 1 "$WORK_DIR/deployed.tsv"
+write_generation 2 "$WORK_DIR/rollback.tsv"
+write_generation 3 "$WORK_DIR/current.tsv"
+write_generation 4 "$WORK_DIR/target-two.tsv"
+write_generation 5 "$WORK_DIR/failed-target.tsv"
 cat \
   "$WORK_DIR/current.tsv" \
   "$WORK_DIR/deployed.tsv" \
   "$WORK_DIR/rollback.tsv" \
   > "$WORK_DIR/protected.tsv"
+printf '%s\n' \
+  "$TARGET_ONE_SHA" \
+  "$TARGET_TWO_SHA" \
+  "$FAILED_TARGET_SHA" \
+  > "$WORK_DIR/target-source-shas.txt"
+{
+  awk -F '\t' -v sha="$TARGET_ONE_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/target-one.tsv"
+  awk -F '\t' -v sha="$TARGET_TWO_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/target-two.tsv"
+} > "$WORK_DIR/trusted-target-images.tsv"
 
 jq -n \
-  --arg target_sha "$TARGET_SHA" \
+  --arg target_one_sha "$TARGET_ONE_SHA" \
   --arg deployed_sha "$DEPLOYED_SHA" \
   --arg rollback_sha "$ROLLBACK_SHA" \
-  --arg current_sha "$CURRENT_SHA" '
+  --arg current_sha "$CURRENT_SHA" \
+  --arg target_two_sha "$TARGET_TWO_SHA" \
+  --arg failed_target_sha "$FAILED_TARGET_SHA" '
     def services: [
       "auth", "backoffice", "bet", "client", "event", "gamemaster",
       "moderation", "resulting", "slip"
@@ -65,10 +83,12 @@ jq -n \
       ($value | tostring) as $text
       | ("0" * ($width - ($text | length))) + $text;
     [
-      [$target_sha, 0],
+      [$target_one_sha, 0],
       [$deployed_sha, 1],
       [$rollback_sha, 2],
-      [$current_sha, 3]
+      [$current_sha, 3],
+      [$target_two_sha, 4],
+      [$failed_target_sha, 5]
     ] as $generations
     | {
         data: {
@@ -94,6 +114,7 @@ jq -n \
         }
       }
   ' > "$WORK_DIR/state/images.json"
+cp "$WORK_DIR/state/images.json" "$WORK_DIR/state/images-original.json"
 
 cat > "$WORK_DIR/bin/oci" <<'MOCK'
 #!/usr/bin/env bash
@@ -146,6 +167,9 @@ MOCK
 chmod +x "$WORK_DIR/bin/oci"
 
 run_prune() {
+  local protected_file="${TEST_PROTECTED_IMAGES_FILE:-$WORK_DIR/protected.tsv}"
+  local trusted_target_file="${TEST_TRUSTED_TARGET_IMAGES_FILE:-$WORK_DIR/trusted-target-images.tsv}"
+
   env \
     PATH="$WORK_DIR/bin:$PATH" \
     MOCK_OCI_LOG="$WORK_DIR/oci.log" \
@@ -154,9 +178,9 @@ run_prune() {
     OCI_COMPARTMENT_OCID=ocid1.compartment.oc1..fixture \
     OCI_IMAGE_PREFIX=betstan \
     OCI_REGISTRY_MAX_BYTES=500000000 \
-    TARGET_IMAGES_FILE="$WORK_DIR/target.tsv" \
-    PROTECTED_IMAGES_FILE="$WORK_DIR/protected.tsv" \
-    TARGET_SOURCE_SHA="$TARGET_SHA" \
+    TARGET_SOURCE_SHAS_FILE="$WORK_DIR/target-source-shas.txt" \
+    TRUSTED_TARGET_IMAGES_FILE="$trusted_target_file" \
+    PROTECTED_IMAGES_FILE="$protected_file" \
     CURRENT_SOURCE_SHA="$CURRENT_SHA" \
     OUTPUT_DIR="$WORK_DIR/evidence" \
     PRUNE_POLL_ATTEMPTS=1 \
@@ -164,69 +188,109 @@ run_prune() {
     "$OCI_DIR/scripts/prune-registry-generation.sh"
 }
 
+: > "$WORK_DIR/oci.log"
 run_prune
-[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "9" ]] ||
-  fail "prune did not delete exactly one complete generation"
-jq -e '
-  .terminal_status == "PRUNED" and
-  .unique_images == 27
-' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
-  fail "prune did not emit terminal evidence"
-[[ "$(wc -l < "$WORK_DIR/evidence/deleted-images.tsv" | tr -d ' ')" == "9" ]] ||
-  fail "prune evidence does not contain nine deleted service images"
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "27" ]] ||
+  fail "batch prune did not delete exactly three complete generations"
+jq -e \
+  --arg one "$TARGET_ONE_SHA" \
+  --arg two "$TARGET_TWO_SHA" \
+  --arg failed "$FAILED_TARGET_SHA" '
+    .terminal_status == "PRUNED" and
+    .target_source_shas == [$one, $two, $failed] and
+    .requested_target_generations == 3 and
+    .pruned_target_generations == 3 and
+    .unique_images == 27
+  ' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
+  fail "batch prune did not emit terminal evidence"
+[[ "$(wc -l < "$WORK_DIR/evidence/deleted-images.tsv" | tr -d ' ')" == "27" ]] ||
+  fail "batch prune evidence does not contain 27 deleted service images"
 [[ "$(
   jq -c '[.data.items | length, ([.[] | .digest] | unique | length)]' \
     "$WORK_DIR/state/images.json"
 )" == "[27,27]" ]] ||
-  fail "prune did not retain exactly three complete generations"
+  fail "batch prune did not retain exactly three complete generations"
 
 rm -rf "$WORK_DIR/evidence"
 : > "$WORK_DIR/oci.log"
 run_prune
 [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
-  fail "an already-pruned generation was deleted again"
+  fail "an already-pruned target generation was deleted again"
 jq -e '
   .deletion_required == false and
+  .present_target_generations == 0 and
   .unique_images == 27
 ' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
-  fail "an already-pruned generation was not resumed idempotently"
+  fail "an already-pruned batch was not resumed idempotently"
 
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
 rm -rf "$WORK_DIR/evidence"
 : > "$WORK_DIR/oci.log"
-cp "$WORK_DIR/current.tsv" "$WORK_DIR/protected-overlap.tsv"
 cat \
+  "$WORK_DIR/current.tsv" \
   "$WORK_DIR/deployed.tsv" \
-  "$WORK_DIR/target.tsv" \
-  >> "$WORK_DIR/protected-overlap.tsv"
-if env \
-  PATH="$WORK_DIR/bin:$PATH" \
-  MOCK_OCI_LOG="$WORK_DIR/oci.log" \
-  MOCK_OCI_STATE="$WORK_DIR/state" \
-  OCI_CLI_VERSION=3.90.0 \
-  OCI_COMPARTMENT_OCID=ocid1.compartment.oc1..fixture \
-  OCI_IMAGE_PREFIX=betstan \
-  OCI_REGISTRY_MAX_BYTES=500000000 \
-  TARGET_IMAGES_FILE="$WORK_DIR/target.tsv" \
-  PROTECTED_IMAGES_FILE="$WORK_DIR/protected-overlap.tsv" \
-  TARGET_SOURCE_SHA="$TARGET_SHA" \
-  CURRENT_SOURCE_SHA="$CURRENT_SHA" \
-  OUTPUT_DIR="$WORK_DIR/evidence" \
-  PRUNE_POLL_ATTEMPTS=1 \
-  PRUNE_POLL_SECONDS=0 \
-  "$OCI_DIR/scripts/prune-registry-generation.sh" >/dev/null 2>&1; then
+  "$WORK_DIR/target-one.tsv" \
+  > "$WORK_DIR/protected-overlap.tsv"
+if TEST_PROTECTED_IMAGES_FILE="$WORK_DIR/protected-overlap.tsv" run_prune \
+  >/dev/null 2>&1; then
   fail "overlapping protected and target generations were accepted"
 fi
 [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
   fail "overlap rejection happened after a delete"
 
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+cp "$WORK_DIR/trusted-target-images.tsv" "$WORK_DIR/trusted-target-images-mismatch.tsv"
+sed '1s/sha256:[0-9a-f]\{64\}/sha256:9999999999999999999999999999999999999999999999999999999999999999/g' \
+  "$WORK_DIR/trusted-target-images-mismatch.tsv" \
+  > "$WORK_DIR/trusted-target-images-mismatch.tmp"
+mv \
+  "$WORK_DIR/trusted-target-images-mismatch.tmp" \
+  "$WORK_DIR/trusted-target-images-mismatch.tsv"
+if TEST_TRUSTED_TARGET_IMAGES_FILE="$WORK_DIR/trusted-target-images-mismatch.tsv" \
+  run_prune >/dev/null 2>&1; then
+  fail "registry drift from trusted target provenance was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "trusted target mismatch was rejected after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+jq \
+  --arg trusted_sha "$TARGET_ONE_SHA" \
+  --arg failed_sha "$FAILED_TARGET_SHA" '
+  .data.items |= (
+    map(select(
+      .version != ("oci-auth-" + $trusted_sha) and
+      .version != ("oci-auth-" + $failed_sha)
+    ))
+  )
+' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+run_prune
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "25" ]] ||
+  fail "partial batch recovery did not delete every remaining target image"
+jq -e '
+  .deletion_required == true and
+  .present_target_generations == 3 and
+  .present_target_images == 25 and
+  .unique_images == 52
+' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
+  fail "partial batch recovery did not record its exact starting state"
+[[ "$(jq '[.data.items[]] | length' "$WORK_DIR/state/images.json")" == "27" ]] ||
+  fail "partial batch recovery did not retain exactly the protected images"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
 rm -rf "$WORK_DIR/evidence"
 : > "$WORK_DIR/oci.log"
 jq '
   .data.items += [{
     id: "ocid1.containerimage.oc1..fixture999",
     "repository-name": "betstan_images",
-    version: "oci-auth-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-    digest: ("sha256:" + ("f" * 64)),
+    version: "oci-auth-9999999999999999999999999999999999999999",
+    digest: ("sha256:" + ("9" * 64)),
     "lifecycle-state": "AVAILABLE"
   }]
 ' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"

--- a/infra/oci/tests/test-registry-prune-contract.sh
+++ b/infra/oci/tests/test-registry-prune-contract.sh
@@ -78,6 +78,31 @@ printf '%s\n' \
     'BEGIN { OFS = "\t" } { print sha, $0 }' \
     "$WORK_DIR/target-two.tsv"
 } > "$WORK_DIR/trusted-target-images.tsv"
+jq -cnS \
+  --arg source_sha "$CURRENT_SHA" \
+  --arg deployed_sha "$DEPLOYED_SHA" \
+  --arg rollback_sha "$ROLLBACK_SHA" \
+  --arg target_one_sha "$TARGET_ONE_SHA" \
+  --arg target_two_sha "$TARGET_TWO_SHA" \
+  --arg failed_target_sha "$FAILED_TARGET_SHA" '
+    {
+      schema: "betstan.oci-registry-prune-request.v1",
+      source_sha: $source_sha,
+      candidate_build_run_id: "1001",
+      deployed_sha: $deployed_sha,
+      deployed_run_id: "1002",
+      fallback_sha: $rollback_sha,
+      fallback_build_run_id: "1003",
+      obsolete_generations: [
+        {sha: $target_one_sha, build_run_id: "2001"},
+        {sha: $target_two_sha, build_run_id: "2002"},
+        {sha: $failed_target_sha, build_run_id: "2003"}
+      ]
+    }
+  ' > "$WORK_DIR/request-provenance.json"
+cp \
+  "$WORK_DIR/request-provenance.json" \
+  "$WORK_DIR/request-provenance-original.json"
 
 jq -n \
   --arg target_one_sha "$TARGET_ONE_SHA" \
@@ -190,16 +215,30 @@ case "$*" in
     cat "${MOCK_OCI_STATE:?}/images.json"
     ;;
   "artifacts container repository list "*)
+    repository_list_count_file="${MOCK_OCI_STATE:?}/repository-list-count"
+    repository_list_count=0
+    if [[ -f "$repository_list_count_file" ]]; then
+      repository_list_count="$(cat "$repository_list_count_file")"
+    fi
+    repository_list_count="$((repository_list_count + 1))"
+    printf '%s\n' "$repository_list_count" > "$repository_list_count_file"
+    layers_size_bytes=300000000
+    if [[ -n "${MOCK_OCI_ACCOUNTING_DRIFT_ON_LIST_CALL:-}" &&
+          "$repository_list_count" == "$MOCK_OCI_ACCOUNTING_DRIFT_ON_LIST_CALL" ]]; then
+      layers_size_bytes=300000001
+    fi
     image_count="$(
       jq '[.data.items[].digest] | unique | length' \
         "${MOCK_OCI_STATE:?}/images.json"
     )"
-    jq -n --argjson image_count "$image_count" '{
+    jq -n \
+      --argjson image_count "$image_count" \
+      --argjson layers_size_bytes "$layers_size_bytes" '{
       data: {
         items: [{
           "display-name": "betstan_images",
           "image-count": $image_count,
-          "layers-size-in-bytes": 300000000
+          "layers-size-in-bytes": $layers_size_bytes
         }]
       }
     }'
@@ -238,6 +277,7 @@ run_prune() {
     MOCK_OCI_STATE="$WORK_DIR/state" \
     MOCK_OCI_MUTATE_ON_LIST_CALL="${MOCK_OCI_MUTATE_ON_LIST_CALL:-}" \
     MOCK_OCI_REKEY_ON_LIST_CALL="${MOCK_OCI_REKEY_ON_LIST_CALL:-}" \
+    MOCK_OCI_ACCOUNTING_DRIFT_ON_LIST_CALL="${MOCK_OCI_ACCOUNTING_DRIFT_ON_LIST_CALL:-}" \
     OCI_CLI_VERSION=3.90.0 \
     OCI_COMPARTMENT_OCID=ocid1.compartment.oc1..fixture \
     OCI_IMAGE_PREFIX=betstan \
@@ -246,15 +286,49 @@ run_prune() {
     TRUSTED_TARGET_IMAGES_FILE="$trusted_target_file" \
     PROTECTED_IMAGES_FILE="$protected_file" \
     TRUSTED_PROTECTED_IMAGES_FILE="$trusted_protected_file" \
+    REQUEST_PROVENANCE_FILE="$WORK_DIR/request-provenance.json" \
+    VALIDATED_BEFORE_SUMMARY_FILE="$WORK_DIR/validated-before-summary.json" \
     CURRENT_SOURCE_SHA="$CURRENT_SHA" \
     OUTPUT_DIR="$WORK_DIR/evidence" \
+    PRUNE_MODE="${TEST_PRUNE_MODE:-apply}" \
     PRUNE_POLL_ATTEMPTS=1 \
     PRUNE_POLL_SECONDS=0 \
     "$OCI_DIR/scripts/prune-registry-generation.sh"
 }
 
-: > "$WORK_DIR/oci.log"
-rm -f "$WORK_DIR/state/list-count"
+prepare_validation() {
+  rm -rf "$WORK_DIR/evidence" "$WORK_DIR/validation-evidence"
+  : > "$WORK_DIR/oci.log"
+  rm -f \
+    "$WORK_DIR/state/list-count" \
+    "$WORK_DIR/state/repository-list-count"
+  TEST_PRUNE_MODE=validate run_prune
+  [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+    fail "read-only registry validation attempted deletion"
+  jq -e '.terminal_status == "VALIDATED"' \
+    "$WORK_DIR/evidence/validation-summary.json" >/dev/null ||
+    fail "registry validation did not emit terminal evidence"
+  cp \
+    "$WORK_DIR/evidence/before-summary.json" \
+    "$WORK_DIR/validated-before-summary.json"
+  mv "$WORK_DIR/evidence" "$WORK_DIR/validation-evidence"
+  : > "$WORK_DIR/oci.log"
+  rm -f \
+    "$WORK_DIR/state/list-count" \
+    "$WORK_DIR/state/repository-list-count"
+}
+
+prepare_validation
+jq -e '
+  .terminal_status == "VALIDATED" and
+  .present_target_images == 27 and
+  .unique_images == 54 and
+  .unique_image_ids == 54 and
+  .tag_rows == 360 and
+  .alias_rows == 306 and
+  .tag_generations == 40
+' "$WORK_DIR/validation-evidence/validation-summary.json" >/dev/null ||
+  fail "read-only validation did not capture the production-shaped inventory"
 run_prune
 [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "27" ]] ||
   fail "batch prune did not delete exactly three complete generations"
@@ -284,6 +358,13 @@ jq -e \
     .tag_generations == 21
   ' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
   fail "batch prune did not emit terminal evidence"
+validated_before_summary_sha256="$(
+  shasum -a 256 "$WORK_DIR/evidence/validated-before-summary.json" |
+    awk '{ print $1 }'
+)"
+[[ "$(jq -r '.validated_before_summary_sha256' "$WORK_DIR/evidence/after-summary.json")" == \
+    "$validated_before_summary_sha256" ]] ||
+  fail "batch prune did not bind the exact read-only validation snapshot"
 [[ "$(wc -l < "$WORK_DIR/evidence/deleted-images.tsv" | tr -d ' ')" == "27" ]] ||
   fail "batch prune evidence does not contain 27 deleted service images"
 protected_image_ids_sha256="$(
@@ -309,9 +390,7 @@ protected_image_ids_sha256="$(
 )" == "[189,27,27]" ]] ||
   fail "batch prune did not retain exactly three protected alias generations"
 
-rm -rf "$WORK_DIR/evidence"
-: > "$WORK_DIR/oci.log"
-rm -f "$WORK_DIR/state/list-count"
+prepare_validation
 run_prune
 [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
   fail "an already-pruned target generation was deleted again"
@@ -327,9 +406,55 @@ jq -e '
   fail "an already-pruned batch was not resumed idempotently"
 
 cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
-rm -rf "$WORK_DIR/evidence"
-: > "$WORK_DIR/oci.log"
-rm -f "$WORK_DIR/state/list-count"
+cp \
+  "$WORK_DIR/request-provenance-original.json" \
+  "$WORK_DIR/request-provenance.json"
+prepare_validation
+jq -cS '.candidate_build_run_id = "9999"' \
+  "$WORK_DIR/request-provenance.json" \
+  > "$WORK_DIR/request-provenance.tmp"
+mv "$WORK_DIR/request-provenance.tmp" "$WORK_DIR/request-provenance.json"
+if run_prune >/dev/null 2>&1; then
+  fail "same-SHA validation replay with a different run ID was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "request provenance replay was rejected after a delete"
+cp \
+  "$WORK_DIR/request-provenance-original.json" \
+  "$WORK_DIR/request-provenance.json"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+prepare_validation
+jq --arg current_sha "$CURRENT_SHA" '
+  def services: [
+    "auth", "backoffice", "bet", "client", "event", "gamemaster",
+    "moderation", "resulting", "slip"
+  ];
+  .data.items as $rows
+  | .data.items += [
+      range(0; 9) as $service_index
+      | ($rows[]
+        | select(
+            .version ==
+            ("oci-" + services[$service_index] + "-" + $current_sha)
+          ))
+      | . + {
+          version: (
+            "oci-" + services[$service_index] + "-" +
+            "6666666666666666666666666666666666666666"
+          )
+        }
+    ]
+' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+if run_prune >/dev/null 2>&1; then
+  fail "registry changes after read-only validation were accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "stale validation was rejected after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+prepare_validation
 if MOCK_OCI_MUTATE_ON_LIST_CALL=2 run_prune >/dev/null 2>&1; then
   fail "registry alias drift immediately before deletion was accepted"
 fi
@@ -337,9 +462,16 @@ fi
   fail "pre-delete alias drift was rejected after a delete"
 
 cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
-rm -rf "$WORK_DIR/evidence"
-: > "$WORK_DIR/oci.log"
-rm -f "$WORK_DIR/state/list-count"
+prepare_validation
+if MOCK_OCI_ACCOUNTING_DRIFT_ON_LIST_CALL=2 \
+  run_prune >/dev/null 2>&1; then
+  fail "registry accounting drift immediately before deletion was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "pre-delete accounting drift was rejected after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+prepare_validation
 if MOCK_OCI_REKEY_ON_LIST_CALL=3 run_prune >/dev/null 2>&1; then
   fail "post-delete protected image OCID substitution was accepted"
 fi
@@ -414,6 +546,9 @@ jq \
       )
   ' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
 mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+TEST_PROTECTED_IMAGES_FILE="$WORK_DIR/protected-reused.tsv" \
+  TEST_TRUSTED_PROTECTED_IMAGES_FILE="$WORK_DIR/trusted-protected-reused.tsv" \
+  prepare_validation
 TEST_PROTECTED_IMAGES_FILE="$WORK_DIR/protected-reused.tsv" \
   TEST_TRUSTED_PROTECTED_IMAGES_FILE="$WORK_DIR/trusted-protected-reused.tsv" \
   run_prune
@@ -515,6 +650,7 @@ jq \
     ))
 ' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
 mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+prepare_validation
 run_prune
 [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "25" ]] ||
   fail "partial batch recovery did not delete every remaining target image"

--- a/infra/oci/tests/test-registry-prune-contract.sh
+++ b/infra/oci/tests/test-registry-prune-contract.sh
@@ -54,6 +54,17 @@ cat \
   "$WORK_DIR/deployed.tsv" \
   "$WORK_DIR/rollback.tsv" \
   > "$WORK_DIR/protected.tsv"
+{
+  awk -F '\t' -v sha="$CURRENT_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/current.tsv"
+  awk -F '\t' -v sha="$DEPLOYED_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/deployed.tsv"
+  awk -F '\t' -v sha="$ROLLBACK_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/rollback.tsv"
+} > "$WORK_DIR/trusted-protected-images.tsv"
 printf '%s\n' \
   "$TARGET_ONE_SHA" \
   "$TARGET_TWO_SHA" \
@@ -95,6 +106,22 @@ jq -n \
           items: [
             $generations[] as $generation
             | range(0; 9) as $service_index
+            | (
+                if $generation[1] < 4
+                then 7
+                else 6
+                end
+              ) as $tag_count
+            | range(0; $tag_count) as $tag_index
+            | (
+                if $tag_index == 0
+                then $generation[0]
+                else pad(
+                  100 + ($generation[1] * 10) + $tag_index;
+                  40
+                )
+                end
+              ) as $tag_source_sha
             | {
                 id: (
                   "ocid1.containerimage.oc1..fixture" +
@@ -102,7 +129,7 @@ jq -n \
                 ),
                 "repository-name": "betstan_images",
                 version: (
-                  "oci-\(services[$service_index])-\($generation[0])"
+                  "oci-\(services[$service_index])-\($tag_source_sha)"
                 ),
                 digest: (
                   "sha256:" +
@@ -126,6 +153,40 @@ fi
 printf '%s\n' "$*" >> "${MOCK_OCI_LOG:?}"
 case "$*" in
   "artifacts container image list "*)
+    list_count_file="${MOCK_OCI_STATE:?}/list-count"
+    list_count=0
+    if [[ -f "$list_count_file" ]]; then
+      list_count="$(cat "$list_count_file")"
+    fi
+    list_count="$((list_count + 1))"
+    printf '%s\n' "$list_count" > "$list_count_file"
+    if [[ -n "${MOCK_OCI_MUTATE_ON_LIST_CALL:-}" &&
+          "$list_count" == "$MOCK_OCI_MUTATE_ON_LIST_CALL" ]]; then
+      jq '
+        .data.items[0] as $source
+        | .data.items += [
+            $source + {
+              version: "oci-auth-7777777777777777777777777777777777777777"
+            }
+          ]
+      ' "${MOCK_OCI_STATE:?}/images.json" \
+        > "${MOCK_OCI_STATE:?}/images.json.tmp"
+      mv \
+        "${MOCK_OCI_STATE:?}/images.json.tmp" \
+        "${MOCK_OCI_STATE:?}/images.json"
+    fi
+    if [[ -n "${MOCK_OCI_REKEY_ON_LIST_CALL:-}" &&
+          "$list_count" == "$MOCK_OCI_REKEY_ON_LIST_CALL" ]]; then
+      jq '
+        .data.items |= map(
+          .id |= sub("fixture"; "rekey")
+        )
+      ' "${MOCK_OCI_STATE:?}/images.json" \
+        > "${MOCK_OCI_STATE:?}/images.json.tmp"
+      mv \
+        "${MOCK_OCI_STATE:?}/images.json.tmp" \
+        "${MOCK_OCI_STATE:?}/images.json"
+    fi
     cat "${MOCK_OCI_STATE:?}/images.json"
     ;;
   "artifacts container repository list "*)
@@ -169,11 +230,14 @@ chmod +x "$WORK_DIR/bin/oci"
 run_prune() {
   local protected_file="${TEST_PROTECTED_IMAGES_FILE:-$WORK_DIR/protected.tsv}"
   local trusted_target_file="${TEST_TRUSTED_TARGET_IMAGES_FILE:-$WORK_DIR/trusted-target-images.tsv}"
+  local trusted_protected_file="${TEST_TRUSTED_PROTECTED_IMAGES_FILE:-$WORK_DIR/trusted-protected-images.tsv}"
 
   env \
     PATH="$WORK_DIR/bin:$PATH" \
     MOCK_OCI_LOG="$WORK_DIR/oci.log" \
     MOCK_OCI_STATE="$WORK_DIR/state" \
+    MOCK_OCI_MUTATE_ON_LIST_CALL="${MOCK_OCI_MUTATE_ON_LIST_CALL:-}" \
+    MOCK_OCI_REKEY_ON_LIST_CALL="${MOCK_OCI_REKEY_ON_LIST_CALL:-}" \
     OCI_CLI_VERSION=3.90.0 \
     OCI_COMPARTMENT_OCID=ocid1.compartment.oc1..fixture \
     OCI_IMAGE_PREFIX=betstan \
@@ -181,6 +245,7 @@ run_prune() {
     TARGET_SOURCE_SHAS_FILE="$WORK_DIR/target-source-shas.txt" \
     TRUSTED_TARGET_IMAGES_FILE="$trusted_target_file" \
     PROTECTED_IMAGES_FILE="$protected_file" \
+    TRUSTED_PROTECTED_IMAGES_FILE="$trusted_protected_file" \
     CURRENT_SOURCE_SHA="$CURRENT_SHA" \
     OUTPUT_DIR="$WORK_DIR/evidence" \
     PRUNE_POLL_ATTEMPTS=1 \
@@ -189,9 +254,20 @@ run_prune() {
 }
 
 : > "$WORK_DIR/oci.log"
+rm -f "$WORK_DIR/state/list-count"
 run_prune
 [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "27" ]] ||
   fail "batch prune did not delete exactly three complete generations"
+jq -e '
+  .present_target_images == 27 and
+  .protected_unique_generations == 3 and
+  .unique_images == 54 and
+  .unique_image_ids == 54 and
+  .tag_rows == 360 and
+  .alias_rows == 306 and
+  .tag_generations == 40
+' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
+  fail "batch prune did not model tag aliases separately from image IDs"
 jq -e \
   --arg one "$TARGET_ONE_SHA" \
   --arg two "$TARGET_TWO_SHA" \
@@ -200,32 +276,199 @@ jq -e \
     .target_source_shas == [$one, $two, $failed] and
     .requested_target_generations == 3 and
     .pruned_target_generations == 3 and
-    .unique_images == 27
+    .protected_unique_generations == 3 and
+    .unique_images == 27 and
+    .unique_image_ids == 27 and
+    .tag_rows == 189 and
+    .alias_rows == 162 and
+    .tag_generations == 21
   ' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
   fail "batch prune did not emit terminal evidence"
 [[ "$(wc -l < "$WORK_DIR/evidence/deleted-images.tsv" | tr -d ' ')" == "27" ]] ||
   fail "batch prune evidence does not contain 27 deleted service images"
+protected_image_ids_sha256="$(
+  shasum -a 256 "$WORK_DIR/evidence/protected-image-ids.txt" |
+    awk '{ print $1 }'
+)"
+[[ "$(wc -l < "$WORK_DIR/evidence/protected-image-ids.txt" | tr -d ' ')" == "27" &&
+    "$(jq -r '.protected_image_ids_sha256' "$WORK_DIR/evidence/before-summary.json")" == \
+      "$protected_image_ids_sha256" &&
+    "$(jq -r '.protected_image_ids_sha256' "$WORK_DIR/evidence/after-summary.json")" == \
+      "$protected_image_ids_sha256" ]] ||
+  fail "batch prune did not bind exact protected image OCID evidence"
+[[ "$(wc -l < "$WORK_DIR/evidence/before-aliases.tsv" | tr -d ' ')" == "360" &&
+    "$(wc -l < "$WORK_DIR/evidence/after-aliases.tsv" | tr -d ' ')" == "189" ]] ||
+  fail "batch prune did not retain complete before/after alias evidence"
 [[ "$(
-  jq -c '[.data.items | length, ([.[] | .digest] | unique | length)]' \
+  jq -c '[
+    .data.items | length,
+    ([.[] | .id] | unique | length),
+    ([.[] | .digest] | unique | length)
+  ]' \
     "$WORK_DIR/state/images.json"
-)" == "[27,27]" ]] ||
-  fail "batch prune did not retain exactly three complete generations"
+)" == "[189,27,27]" ]] ||
+  fail "batch prune did not retain exactly three protected alias generations"
 
 rm -rf "$WORK_DIR/evidence"
 : > "$WORK_DIR/oci.log"
+rm -f "$WORK_DIR/state/list-count"
 run_prune
 [[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
   fail "an already-pruned target generation was deleted again"
 jq -e '
   .deletion_required == false and
   .present_target_generations == 0 and
-  .unique_images == 27
+  .protected_unique_generations == 3 and
+  .unique_images == 27 and
+  .unique_image_ids == 27 and
+  .tag_rows == 189 and
+  .alias_rows == 162
 ' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
   fail "an already-pruned batch was not resumed idempotently"
 
 cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
 rm -rf "$WORK_DIR/evidence"
 : > "$WORK_DIR/oci.log"
+rm -f "$WORK_DIR/state/list-count"
+if MOCK_OCI_MUTATE_ON_LIST_CALL=2 run_prune >/dev/null 2>&1; then
+  fail "registry alias drift immediately before deletion was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "pre-delete alias drift was rejected after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+rm -f "$WORK_DIR/state/list-count"
+if MOCK_OCI_REKEY_ON_LIST_CALL=3 run_prune >/dev/null 2>&1; then
+  fail "post-delete protected image OCID substitution was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "27" ]] ||
+  fail "protected OCID substitution fixture did not reach post-delete validation"
+[[ ! -e "$WORK_DIR/evidence/after-summary.json" ]] ||
+  fail "protected OCID substitution emitted terminal success evidence"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+rm -f "$WORK_DIR/state/list-count"
+cat \
+  "$WORK_DIR/deployed.tsv" \
+  "$WORK_DIR/deployed.tsv" \
+  "$WORK_DIR/rollback.tsv" \
+  > "$WORK_DIR/protected-reused.tsv"
+{
+  awk -F '\t' -v sha="$CURRENT_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/deployed.tsv"
+  awk -F '\t' -v sha="$DEPLOYED_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/deployed.tsv"
+  awk -F '\t' -v sha="$ROLLBACK_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/rollback.tsv"
+} > "$WORK_DIR/trusted-protected-reused.tsv"
+jq -r \
+  --arg deployed_sha "$DEPLOYED_SHA" \
+  --arg rollback_sha "$ROLLBACK_SHA" '
+    .data.items[]
+    | select(
+        (.version | endswith("-" + $deployed_sha)) or
+        (.version | endswith("-" + $rollback_sha))
+      )
+    | .id
+  ' "$WORK_DIR/state/images.json" |
+  LC_ALL=C sort -u > "$WORK_DIR/expected-reused-protected-ids.txt"
+jq \
+  --arg current_sha "$CURRENT_SHA" \
+  --arg deployed_sha "$DEPLOYED_SHA" '
+    def services: [
+      "auth", "backoffice", "bet", "client", "event", "gamemaster",
+      "moderation", "resulting", "slip"
+    ];
+    .data.items as $rows
+    | ([
+        $rows[]
+        | select(.version | endswith("-" + $current_sha))
+        | .id
+      ] | unique) as $old_current_ids
+    | ([
+        range(0; 9) as $service_index
+        | ($rows[]
+          | select(
+              .version ==
+              ("oci-" + services[$service_index] + "-" + $deployed_sha)
+            ))
+        | . + {
+            version: (
+              "oci-" + services[$service_index] + "-" + $current_sha
+            )
+          }
+      ]) as $reused_current_tags
+    | .data.items = (
+        [
+          $rows[]
+          | .id as $id
+          | select(($old_current_ids | index($id)) == null)
+        ] + $reused_current_tags
+      )
+  ' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+TEST_PROTECTED_IMAGES_FILE="$WORK_DIR/protected-reused.tsv" \
+  TEST_TRUSTED_PROTECTED_IMAGES_FILE="$WORK_DIR/trusted-protected-reused.tsv" \
+  run_prune
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log")" == "27" ]] ||
+  fail "reused protected generations changed the exact target delete count"
+jq -e '
+  .terminal_status == "PRUNED" and
+  .protected_unique_generations == 2 and
+  .unique_images == 18 and
+  .unique_image_ids == 18 and
+  .tag_rows == 135 and
+  .alias_rows == 117 and
+  .tag_generations == 15
+' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
+  fail "reused protected generations did not retain exact alias accounting"
+jq -r '.data.items[].id' "$WORK_DIR/state/images.json" |
+  LC_ALL=C sort -u > "$WORK_DIR/actual-reused-protected-ids.txt"
+cmp -s \
+  "$WORK_DIR/expected-reused-protected-ids.txt" \
+  "$WORK_DIR/actual-reused-protected-ids.txt" ||
+  fail "reused protected generations did not preserve exact protected OCIDs"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+{
+  head -n 1 "$WORK_DIR/deployed.tsv"
+  tail -n +2 "$WORK_DIR/current.tsv"
+  cat "$WORK_DIR/deployed.tsv" "$WORK_DIR/rollback.tsv"
+} > "$WORK_DIR/protected-partial-reuse.tsv"
+{
+  {
+    head -n 1 "$WORK_DIR/deployed.tsv"
+    tail -n +2 "$WORK_DIR/current.tsv"
+  } | awk -F '\t' -v sha="$CURRENT_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }'
+  awk -F '\t' -v sha="$DEPLOYED_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/deployed.tsv"
+  awk -F '\t' -v sha="$ROLLBACK_SHA" \
+    'BEGIN { OFS = "\t" } { print sha, $0 }' \
+    "$WORK_DIR/rollback.tsv"
+} > "$WORK_DIR/trusted-protected-partial-reuse.tsv"
+if TEST_PROTECTED_IMAGES_FILE="$WORK_DIR/protected-partial-reuse.tsv" \
+  TEST_TRUSTED_PROTECTED_IMAGES_FILE="$WORK_DIR/trusted-protected-partial-reuse.tsv" \
+  run_prune >/dev/null 2>&1; then
+  fail "a partially overlapping protected generation was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "partial protected overlap rejection happened after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+rm -f "$WORK_DIR/state/list-count"
 cat \
   "$WORK_DIR/current.tsv" \
   "$WORK_DIR/deployed.tsv" \
@@ -261,12 +504,15 @@ rm -rf "$WORK_DIR/evidence"
 jq \
   --arg trusted_sha "$TARGET_ONE_SHA" \
   --arg failed_sha "$FAILED_TARGET_SHA" '
-  .data.items |= (
-    map(select(
-      .version != ("oci-auth-" + $trusted_sha) and
-      .version != ("oci-auth-" + $failed_sha)
+  ([.data.items[]
+    | select(.version == ("oci-auth-" + $trusted_sha))
+    | .id][0]) as $trusted_id
+  | ([.data.items[]
+    | select(.version == ("oci-auth-" + $failed_sha))
+    | .id][0]) as $failed_id
+  | .data.items |= map(select(
+      .id != $trusted_id and .id != $failed_id
     ))
-  )
 ' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
 mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
 run_prune
@@ -276,11 +522,131 @@ jq -e '
   .deletion_required == true and
   .present_target_generations == 3 and
   .present_target_images == 25 and
-  .unique_images == 52
+  .unique_images == 52 and
+  .unique_image_ids == 52 and
+  .tag_rows == 347 and
+  .alias_rows == 295
 ' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
   fail "partial batch recovery did not record its exact starting state"
-[[ "$(jq '[.data.items[]] | length' "$WORK_DIR/state/images.json")" == "27" ]] ||
-  fail "partial batch recovery did not retain exactly the protected images"
+[[ "$(
+  jq -c '[
+    .data.items | length,
+    ([.[] | .id] | unique | length),
+    ([.[] | .digest] | unique | length)
+  ]' "$WORK_DIR/state/images.json"
+)" == "[189,27,27]" ]] ||
+  fail "partial batch recovery did not retain protected aliases exactly"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+jq --arg current_sha "$CURRENT_SHA" '
+  .data.items |= map(select(.version != ("oci-auth-" + $current_sha)))
+' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+if run_prune >/dev/null 2>&1; then
+  fail "a missing canonical protected source tag was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "missing protected tag rejection happened after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+jq --arg target_sha "$TARGET_ONE_SHA" '
+  (.data.items[]
+    | select(.version == ("oci-auth-" + $target_sha))) as $source
+  | .data.items += [
+      $source + {
+        version: "oci-bet-1111111111111111111111111111111111111111"
+      }
+    ]
+' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+if run_prune >/dev/null 2>&1; then
+  fail "a cross-service alias was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "cross-service alias rejection happened after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+jq --arg target_sha "$TARGET_ONE_SHA" '
+  (.data.items[]
+    | select(.version == ("oci-auth-" + $target_sha))) as $source
+  | .data.items += [
+      $source + {
+        id: "ocid1.containerimage.oc1..fixture-conflict",
+        version: "oci-auth-2222222222222222222222222222222222222222"
+      }
+    ]
+' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+if run_prune >/dev/null 2>&1; then
+  fail "one digest mapped to multiple image IDs"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "image ID conflict rejection happened after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+jq --arg target_sha "$TARGET_ONE_SHA" '
+  (.data.items[]
+    | select(.version == ("oci-auth-" + $target_sha))) as $source
+  | .data.items += [
+      $source + {
+        version: "oci-auth-4444444444444444444444444444444444444444",
+        digest: ("sha256:" + ("8" * 64))
+      }
+    ]
+' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+if run_prune >/dev/null 2>&1; then
+  fail "one image ID mapped to multiple digests"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "digest conflict rejection happened after a delete"
+
+cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
+rm -rf "$WORK_DIR/evidence"
+: > "$WORK_DIR/oci.log"
+jq \
+  --arg target_one_sha "$TARGET_ONE_SHA" \
+  --arg target_two_sha "$TARGET_TWO_SHA" '
+    def services: [
+      "auth", "backoffice", "bet", "client", "event", "gamemaster",
+      "moderation", "resulting", "slip"
+    ];
+    .data.items as $rows
+    | .data.items += [
+        range(0; 9) as $service_index
+        | (
+            if $service_index == 0
+            then $target_one_sha
+            else $target_two_sha
+            end
+          ) as $source_sha
+        | ($rows[]
+          | select(
+              .version ==
+              ("oci-" + services[$service_index] + "-" + $source_sha)
+            )) as $source
+        | $source + {
+            version: (
+              "oci-" + services[$service_index] + "-" +
+              "3333333333333333333333333333333333333333"
+            )
+          }
+      ]
+  ' "$WORK_DIR/state/images.json" > "$WORK_DIR/state/images.json.tmp"
+mv "$WORK_DIR/state/images.json.tmp" "$WORK_DIR/state/images.json"
+if run_prune >/dev/null 2>&1; then
+  fail "a mixed-generation alias set was accepted"
+fi
+[[ "$(grep -c '^artifacts container image delete ' "$WORK_DIR/oci.log" || true)" == "0" ]] ||
+  fail "mixed alias rejection happened after a delete"
 
 cp "$WORK_DIR/state/images-original.json" "$WORK_DIR/state/images.json"
 rm -rf "$WORK_DIR/evidence"


### PR DESCRIPTION
## Summary
- promote the mandatory read-only OCIR validation phase to `master`
- bind destructive pruning to immutable validation evidence and exact release lineage
- preserve existing application image digests through guarded OCI image reuse

## Rollout
- build exact promoted master SHA
- verify byte-identical nine-image provenance
- remove temporary reuse controls immediately after OCI build
- dispatch validation before any registry mutation