### PR TITLE
chore: promote OCIR accounting correction

### DIFF
--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -63,8 +63,11 @@ conversation summaries are not authority.
   can safely converge.
 - OCIR lists one row per tag, not necessarily one row per stored image.
   `imagetools create` reuse adds exact-SHA aliases that share an image OCID and
-  digest. Destructive checks must validate every alias while counting and
-  deleting unique image IDs: require one service and digest per ID, one
+  digest. Repository `image-count` also counts those tag rows rather than
+  unique OCIDs, so reconcile it with the validated alias inventory while
+  retaining separate unique-identity checks. Destructive checks must validate
+  every alias while counting and deleting unique image IDs: require one
+  service and digest per ID, one
   service and ID per digest, complete trusted alias generations, canonical
   protected tags, and equality of the exact protected OCID set before and
   after deletion rather than relying on counts alone. Candidate, deployed,

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -184,8 +184,10 @@ concurrent retirement fixture isolation without masking failed suites.
    snapshot immediately before deletion, deletes each target image ID once,
    records the complete before/after alias inventory, and waits until all
    target digests are absent, the exact pre-delete protected set of 9, 18, or
-   27 image OCIDs/digests remains, provider image accounting matches that set,
-   and retained layers are within the configured Free Tier ceiling.
+   27 image OCIDs/digests remains, provider image accounting matches the
+   validated retained tag-row count, and retained layers are within the
+   configured Free Tier ceiling. OCIR repository `image-count` counts tag rows,
+   not unique image OCIDs.
 3. Dispatch `oci-infrastructure` with phase `prepare`.
    `scripts/provision.sh cloud` creates/reconciles only the VCN, Internet
    Gateway, public/restricted subnets, NSGs, and OCI Bastion.

--- a/infra/oci/scripts/prune-registry-generation.sh
+++ b/infra/oci/scripts/prune-registry-generation.sh
@@ -719,12 +719,15 @@ cmp -s \
   oci_die "registry service and digest mappings differ from trusted provenance"
 registry_accounting "$work_dir/before-accounting.json"
 jq -e \
-  --argjson expected_images "$expected_images_before" \
+  --argjson expected_tag_rows "$before_row_count" \
   --argjson max_bytes "$OCI_REGISTRY_MAX_BYTES" '
-    .image_count == $expected_images and
+    .image_count == $expected_tag_rows and
     .layers_size_bytes <= $max_bytes
   ' "$work_dir/before-accounting.json" >/dev/null ||
-  oci_die "registry accounting does not match validated unique identities"
+  oci_die "registry accounting does not match validated tag rows"
+before_registry_image_count="$(
+  jq -r '.image_count' "$work_dir/before-accounting.json"
+)"
 before_layers_size_bytes="$(
   jq -r '.layers_size_bytes' "$work_dir/before-accounting.json"
 )"
@@ -786,6 +789,7 @@ jq -n \
   --argjson tag_rows "$before_row_count" \
   --argjson alias_rows "$before_alias_count" \
   --argjson tag_generations "$before_tag_generation_count" \
+  --argjson registry_image_count "$before_registry_image_count" \
   --argjson registry_layers_size_bytes "$before_layers_size_bytes" \
   '{
     target_source_shas: $target_source_shas,
@@ -806,6 +810,7 @@ jq -n \
     tag_rows: $tag_rows,
     alias_rows: $alias_rows,
     tag_generations: $tag_generations,
+    registry_image_count: $registry_image_count,
     registry_layers_size_bytes: $registry_layers_size_bytes,
     deletion_required: ($deletion_required == "true")
   }' > "$OUTPUT_DIR/before-summary.json"
@@ -897,11 +902,12 @@ for ((attempt = 1; attempt <= PRUNE_POLL_ATTEMPTS; attempt++)); do
         grep -q .; then
         oci_die "a canonical protected source tag disappeared during pruning"
       fi
+      after_row_count="$(active_registry_row_count "$work_dir/after.json")"
       registry_accounting "$work_dir/accounting.json"
       if jq -e \
-        --argjson expected_images "$protected_image_count" \
+        --argjson expected_tag_rows "$after_row_count" \
         --argjson max_bytes "$OCI_REGISTRY_MAX_BYTES" '
-          .image_count == $expected_images and
+          .image_count == $expected_tag_rows and
           .layers_size_bytes <= $max_bytes
         ' "$work_dir/accounting.json" >/dev/null; then
         pruned=true
