### PR TITLE
fix: validate over-limit registry before pruning

### DIFF
--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -63,11 +63,10 @@ conversation summaries are not authority.
   can safely converge.
 - OCIR lists one row per tag, not necessarily one row per stored image.
   `imagetools create` reuse adds exact-SHA aliases that share an image OCID and
-  digest. Repository `image-count` also counts those tag rows rather than
-  unique OCIDs, so reconcile it with the validated alias inventory while
-  retaining separate unique-identity checks. Destructive checks must validate
-  every alias while counting and deleting unique image IDs: require one
-  service and digest per ID, one
+  digest. Repository `image-count` counts unique manifests, so reconcile it
+  with unique digests/OCIDs while separately validating the complete alias
+  inventory. Destructive checks must validate every alias while counting and
+  deleting unique image IDs: require one service and digest per ID, one
   service and ID per digest, complete trusted alias generations, canonical
   protected tags, and equality of the exact protected OCID set before and
   after deletion rather than relying on counts alone. Candidate, deployed,
@@ -78,7 +77,9 @@ conversation summaries are not authority.
   evidence. Capture a read-only registry validation artifact first, then make
   apply require byte-for-byte equality of the live before-summary (all aliases,
   OCIDs, digests, lineage, and accounting) with that artifact before issuing
-  any delete.
+  any delete. The read-only phase may attest storage above the configured
+  ceiling; enforce that ceiling after the approved obsolete identities have
+  been deleted and provider accounting converges.
 - Normalize documented case-insensitive provider enums before comparing them.
   OCI has returned values such as `paravirtualized` in lowercase.
 - A healthy load-balancer control plane does not prove a healthy data plane.

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -184,10 +184,10 @@ concurrent retirement fixture isolation without masking failed suites.
    snapshot immediately before deletion, deletes each target image ID once,
    records the complete before/after alias inventory, and waits until all
    target digests are absent, the exact pre-delete protected set of 9, 18, or
-   27 image OCIDs/digests remains, provider image accounting matches the
-   validated retained tag-row count, and retained layers are within the
-   configured Free Tier ceiling. OCIR repository `image-count` counts tag rows,
-   not unique image OCIDs.
+   27 image OCIDs/digests remains, provider image accounting matches that
+   unique manifest set, and retained layers are within the configured Free
+   Tier ceiling. Read-only validation records an over-ceiling layer total
+   because reducing that total is the purpose of the subsequent prune.
 3. Dispatch `oci-infrastructure` with phase `prepare`.
    `scripts/provision.sh cloud` creates/reconciles only the VCN, Internet
    Gateway, public/restricted subnets, NSGs, and OCI Bastion.

--- a/infra/oci/scripts/prune-registry-generation.sh
+++ b/infra/oci/scripts/prune-registry-generation.sh
@@ -719,12 +719,10 @@ cmp -s \
   oci_die "registry service and digest mappings differ from trusted provenance"
 registry_accounting "$work_dir/before-accounting.json"
 jq -e \
-  --argjson expected_tag_rows "$before_row_count" \
-  --argjson max_bytes "$OCI_REGISTRY_MAX_BYTES" '
-    .image_count == $expected_tag_rows and
-    .layers_size_bytes <= $max_bytes
+  --argjson expected_images "$expected_images_before" '
+    .image_count == $expected_images
   ' "$work_dir/before-accounting.json" >/dev/null ||
-  oci_die "registry accounting does not match validated tag rows"
+  oci_die "registry accounting does not match validated unique identities"
 before_registry_image_count="$(
   jq -r '.image_count' "$work_dir/before-accounting.json"
 )"
@@ -905,9 +903,9 @@ for ((attempt = 1; attempt <= PRUNE_POLL_ATTEMPTS; attempt++)); do
       after_row_count="$(active_registry_row_count "$work_dir/after.json")"
       registry_accounting "$work_dir/accounting.json"
       if jq -e \
-        --argjson expected_tag_rows "$after_row_count" \
+        --argjson expected_images "$protected_image_count" \
         --argjson max_bytes "$OCI_REGISTRY_MAX_BYTES" '
-          .image_count == $expected_tag_rows and
+          .image_count == $expected_images and
           .layers_size_bytes <= $max_bytes
         ' "$work_dir/accounting.json" >/dev/null; then
         pruned=true

--- a/infra/oci/tests/test-contract.sh
+++ b/infra/oci/tests/test-contract.sh
@@ -575,9 +575,9 @@ grep -Fq 'registry aliases changed after validation and before deletion' \
 grep -Fq 'registry accounting changed after validation and before deletion' \
   "$registry_pruner" ||
   fail "registry pruning does not revalidate accounting before deletion"
