### PR TITLE
Close live quote timing races

### DIFF
--- a/.github/workflows/oci-migration-recovery.yml
+++ b/.github/workflows/oci-migration-recovery.yml
@@ -81,6 +81,7 @@ jobs:
       EXPECTED_OWNER_RUN_ATTEMPT: ${{ github.event_name == 'workflow_dispatch' && inputs.migration_run_attempt || vars.OCI_MIGRATION_RECOVERY_RUN_ATTEMPT }}
       EXPECTED_MIGRATION_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.migration_id || vars.OCI_MIGRATION_RECOVERY_MIGRATION_ID }}
       EXPECTED_FENCING_GENERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.fencing_generation || vars.OCI_MIGRATION_RECOVERY_FENCING_GENERATION }}
+      CONFIRMATION: ${{ inputs.confirmation }}
 
     steps:
       - name: Initialize isolated recovery paths
@@ -167,8 +168,7 @@ jobs:
               ;;
             workflow_dispatch)
               [ "$GITHUB_REF_NAME" = "master" ]
-              [ "${{ inputs.confirmation }}" = \
-                "STOP AZURE FOR EXACT MIGRATION" ]
+              [ "$CONFIRMATION" = "STOP AZURE FOR EXACT MIGRATION" ]
               ;;
             workflow_run)
               [[ "$UPSTREAM_RUN_ID" =~ ^[1-9][0-9]*$ ]]

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -104,7 +104,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Validate trusted production workflow chain
-        run: ./infra/azure/agents/workflow-trigger-guard-stan.sh
+        run: |
+          python3 -m py_compile \
+            infra/azure/agents/workflow-shell-input-guard-stan.py
+          bash -n \
+            infra/azure/agents/test-workflow-shell-input-guard-stan.sh
+          ./infra/azure/agents/test-workflow-shell-input-guard-stan.sh
+          ./infra/azure/agents/workflow-trigger-guard-stan.sh
 
   deployment-safety-contracts:
     runs-on: ubuntu-latest

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -104,13 +104,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Validate trusted production workflow chain
-        run: |
-          python3 -m py_compile \
-            infra/azure/agents/workflow-shell-input-guard-stan.py
-          bash -n \
-            infra/azure/agents/test-workflow-shell-input-guard-stan.sh
-          ./infra/azure/agents/test-workflow-shell-input-guard-stan.sh
-          ./infra/azure/agents/workflow-trigger-guard-stan.sh
+        run: ./infra/azure/agents/workflow-trigger-guard-stan.sh
 
   deployment-safety-contracts:
     runs-on: ubuntu-latest

--- a/.github/workflows/production-rollback.yml
+++ b/.github/workflows/production-rollback.yml
@@ -30,6 +30,7 @@ env:
   BASELINE_SOURCE_RUN_ID: ${{ inputs.baseline_source_run_id }}
   BASELINE_SOURCE_RUN_ATTEMPT: ${{ inputs.baseline_source_run_attempt }}
   BASELINE_ARTIFACT_NAME: ${{ inputs.baseline_artifact_name }}
+  CONFIRMATION: ${{ inputs.confirmation }}
   RESOURCE_GROUP: ${{ secrets.RESOURCE_GROUP }}
   CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
   APP_DOMAIN: ${{ vars.APP_DOMAIN || 'betstan.xyz' }}
@@ -61,7 +62,7 @@ jobs:
         run: |
           set -euo pipefail
           [ "$GITHUB_REF_NAME" = "master" ]