@@ -931,6 +937,12 @@ cp "$work_dir/after-aliases.tsv" "$OUTPUT_DIR/after-aliases.tsv"
 jq -e . "$work_dir/accounting.json" > "$OUTPUT_DIR/registry-accounting.json"
 after_row_count="$(active_registry_row_count "$work_dir/after.json")"
 after_alias_count="$((after_row_count - protected_image_count))"
+after_registry_image_count="$(
+  jq -r '.image_count' "$work_dir/accounting.json"
+)"
+after_layers_size_bytes="$(
+  jq -r '.layers_size_bytes' "$work_dir/accounting.json"
+)"
 after_tag_generation_count="$(
   cut -f1 "$work_dir/after-aliases.tsv" | LC_ALL=C sort -u | wc -l |
     tr -d ' '
@@ -953,6 +965,8 @@ jq -n \
   --argjson tag_rows "$after_row_count" \
   --argjson alias_rows "$after_alias_count" \
   --argjson tag_generations "$after_tag_generation_count" \
+  --argjson registry_image_count "$after_registry_image_count" \
+  --argjson registry_layers_size_bytes "$after_layers_size_bytes" \
   '{
     target_source_shas: $target_source_shas,
     current_source_sha: $current_source_sha,
@@ -970,6 +984,8 @@ jq -n \
     tag_rows: $tag_rows,
     alias_rows: $alias_rows,
     tag_generations: $tag_generations,
+    registry_image_count: $registry_image_count,
+    registry_layers_size_bytes: $registry_layers_size_bytes,
     terminal_status: "PRUNED"
   }' > "$OUTPUT_DIR/after-summary.json"
 

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -575,6 +575,9 @@ grep -Fq 'registry aliases changed after validation and before deletion' \
 grep -Fq 'registry accounting changed after validation and before deletion' \
   "$registry_pruner" ||
   fail "registry pruning does not revalidate accounting before deletion"
+grep -Fq -- '--argjson expected_tag_rows "$before_row_count"' \
+  "$registry_pruner" ||
+  fail "registry pruning does not reconcile provider image accounting with tag rows"
 grep -Fq 'the exact protected image OCID set changed during pruning' \
   "$registry_pruner" ||
   fail "registry pruning does not preserve the exact protected image OCID set"

--- a/infra/oci/tests/test-registry-prune-contract.sh
+++ b/infra/oci/tests/test-registry-prune-contract.sh
@@ -228,7 +228,10 @@ case "$*" in
       layers_size_bytes=300000001
     fi
     image_count="$(
-      jq '[.data.items[].digest] | unique | length' \
+      jq '[
+        .data.items[]
+        | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
+      ] | length' \
         "${MOCK_OCI_STATE:?}/images.json"
     )"
     jq -n \
@@ -326,7 +329,9 @@ jq -e '
   .unique_image_ids == 54 and
   .tag_rows == 360 and
   .alias_rows == 306 and
-  .tag_generations == 40
+  .tag_generations == 40 and
+  .registry_image_count == 360 and
+  .registry_layers_size_bytes == 300000000
 ' "$WORK_DIR/validation-evidence/validation-summary.json" >/dev/null ||
   fail "read-only validation did not capture the production-shaped inventory"
 run_prune
@@ -339,7 +344,9 @@ jq -e '
   .unique_image_ids == 54 and
   .tag_rows == 360 and
   .alias_rows == 306 and
-  .tag_generations == 40
+  .tag_generations == 40 and
+  .registry_image_count == 360 and
+  .registry_layers_size_bytes == 300000000
 ' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
   fail "batch prune did not model tag aliases separately from image IDs"
 jq -e \
@@ -355,7 +362,9 @@ jq -e \
     .unique_image_ids == 27 and
     .tag_rows == 189 and
     .alias_rows == 162 and
-    .tag_generations == 21
+    .tag_generations == 21 and
+    .registry_image_count == 189 and
+    .registry_layers_size_bytes == 300000000
   ' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
   fail "batch prune did not emit terminal evidence"
 validated_before_summary_sha256="$(
@@ -561,7 +570,8 @@ jq -e '
   .unique_image_ids == 18 and
   .tag_rows == 135 and
   .alias_rows == 117 and
-  .tag_generations == 15
+  .tag_generations == 15 and
+  .registry_image_count == 135
 ' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
   fail "reused protected generations did not retain exact alias accounting"
 jq -r '.data.items[].id' "$WORK_DIR/state/images.json" |


### PR DESCRIPTION
## Summary
- promote the OCIR tag-row accounting correction to `master`
- keep exact OCID/digest protection and unique-image deletion unchanged
- preserve application images through immutable reuse from the current master OCI build

## Rollout
- build exact promoted master SHA
- verify byte-identical nine-image provenance and clear temporary reuse controls
- repeat read-only registry validation before any deletion