-grep -Fq -- '--argjson expected_tag_rows "$before_row_count"' \
+grep -Fq -- '--argjson expected_images "$expected_images_before"' \
   "$registry_pruner" ||
-  fail "registry pruning does not reconcile provider image accounting with tag rows"
+  fail "registry pruning does not reconcile provider accounting with unique images"
 grep -Fq 'the exact protected image OCID set changed during pruning' \
   "$registry_pruner" ||
   fail "registry pruning does not preserve the exact protected image OCID set"

--- a/infra/oci/tests/test-registry-prune-contract.sh
+++ b/infra/oci/tests/test-registry-prune-contract.sh
@@ -222,18 +222,19 @@ case "$*" in
     fi
     repository_list_count="$((repository_list_count + 1))"
     printf '%s\n' "$repository_list_count" > "$repository_list_count_file"
-    layers_size_bytes=300000000
-    if [[ -n "${MOCK_OCI_ACCOUNTING_DRIFT_ON_LIST_CALL:-}" &&
-          "$repository_list_count" == "$MOCK_OCI_ACCOUNTING_DRIFT_ON_LIST_CALL" ]]; then
-      layers_size_bytes=300000001
-    fi
     image_count="$(
-      jq '[
-        .data.items[]
-        | select((."lifecycle-state" // "" | ascii_upcase) != "DELETED")
-      ] | length' \
+      jq '[.data.items[].digest] | unique | length' \
         "${MOCK_OCI_STATE:?}/images.json"
     )"
+    if ((image_count > 27)); then
+      layers_size_bytes=600000000
+    else
+      layers_size_bytes=300000000
+    fi
+    if [[ -n "${MOCK_OCI_ACCOUNTING_DRIFT_ON_LIST_CALL:-}" &&
+          "$repository_list_count" == "$MOCK_OCI_ACCOUNTING_DRIFT_ON_LIST_CALL" ]]; then
+      layers_size_bytes="$((layers_size_bytes + 1))"
+    fi
     jq -n \
       --argjson image_count "$image_count" \
       --argjson layers_size_bytes "$layers_size_bytes" '{
@@ -330,8 +331,8 @@ jq -e '
   .tag_rows == 360 and
   .alias_rows == 306 and
   .tag_generations == 40 and
-  .registry_image_count == 360 and
-  .registry_layers_size_bytes == 300000000
+  .registry_image_count == 54 and
+  .registry_layers_size_bytes == 600000000
 ' "$WORK_DIR/validation-evidence/validation-summary.json" >/dev/null ||
   fail "read-only validation did not capture the production-shaped inventory"
 run_prune
@@ -345,8 +346,8 @@ jq -e '
   .tag_rows == 360 and
   .alias_rows == 306 and
   .tag_generations == 40 and
-  .registry_image_count == 360 and
-  .registry_layers_size_bytes == 300000000
+  .registry_image_count == 54 and
+  .registry_layers_size_bytes == 600000000
 ' "$WORK_DIR/evidence/before-summary.json" >/dev/null ||
   fail "batch prune did not model tag aliases separately from image IDs"
 jq -e \
@@ -363,7 +364,7 @@ jq -e \
     .tag_rows == 189 and
     .alias_rows == 162 and
     .tag_generations == 21 and
-    .registry_image_count == 189 and
+    .registry_image_count == 27 and
     .registry_layers_size_bytes == 300000000
   ' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
   fail "batch prune did not emit terminal evidence"
@@ -571,7 +572,7 @@ jq -e '
   .tag_rows == 135 and
   .alias_rows == 117 and
   .tag_generations == 15 and
-  .registry_image_count == 135
+  .registry_image_count == 18
 ' "$WORK_DIR/evidence/after-summary.json" >/dev/null ||
   fail "reused protected generations did not retain exact alias accounting"
 jq -r '.data.items[].id' "$WORK_DIR/state/images.json" |


### PR DESCRIPTION
## Summary
- keep OCIR repository `image-count` bound to unique manifests
- allow read-only validation to attest the expected pre-prune over-ceiling layer total
- continue enforcing the 500 MB ceiling only after exact target OCID deletion and provider convergence
- model 54 unique images/360 aliases above the ceiling and 27 protected images below it

## Evidence
- validations `32647157529` and `32649424434` failed safely before deletion on the conflated accounting guard
- complete OCI contract entrypoint passes with oversized pre-prune and bounded terminal accounting