-          [ "${{ inputs.confirmation }}" = "ROLLBACK PRODUCTION EXACT DIGEST" ]
+          [ "$CONFIRMATION" = "ROLLBACK PRODUCTION EXACT DIGEST" ]
           [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$BASELINE_SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
           [ "$BASELINE_SOURCE_RUN_ATTEMPT" = "1" ]

--- a/client/src/liveBettingUtils.js
+++ b/client/src/liveBettingUtils.js
@@ -332,12 +332,12 @@ export const formatMarketStatus = (status) => (
 export const isMarketStale = (market, now = Date.now()) => {
   const expiresAt = normalizeText(market?.quoteValidUntil);
   if (!expiresAt) {
-    return false;
+    return true;
   }
 
   const expirationTime = Date.parse(expiresAt);
   if (Number.isNaN(expirationTime)) {
-    return false;
+    return true;
   }
 
   return expirationTime <= now;

--- a/client/src/pages/event/EventList.test.js
+++ b/client/src/pages/event/EventList.test.js
@@ -21,7 +21,7 @@ const buildLiveMarket = ({
   marketVersion,
   quoteVersion,
   status = 'OPEN',
-  quoteValidUntil,
+  quoteValidUntil = new Date(Date.now() + 60_000).toISOString(),
   odds = 1.8,
 }) => ({
   marketId,
@@ -65,7 +65,7 @@ const liveEvent = {
       buildLiveMarket({ marketId: 'market-1', marketType: 'NEXT_CORNER', marketVersion: 1, quoteVersion: 1, odds: 1.8 }),
       buildLiveMarket({ marketId: 'market-2', marketType: 'NEXT_RED_CARD', marketVersion: 1, quoteVersion: 2, status: 'SUSPENDED', odds: 3.2 }),
       buildLiveMarket({ marketId: 'market-3', marketType: 'NEXT_YELLOW_CARD', marketVersion: 1, quoteVersion: 3, quoteValidUntil: '2000-01-01T00:00:00.000Z', odds: 2.4 }),
-      buildLiveMarket({ marketId: 'market-4', marketType: 'NEXT_PENALTY', marketVersion: 1, quoteVersion: 4, odds: 5.1 }),
+      buildLiveMarket({ marketId: 'market-4', marketType: 'NEXT_PENALTY', marketVersion: 1, quoteVersion: 4, quoteValidUntil: null, odds: 5.1 }),
       buildLiveMarket({ marketId: 'market-5', marketType: 'HALF_TIME_RESULT', marketVersion: 1, quoteVersion: 5, odds: 1.4 }),
       buildLiveMarket({ marketId: 'market-6', marketType: 'NEXT_CORNER', marketVersion: 2, quoteVersion: 6, odds: 2.1 }),
     ],
@@ -132,11 +132,13 @@ describe('EventList', () => {
     const preMatchSelection = screen.getByRole('button', { name: 'Select 1X2 Team A at 1.5' });
     const suspendedSelection = screen.getByRole('button', { name: 'Select Next Red Card: Team A at 3.2' });
     const staleSelection = screen.getByRole('button', { name: 'Select Next Yellow Card: Team A at 2.4' });
+    const missingExpirySelection = screen.getByRole('button', { name: 'Select Next Penalty: Team A at 5.1' });
 
     expect(liveSelection).toHaveClass('product-button--selected');
     expect(preMatchSelection).toHaveClass('product-button--selected');
     expect(suspendedSelection).toBeDisabled();
     expect(staleSelection).toBeDisabled();
+    expect(missingExpirySelection).toBeDisabled();
     expect(screen.getByText('Quote v5')).toBeInTheDocument();
     expect(screen.queryByText('Quote v6')).toBeNull();
 

--- a/event/src/route/EventOddsClicked.ts
+++ b/event/src/route/EventOddsClicked.ts
@@ -106,6 +106,18 @@ const isLiveSelectionRequest = (body: Record<string, unknown>): boolean =>
     body.selectionId,
   ].some((value) => value !== undefined);
 
+const isQuoteValidAt = (
+  validUntil: unknown,
+  selectedAt: Date
+): validUntil is string => {
+  if (!isNonEmptyString(validUntil)) {
+    return false;
+  }
+
+  const validUntilMs = Date.parse(validUntil);
+  return Number.isFinite(validUntilMs) && selectedAt.getTime() < validUntilMs;
+};
+
 router.post(
   "/api/event/odds",
   async (req: Request, res: Response, next: NextFunction) => {
@@ -187,6 +199,12 @@ router.post(
         return next(new BadRequestError("Market version mismatch"));
       }
 
+      const selectedAt = new Date();
+      const quoteValidUntil = selectedMarket.quoteValidUntil;
+      if (!isQuoteValidAt(quoteValidUntil, selectedAt)) {
+        return next(new BadRequestError("Live quote is stale"));
+      }
+
       const selectedSelection = selectedMarket.selections.find(
         (marketSelection) => marketSelection.selectionId === selectionId
       );
@@ -217,8 +235,8 @@ router.post(
           quoteVersion: selectedMarket.quoteVersion,
           selectionId: selectedSelection.selectionId,
           side: selectedSelection.side,
-          selectedAt: new Date().toISOString(),
-          quoteValidUntil: selectedMarket.quoteValidUntil || undefined,
+          selectedAt: selectedAt.toISOString(),
+          quoteValidUntil,
         },
       });
 

--- a/event/src/route/__test__/EventOddsClicked.test.ts
+++ b/event/src/route/__test__/EventOddsClicked.test.ts
@@ -82,6 +82,7 @@ const createLiveEvent = async (
           marketType: LiveMarketType.NEXT_CORNER,
           marketVersion: 2,
           quoteVersion: 4,
+          quoteValidUntil: new Date(now + 60 * 1000).toISOString(),
           status: LiveMarketStatus.OPEN,
           selections: [
             { selectionId: "home", side: TeamSide.HOME, odds: 1.8 },
@@ -433,7 +434,42 @@ it("rejects live selections when the server-side selection does not exist", asyn
     .expect(400);
 });
 
+it.each([
+  ["missing", undefined],
+  ["invalid", "not-a-date"],
+  ["expired", new Date(Date.now() - 1_000).toISOString()],
+])("rejects live selections with %s quote expiry", async (_label, quoteValidUntil) => {
+  await createLiveEvent();
+
+  if (quoteValidUntil === undefined) {
+    await Event.updateOne(
+      { eventId: "test-event-id" },
+      { $unset: { "live.currentMarkets.0.quoteValidUntil": 1 } }
+    );
+  } else {
+    await Event.updateOne(
+      { eventId: "test-event-id" },
+      { $set: { "live.currentMarkets.0.quoteValidUntil": quoteValidUntil } }
+    );
+  }
+
+  const response = await request(app)
+    .post("/api/event/odds")
+    .send({
+      eventId: "test-event-id",
+      marketId: "market-1",
+      marketVersion: 2,
+      quoteVersion: 4,
+      selectionId: "home",
+    })
+    .expect(400);
+
+  expect(response.body.errors[0].msg).toEqual("Live quote is stale");
+  expect(EventOddsSelectedPublisher.prototype.publish).not.toHaveBeenCalled();
+});
+
 it("accepts string live versions, away selections, and string event times", async () => {
+  const quoteValidUntil = new Date(Date.now() + 60_000).toISOString();
   await Event.collection.insertOne({
     eventId: "string-live-event",
     name: "Team A - Team B",
@@ -459,6 +495,7 @@ it("accepts string live versions, away selections, and string event times", asyn
           marketType: LiveMarketType.NEXT_CORNER,
           marketVersion: 2,
           quoteVersion: 4,
+          quoteValidUntil,
           status: LiveMarketStatus.OPEN,
           selections: [
             { selectionId: "away", side: TeamSide.AWAY, odds: 2.1 },
@@ -486,6 +523,7 @@ it("accepts string live versions, away selections, and string event times", asyn
       eventTime: "2030-01-01T12:00:00.000Z",
       marketVersion: 2,
       quoteVersion: 4,
+      quoteValidUntil,
     }),
   });
 });
@@ -532,6 +570,7 @@ it("falls back to stored kickoff time for pre-match eventTime when no event time
 });
 
 it("uses public fallback labels for live selections when team names or mappings are missing", async () => {
+  const quoteValidUntil = new Date(Date.now() + 60_000).toISOString();
   await Event.collection.insertOne({
     eventId: "label-fallback-event",
     name: "Fallback",
@@ -554,6 +593,7 @@ it("uses public fallback labels for live selections when team names or mappings 
           marketType: LiveMarketType.NEXT_PENALTY,
           marketVersion: 1,
           quoteVersion: 1,
+          quoteValidUntil,
           status: LiveMarketStatus.OPEN,
           selections: [
             { selectionId: "home", side: TeamSide.HOME, odds: 1.1 },
@@ -564,6 +604,7 @@ it("uses public fallback labels for live selections when team names or mappings 
           marketType: "CUSTOM_MARKET",
           marketVersion: 2,
           quoteVersion: 2,
+          quoteValidUntil,
           status: LiveMarketStatus.OPEN,
           selections: [
             { selectionId: "draw", side: TeamSide.DRAW, odds: 3.3 },
@@ -612,7 +653,7 @@ it("uses public fallback labels for live selections when team names or mappings 
         eventId: "label-fallback-event",
         oddsName: "Draw",
         productName: "CUSTOM_MARKET",
-        quoteValidUntil: undefined,
+        quoteValidUntil,
       }),
     }
   );

--- a/gamemaster/src/worker/GamemasterWorker.ts
+++ b/gamemaster/src/worker/GamemasterWorker.ts
@@ -669,6 +669,11 @@ export class GamemasterWorker {
   ): ILiveEventUpdateEvent {
     const occurredAtIso = occurredAt.toISOString();
     const incident = buildPublishedIncident(transition, occurredAtIso);
+    const quoteValidUntil = this.nextTransitionAt(
+      this.kickoffAt(event),
+      storedTransitions(event),
+      transition.sequence
+    )?.toISOString();
     const data: LiveUpdateData = {
       eventId: event.eventId,
       sequence: transition.sequence,
@@ -687,6 +692,10 @@ export class GamemasterWorker {
         marketType: market.marketType as unknown as ILiveEventUpdateEvent["data"]["markets"][number]["marketType"],
         marketVersion: market.marketVersion,
         quoteVersion: market.quoteVersion,
+        quoteValidUntil:
+          market.status === LiveMarketStatus.OPEN
+            ? quoteValidUntil
+            : undefined,
         status: market.status as unknown as ILiveEventUpdateEvent["data"]["markets"][number]["status"],
         selections: market.selections.map((selection) => ({
           selectionId: selection.selectionId,

--- a/gamemaster/src/worker/__test__/GamemasterWorker.test.ts
+++ b/gamemaster/src/worker/__test__/GamemasterWorker.test.ts
@@ -701,6 +701,18 @@ it("persists a simulation before kickoff publication and replays it after restar
     kickoffPayload.data.incidents.map((incident: { id: string }) => incident.id)
   ).toEqual([simulation.transitions[0].incident.id]);
   expect(kickoffPayload.data.incident.id).toBe(simulation.transitions[0].incident.id);
+  const kickoffOpenMarkets = kickoffPayload.data.markets.filter(
+    (market: { status: LiveMarketStatus }) =>
+      market.status === LiveMarketStatus.OPEN
+  );
+  expect(kickoffOpenMarkets.length).toBeGreaterThan(0);
+  expect(
+    kickoffOpenMarkets.every(
+      (market: { quoteValidUntil?: string }) =>
+        market.quoteValidUntil
+        === new Date(baseKickoff.getTime() + 500).toISOString()
+    )
+  ).toBe(true);
 
   const restartClock: WorkerClock = {
     now: () => new Date(baseKickoff.getTime() + 5000),
@@ -721,6 +733,13 @@ it("persists a simulation before kickoff publication and replays it after restar
     LiveEventUpdatePublisher.prototype.publishWithConfirm as unknown as jest.Mock
   ).mock.calls[4][0];
   expect(finalSnapshot.data.sequence).toBe(5);
+  expect(finalSnapshot.data.markets.length).toBeGreaterThan(0);
+  expect(
+    finalSnapshot.data.markets.every(
+      (market: { quoteValidUntil?: string }) =>
+        market.quoteValidUntil === undefined
+    )
+  ).toBe(true);
   expect(
     finalSnapshot.data.incidents.map((incident: { id: string }) => incident.id)
   ).toEqual(simulation.transitions.map((transition) => transition.incident.id));

--- a/infra/azure/agents/production-workflow-inventory-stan.rb
+++ b/infra/azure/agents/production-workflow-inventory-stan.rb
@@ -258,8 +258,18 @@ def validate_azure_rollback_workflow!(file, document, content)
   )
   require_content(
     content,
-    /\[\s*"\$\{\{\s*inputs\.confirmation\s*\}\}"\s*=\s*"ROLLBACK PRODUCTION EXACT DIGEST"\s*\]/,
+    /CONFIRMATION:\s*\$\{\{\s*inputs\.confirmation\s*\}\}/,
+    "#{name} must bind the production rollback confirmation through the environment"
+  )
+  require_content(
+    content,
+    /\[\s*"\$CONFIRMATION"\s*=\s*"ROLLBACK PRODUCTION EXACT DIGEST"\s*\]/,
     "#{name} must require the exact production rollback confirmation phrase"
+  )
+  reject_content(
+    content,
+    /\[\s*"\$\{\{\s*inputs\.confirmation\s*\}\}"/,
+    "#{name} must not interpolate the rollback confirmation in shell code"
   )
   require_content(
     content,

--- a/infra/azure/agents/test-production-rollback-stan.sh
+++ b/infra/azure/agents/test-production-rollback-stan.sh
@@ -1291,6 +1291,14 @@ end
 puts 'azure_rollback_yaml=PASS'
 RUBY
 
+assert_contains "$WORKFLOW_FILE" 'CONFIRMATION: ${{ inputs.confirmation }}'
+assert_contains \
+  "$WORKFLOW_FILE" \
+  '[ "$CONFIRMATION" = "ROLLBACK PRODUCTION EXACT DIGEST" ]'
+if grep -Fq '[ "${{ inputs.confirmation }}"' "$WORKFLOW_FILE"; then
+  fail "rollback workflow interpolates the confirmation directly in shell"
+fi
+
 bash -n "$CAPTURE_SCRIPT" "$SCRIPT"
 
 action_lines=(

--- a/infra/azure/agents/test-workflow-shell-input-guard-stan.sh
+++ b/infra/azure/agents/test-workflow-shell-input-guard-stan.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+GUARD="$ROOT_DIR/infra/azure/agents/workflow-shell-input-guard-stan.py"
+WORK_DIR="$(mktemp -d "$ROOT_DIR/.workflow-shell-input-guard.XXXXXX")"
+trap 'rm -rf -- "$WORK_DIR"' EXIT
+
+fail() {
+  echo "workflow_shell_input_guard_tests=FAIL reason=$*" >&2
+  exit 1
+}
+
+cat > "$WORK_DIR/safe.yml" <<'YAML'
+name: safe
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        required: true
+        type: string
+env:
+  CONFIRMATION: ${{ inputs.confirmation }}
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          [ "$CONFIRMATION" = "EXPECTED" ]
+      - uses: actions/checkout@0000000000000000000000000000000000000000
+        with:
+          ref: ${{ inputs.confirmation }}
+YAML
+
+python3 "$GUARD" "$WORK_DIR/safe.yml" >/dev/null ||
+  fail "environment and action input bindings were rejected"
+
+assert_rejected() {
+  local name="$1"
+  local expected_line="$2"
+  local file="$WORK_DIR/$name.yml"
+  shift 2
+  printf '%s\n' "$@" > "$file"
+
+  if python3 "$GUARD" "$file" >"$WORK_DIR/$name.out" 2>&1; then
+    fail "$name direct shell interpolation was accepted"
+  fi
+  grep -Fq "$file:$expected_line" "$WORK_DIR/$name.out" ||
+    fail "$name diagnostic did not identify the exact workflow line"
+}
+
+assert_rejected block 9 \
+  'name: block' \
+  'on: workflow_dispatch' \
+  'jobs:' \
+  '  validate:' \
+  '    runs-on: ubuntu-latest' \
+  '    steps:' \
+  '      - run: |' \
+  '          set -euo pipefail' \
+  '          [ "${{ inputs.confirmation }}" = "EXPECTED" ]'
+
+assert_rejected whitespace 8 \
+  'name: whitespace' \
+  'on: workflow_dispatch' \
+  'jobs:' \
+  '  validate:' \
+  '    runs-on: ubuntu-latest' \
+  '    steps:' \
+  '      - run: |' \
+  '          echo "${{   inputs.confirmation }}"'
+
+assert_rejected legacy 7 \
+  'name: legacy' \
+  'on: workflow_dispatch' \
+  'jobs:' \
+  '  validate:' \
+  '    runs-on: ubuntu-latest' \
+  '    steps:' \
+  '      - run: echo "${{ github.event.inputs.confirmation }}"'
+
+echo "workflow_shell_input_guard_tests=PASS"

--- a/infra/azure/agents/workflow-shell-input-guard-stan.py
+++ b/infra/azure/agents/workflow-shell-input-guard-stan.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import pathlib
+import re
+import sys
+
+
+INPUT_EXPRESSION = re.compile(
+    r"\$\{\{\s*(?:github\.event\.)?inputs\."
+)
+
+
+def workflow_files(paths: list[str]) -> list[pathlib.Path]:
+    files: list[pathlib.Path] = []
+    for raw_path in paths:
+        path = pathlib.Path(raw_path)
+        if path.is_dir():
+            files.extend(path.glob("*.yml"))
+            files.extend(path.glob("*.yaml"))
+        elif path.is_file():
+            files.append(path)
+        else:
+            raise ValueError(f"workflow path does not exist: {path}")
+
+    return sorted(set(files))
+
+
+def direct_shell_interpolations(path: pathlib.Path) -> list[str]:
+    violations: list[str] = []
+    run_indent: int | None = None
+
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+
+        if run_indent is not None:
+            if stripped and indent <= run_indent:
+                run_indent = None
+            elif INPUT_EXPRESSION.search(line):
+                violations.append(f"{path}:{line_number}")
+
+        match = re.match(r"^( *)(?:-\s*)?run\s*:\s*(.*)$", line)
+        if match:
+            if INPUT_EXPRESSION.search(match.group(2)):
+                violations.append(f"{path}:{line_number}")
+            run_indent = len(match.group(1))
+
+    return violations
+
+
+def main() -> int:
+    targets = sys.argv[1:] or [".github/workflows"]
+    try:
+        files = workflow_files(targets)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    if not files:
+        print("no workflow files found", file=sys.stderr)
+        return 2
+
+    violations = [
+        violation
+        for path in files
+        for violation in direct_shell_interpolations(path)
+    ]
+    if violations:
+        print(
+            "Direct inputs interpolation in workflow shell step: "
+            + ", ".join(violations),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"workflow_shell_input_guard=PASS workflows={len(files)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -46,6 +46,12 @@ for file in \
   [[ -f "$file" ]] || fail "required workflow missing: $file"
 done
 
+python3 -m py_compile \
+  infra/azure/agents/workflow-shell-input-guard-stan.py
+bash -n \
+  infra/azure/agents/test-workflow-shell-input-guard-stan.sh
+./infra/azure/agents/test-workflow-shell-input-guard-stan.sh
+
 if ! python3 \
   infra/azure/agents/workflow-shell-input-guard-stan.py \
   .github/workflows; then

--- a/infra/azure/agents/workflow-trigger-guard-stan.sh
+++ b/infra/azure/agents/workflow-trigger-guard-stan.sh
@@ -46,6 +46,12 @@ for file in \
   [[ -f "$file" ]] || fail "required workflow missing: $file"
 done
 
+if ! python3 \
+  infra/azure/agents/workflow-shell-input-guard-stan.py \
+  .github/workflows; then
+  fail "workflow shell steps interpolate untrusted inputs directly"
+fi
+
 retired=(
   .github/workflows/build-push.yml
   .github/workflows/deploy-manifests.yml
@@ -129,8 +135,10 @@ require_literal "$rollback_workflow" "baseline_source_run_id:" "baseline source 
 require_literal "$rollback_workflow" "baseline_source_run_attempt:" "baseline source run attempt input"
 require_literal "$rollback_workflow" "baseline_artifact_name:" "baseline artifact input"
 require_literal "$rollback_workflow" "confirmation:" "manual rollback confirmation input"
+require_literal "$rollback_workflow" 'CONFIRMATION: ${{ inputs.confirmation }}' "environment-bound rollback confirmation"
 require_literal "$rollback_workflow" '[ "$GITHUB_REF_NAME" = "master" ]' "master rollback branch guard"
-require_literal "$rollback_workflow" '[ "${{ inputs.confirmation }}" = "ROLLBACK PRODUCTION EXACT DIGEST" ]' "exact rollback confirmation"
+require_literal "$rollback_workflow" '[ "$CONFIRMATION" = "ROLLBACK PRODUCTION EXACT DIGEST" ]' "exact rollback confirmation"
+reject_literal "$rollback_workflow" '[ "${{ inputs.confirmation }}"' "direct rollback input interpolation"
 require_literal "$rollback_workflow" '[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]' "exact rollback target SHA validation"
 require_literal "$rollback_workflow" '[[ "$BASELINE_SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]' "numeric rollback provenance run ID validation"
 require_literal "$rollback_workflow" '[ "$BASELINE_SOURCE_RUN_ATTEMPT" = "1" ]' "first-attempt rollback provenance guard"
@@ -255,6 +263,9 @@ require_literal "$oci_recovery_workflow" "workflow_dispatch:" "manual recovery t
 require_literal "$oci_recovery_workflow" "OCI_MIGRATION_RECOVERY_ENABLED" "false-by-default recovery guard"
 require_literal "$oci_recovery_workflow" "OCI_MIGRATION_RECOVERY_ARM_UNTIL_EPOCH" "bounded recovery arm deadline"
 require_literal "$oci_recovery_workflow" "86400" "one-day recovery arm bound"
+require_literal "$oci_recovery_workflow" 'CONFIRMATION: ${{ inputs.confirmation }}' "environment-bound recovery confirmation"
+require_literal "$oci_recovery_workflow" '[ "$CONFIRMATION" = "STOP AZURE FOR EXACT MIGRATION" ]' "exact recovery confirmation"
+reject_literal "$oci_recovery_workflow" '[ "${{ inputs.confirmation }}"' "direct recovery input interpolation"
 require_literal "$oci_recovery_workflow" "name: azure-migration-recovery" "stop-only protected environment"
 require_literal "$oci_recovery_workflow" "AZURE_MIGRATION_RECOVERY_CREDENTIALS" "dedicated stop-only credential"
 require_literal "$oci_recovery_workflow" "group: azure-migration-recovery" "collapsed recovery concurrency"

--- a/infra/oci/tests/test-migration-recovery-contract.sh
+++ b/infra/oci/tests/test-migration-recovery-contract.sh
@@ -449,6 +449,8 @@ for literal in \
   'migration_id:' \
   'fencing_generation:' \
   'STOP AZURE FOR EXACT MIGRATION' \
+  'CONFIRMATION: ${{ inputs.confirmation }}' \
+  '[ "$CONFIRMATION" = "STOP AZURE FOR EXACT MIGRATION" ]' \
   "vars.OCI_MIGRATION_RECOVERY_ENABLED == 'true'" \
   "vars.OCI_MIGRATION_RECOVERY_ENABLED || 'false'" \
   'OCI_MIGRATION_RECOVERY_ARM_UNTIL_EPOCH' \
@@ -475,6 +477,8 @@ for literal in \
   grep -Fq "$literal" "$RECOVERY_WORKFLOW" ||
     fail "recovery workflow is missing: $literal"
 done
+! grep -Fq '[ "${{ inputs.confirmation }}"' "$RECOVERY_WORKFLOW" ||
+  fail "recovery workflow interpolates the confirmation directly in shell"
 ! grep -Fq '@tsv' "$RECOVERY_WORKFLOW" ||
   fail "recovery workflow can shift nullable owner-run fields"
 ! grep -Eq \

--- a/moderation/src/event/listener/__test__/LiveEventUpdateListener.test.ts
+++ b/moderation/src/event/listener/__test__/LiveEventUpdateListener.test.ts
@@ -55,13 +55,20 @@ it("stores only the newest live snapshot when duplicates arrive", async () => {
   expect(await LiveEventMirror.countDocuments({ eventId })).toEqual(1);
 });
 
-it("replays parked live bets when the mirror arrives later", async () => {
+it("replays a pre-cutoff live bet when its mirror arrives after expiry", async () => {
   const { placeBetListener, liveEventListener, replayWorker } = await setup();
   const eventId = new mongoose.Types.ObjectId().toHexString();
+  const quoteValidUntil = new Date(Date.now() - 1_000);
   const market = createLiveMarket(eventId, {
-    quoteValidUntil: new Date(Date.now() + 60_000).toISOString(),
+    quoteValidUntil: quoteValidUntil.toISOString(),
   });
-  const placeBet = createLivePlaceBetEvent(market);
+  const placeBet = createLivePlaceBetEvent(market, {
+    data: {
+      submittedAt: new Date(
+        quoteValidUntil.getTime() - 1_000
+      ).toISOString(),
+    },
+  });
 
   await placeBetListener.onMessage(placeBet, createMessage());
 

--- a/moderation/src/event/listener/__test__/PlaceBetListener.test.ts
+++ b/moderation/src/event/listener/__test__/PlaceBetListener.test.ts
@@ -351,6 +351,82 @@ it("expired live quotes are declined", async () => {
   });
 });
 
+it.each([
+  ["missing quote expiry", "missing-expiry"],
+  ["missing submission time", "missing-submission"],
+  ["invalid submission time", "invalid-submission"],
+])("fails closed for live bets with %s", async (_label, scenario) => {
+  const { listener } = await setup();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+  const market = createLiveMarket(eventId);
+
+  if (scenario === "missing-expiry") {
+    market.quoteValidUntil = undefined;
+  }
+
+  await saveMirror(eventId, market);
+  const data = createLivePlaceBetEvent(market, {
+    data: {
+      submittedAt:
+        scenario === "missing-submission"
+          ? undefined
+          : scenario === "invalid-submission"
+            ? "not-a-date"
+            : new Date().toISOString(),
+    },
+  });
+
+  await listener.onMessage(data, createMessage());
+
+  const savedBet = await Bet.findOne({ slipId: data.data.slipId });
+  expect(savedBet).not.toBeNull();
+  expect(savedBet!.status).toEqual(ModerationStatus.DECLINED);
+  expect(savedBet!.declineReason).toEqual(ModerationDeclineReason.STALE_QUOTE);
+});
+
+it("approves delayed moderation when the server accepted the bet before cutoff", async () => {
+  const { listener } = await setup();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+  const quoteValidUntil = new Date(Date.now() - 1_000);
+  const submittedAt = new Date(quoteValidUntil.getTime() - 1_000).toISOString();
+  const market = await saveMirror(
+    eventId,
+    createLiveMarket(eventId, {
+      quoteValidUntil: quoteValidUntil.toISOString(),
+    })
+  );
+  const data = createLivePlaceBetEvent(market, {
+    data: { submittedAt },
+  });
+
+  await listener.onMessage(data, createMessage());
+
+  const savedBet = await Bet.findOne({ slipId: data.data.slipId });
+  expect(savedBet).not.toBeNull();
+  expect(savedBet!.status).toEqual(ModerationStatus.APPROVED);
+  expect(savedBet!.submittedAt).toEqual(submittedAt);
+});
+
+it("declines a bet accepted at the cutoff even while the mirror is stale and open", async () => {
+  const { listener } = await setup();
+  const eventId = new mongoose.Types.ObjectId().toHexString();
+  const quoteValidUntil = new Date(Date.now() - 1_000).toISOString();
+  const market = await saveMirror(
+    eventId,
+    createLiveMarket(eventId, { quoteValidUntil })
+  );
+  const data = createLivePlaceBetEvent(market, {
+    data: { submittedAt: quoteValidUntil },
+  });
+
+  await listener.onMessage(data, createMessage());
+
+  const savedBet = await Bet.findOne({ slipId: data.data.slipId });
+  expect(savedBet).not.toBeNull();
+  expect(savedBet!.status).toEqual(ModerationStatus.DECLINED);
+  expect(savedBet!.declineReason).toEqual(ModerationDeclineReason.STALE_QUOTE);
+});
+
 it("valid live bets are approved against the mirrored market", async () => {
   const { listener } = await setup();
   const eventId = new mongoose.Types.ObjectId().toHexString();

--- a/moderation/src/event/listener/__test__/helpers.ts
+++ b/moderation/src/event/listener/__test__/helpers.ts
@@ -20,6 +20,11 @@ import ParkedPlaceBetReplayWorker, {
 
 type LiveMarket = ILiveEventUpdateEvent["data"]["markets"][number];
 type SlipRow = IPlaceBetEvent["data"]["rows"][number];
+type PlaceBetDataOverrides = Partial<
+  Omit<IPlaceBetEvent["data"], "rows">
+> & {
+  submittedAt?: string;
+};
 
 const objectId = () => new mongoose.Types.ObjectId().toHexString();
 
@@ -92,7 +97,7 @@ export const createMessage = (): ConsumeMessage => ({
 
 export const createPlaceBetEvent = (
   options: {
-    data?: Partial<Omit<IPlaceBetEvent["data"], "rows">>;
+    data?: PlaceBetDataOverrides;
     row?: Partial<SlipRow>;
     rows?: SlipRow[];
   } = {}
@@ -155,7 +160,9 @@ export const createLiveMarket = (
     marketType,
     marketVersion,
     quoteVersion: overrides.quoteVersion ?? 4,
-    quoteValidUntil: overrides.quoteValidUntil,
+    quoteValidUntil:
+      overrides.quoteValidUntil
+      ?? new Date(Date.now() + 60_000).toISOString(),
     status: overrides.status ?? LiveMarketStatus.OPEN,
     selections,
   };
@@ -191,7 +198,7 @@ export const createLiveUpdateEvent = (
 export const createLivePlaceBetEvent = (
   market: LiveMarket,
   options: {
-    data?: Partial<Omit<IPlaceBetEvent["data"], "rows">>;
+    data?: PlaceBetDataOverrides;
     row?: Partial<SlipRow>;
   } = {}
 ): IPlaceBetEvent => {
@@ -202,6 +209,7 @@ export const createLivePlaceBetEvent = (
 
   return createPlaceBetEvent({
     data: {
+      submittedAt: options.data?.submittedAt ?? new Date().toISOString(),
       ...options.data,
       betKind: options.data?.betKind ?? BetKind.LIVE,
     },

--- a/moderation/src/model/Bet.ts
+++ b/moderation/src/model/Bet.ts
@@ -158,6 +158,10 @@ const betSchema = new Schema({
     type: String,
     required: true,
   },
+  submittedAt: {
+    type: String,
+    required: false,
+  },
   moderationTimestamp: {
     type: String,
     required: false,

--- a/moderation/src/service/ModerationService.ts
+++ b/moderation/src/service/ModerationService.ts
@@ -23,8 +23,12 @@ interface NormalizedSlipRow extends SlipRow {
   betKind: BetKind;
 }
 
+type SubmittedPlaceBetData = IPlaceBetEvent["data"] & {
+  submittedAt?: string;
+};
+
 type NormalizedPlaceBetEvent = Omit<IPlaceBetEvent, "data"> & {
-  data: Omit<IPlaceBetEvent["data"], "rows" | "betKind"> & {
+  data: Omit<SubmittedPlaceBetData, "rows" | "betKind"> & {
     rows: NormalizedSlipRow[];
     betKind?: BetKind;
   };
@@ -36,6 +40,7 @@ interface StoredBetRecord {
   status: ModerationStatus;
   wager: number;
   timestamp: string;
+  submittedAt?: string;
   moderationTimestamp: string;
   publishedAt?: string;
   publishToken?: string;
@@ -530,23 +535,34 @@ class ModerationService {
       }
 
       const mirror = mirrorByEventId.get(row.eventId);
-
-      if (!mirror) {
-        if (this.hasExpired(row.quoteValidUntil, evaluatedAt)) {
-          affectedRows.push(
-            this.buildAffectedRow(row, ModerationDeclineReason.STALE_QUOTE)
-          );
-          continue;
-        }
-
-        pendingEventIds.add(row.eventId);
-        continue;
-      }
-
-      const currentMarket = this.findCurrentMarket(mirror, row);
+      const currentMarket = mirror
+        ? this.findCurrentMarket(mirror, row)
+        : undefined;
       const currentSelection = currentMarket
         ? this.findCurrentSelection(currentMarket, row)
         : undefined;
+
+      if (
+        !this.isLiveSubmissionBeforeExpiry(
+          row.quoteValidUntil,
+          event.data.submittedAt
+        )
+      ) {
+        affectedRows.push(
+          this.buildAffectedRow(
+            row,
+            ModerationDeclineReason.STALE_QUOTE,
+            currentMarket,
+            currentSelection
+          )
+        );
+        continue;
+      }
+
+      if (!mirror) {
+        pendingEventIds.add(row.eventId);
+        continue;
+      }
 
       if (!this.isLiveOpen(mirror)) {
         affectedRows.push(
@@ -643,8 +659,11 @@ class ModerationService {
       }
 
       if (
-        this.hasExpired(row.quoteValidUntil, evaluatedAt)
-        || this.hasExpired(exactMarket.quoteValidUntil, evaluatedAt)
+        !this.isValidLiveQuoteAtSubmission(
+          row.quoteValidUntil,
+          exactMarket.quoteValidUntil,
+          event.data.submittedAt
+        )
       ) {
         affectedRows.push(
           this.buildAffectedRow(
@@ -783,6 +802,9 @@ class ModerationService {
     if (event.data.betKind) {
       update.$set.betKind = event.data.betKind;
     }
+    if (event.data.submittedAt) {
+      update.$set.submittedAt = event.data.submittedAt;
+    }
 
     try {
       await Bet.findOneAndUpdate({ slipId: event.data.slipId }, update, {
@@ -830,6 +852,9 @@ class ModerationService {
         ...(update.$unset ?? {}),
         betKind: 1,
       };
+    }
+    if (event.data.submittedAt) {
+      update.$set.submittedAt = event.data.submittedAt;
     }
 
     if (decision.declineReason) {
@@ -1194,14 +1219,44 @@ class ModerationService {
     return parsedKickoff ? now.getTime() >= parsedKickoff.getTime() : false;
   }
 
-  private hasExpired(validUntil: string | undefined, now: Date): boolean {
-    if (!validUntil) {
+  private isValidLiveQuoteAtSubmission(
+    rowValidUntil: string | undefined,
+    marketValidUntil: string | undefined,
+    submittedAt: string | undefined
+  ): boolean {
+    if (
+      !marketValidUntil
+      || !this.isLiveSubmissionBeforeExpiry(rowValidUntil, submittedAt)
+    ) {
       return false;
     }
 
-    const parsedValidUntil = this.parseDate(validUntil);
+    const rowExpiryMs = Date.parse(rowValidUntil);
+    const marketExpiryMs = Date.parse(marketValidUntil);
 
-    return parsedValidUntil ? now.getTime() >= parsedValidUntil.getTime() : true;
+    return (
+      Number.isFinite(rowExpiryMs)
+      && Number.isFinite(marketExpiryMs)
+      && rowExpiryMs === marketExpiryMs
+    );
+  }
+
+  private isLiveSubmissionBeforeExpiry(
+    rowValidUntil: string | undefined,
+    submittedAt: string | undefined
+  ): rowValidUntil is string {
+    if (!rowValidUntil || !submittedAt) {
+      return false;
+    }
+
+    const rowExpiryMs = Date.parse(rowValidUntil);
+    const submittedAtMs = Date.parse(submittedAt);
+
+    return (
+      Number.isFinite(rowExpiryMs)
+      && Number.isFinite(submittedAtMs)
+      && submittedAtMs < rowExpiryMs
+    );
   }
 
   private parseDate(value: string): Date | null {

--- a/slip/src/model/Slip.ts
+++ b/slip/src/model/Slip.ts
@@ -216,6 +216,9 @@ const submittedEventSchema = new Schema(
       type: String,
       required: true,
     },
+    submittedAt: {
+      type: String,
+    },
     placementAttemptId: {
       type: String,
     },

--- a/slip/src/model/slipSupport.ts
+++ b/slip/src/model/slipSupport.ts
@@ -109,6 +109,7 @@ export interface SubmittedEventData {
   userId: string;
   userName: string;
   slipId: string;
+  submittedAt?: string | null;
   placementAttemptId?: string | null;
   wager: number;
   rows: ArrayLike<MutableSubmittedEventRow> & Iterable<MutableSubmittedEventRow>;
@@ -156,6 +157,7 @@ export interface PlainSlip {
 
 export type PublishedSubmittedEventData = IPlaceBetEvent["data"] & {
   placementAttemptId?: string;
+  submittedAt?: string;
 };
 
 const MAX_PLACEMENT_ATTEMPT_ID_LENGTH = 200;
@@ -681,6 +683,7 @@ export const toPublishedSubmittedEventData = (
   userId: submittedEvent.userId,
   userName: submittedEvent.userName,
   slipId: submittedEvent.slipId,
+  submittedAt: submittedEvent.submittedAt ?? undefined,
   placementAttemptId: canonicalPlacementAttemptId(submittedEvent),
   wager: submittedEvent.wager,
   betKind: submittedEvent.betKind ?? undefined,

--- a/slip/src/route/__test__/PlaceBet.test.ts
+++ b/slip/src/route/__test__/PlaceBet.test.ts
@@ -704,6 +704,9 @@ it("keeps the board submitted and pending when publish confirm fails", async () 
   expect(failedResponse.body.submittedEvent.placementAttemptId).toEqual(
     placementAttemptId
   );
+  expect(failedResponse.body.submittedEvent.submittedAt).toEqual(
+    failedResponse.body.submittedAt
+  );
 
   const pendingSlip = await Slip.findById(slip.id);
   expect(pendingSlip!.status).toEqual(SlipStatus.SUBMITTED);
@@ -712,12 +715,16 @@ it("keeps the board submitted and pending when publish confirm fails", async () 
   expect(pendingSlip!.submittedEvent?.placementAttemptId).toEqual(
     placementAttemptId
   );
+  expect(pendingSlip!.submittedEvent?.submittedAt).toEqual(
+    pendingSlip!.submittedAt
+  );
   expect(publishWithConfirmMock).toHaveBeenCalledTimes(1);
   expect(publishWithConfirmMock).toHaveBeenCalledWith(
     expect.objectContaining({
       data: expect.objectContaining({
         slipId: slip.id,
         placementAttemptId,
+        submittedAt: pendingSlip!.submittedAt,
       }),
     })
   );

--- a/slip/src/service/SlipSubmissionWorker.ts
+++ b/slip/src/service/SlipSubmissionWorker.ts
@@ -198,6 +198,7 @@ export const submitDraftSlipAtomically = async (
           userId: args.userId,
           userName: args.userName,
           slipId: args.slipId,
+          submittedAt,
           placementAttemptId: args.placementAttemptId,
           wager: args.wager,
           rows: buildSubmittedEventRowsExpression(args.betKind),

--- a/slip/src/service/__test__/SlipSubmissionWorker.test.ts
+++ b/slip/src/service/__test__/SlipSubmissionWorker.test.ts
@@ -89,6 +89,7 @@ const createSubmittedSlip = async ({
       userId,
       userName: `${userId}@example.com`,
       slipId,
+      submittedAt,
       placementAttemptId:
         placementAttemptId ?? buildPlacementAttemptId(slipId),
       wager: 5,
@@ -232,6 +233,7 @@ it("keeps the slip submitted, times out unknown delivery, and retries the same p
   expect(pendingSlip!.submittedEvent?.placementAttemptId).toEqual(
     placementAttemptId
   );
+  expect(pendingSlip!.submittedEvent?.submittedAt).toEqual(slip.submittedAt);
 
   publishWithConfirmMock.mockResolvedValueOnce(undefined);
   await worker.replayDueSubmissions();
@@ -245,6 +247,7 @@ it("keeps the slip submitted, times out unknown delivery, and retries the same p
       data: expect.objectContaining({
         slipId: slip.id,
         placementAttemptId,
+        submittedAt: slip.submittedAt,
         wager: 5,
       }),
     })
@@ -292,6 +295,7 @@ it("reclaims a stale processing lease on replay and publishes the submitted atte
       data: expect.objectContaining({
         slipId: slip.id,
         placementAttemptId,
+        submittedAt: staleSubmittedAt,
       }),
     })
   );


### PR DESCRIPTION
## Summary
- expire every open live quote at the next authoritative simulation transition
- bind moderation to the immutable server submission time and fail closed on missing metadata
- reject stale/missing quote expiry in Event and client
- remove direct workflow-input shell interpolation and add a fixture-tested guard

## Validation
- complete client, event, gamemaster, moderation, and slip suites
- TypeScript checks for changed services
- production workflow inventory, rollback, migration-recovery, and shell-input guard contracts
- independent security review: no findings