### PR TITLE
Promote capacity queue artifact hardening

### DIFF
--- a/.github/agents/betstan-deployment-safety.agent.md
+++ b/.github/agents/betstan-deployment-safety.agent.md
@@ -51,6 +51,11 @@ inactive. Fail closed when either query is incomplete or fails.
 - Normal changes enter `dev`. Only an up-to-date pull request from `dev` may promote to `master`.
 - For a PR created and labelled `copilot-cli-managed` by the active Copilot CLI workflow, continue without a separate human prompt only after the exact-SHA automated approval gates pass. Work without that provenance requires explicit user approval for the exact target SHA and complete production-capable workflow set.
 - Automatic approval never waives required checks, trusted workflow provenance, resolved review threads, production-run exclusivity, immutable image identity, rollback readiness, or post-deploy verification.
+- Production-run exclusivity may ignore an active stale queue artifact only
+  for `oci-capacity-acquire`: require an old jobless and approval-free
+  first-attempt manual dispatch for a non-current SHA plus a later successful
+  first-attempt run for the exact workflow and SHA. Never apply this exception
+  to deployment, activation, rollback, infrastructure, or data workflows.
 - Use `copilot-cli-run-approval-stan.sh` for protected build/deploy
   environments in automatic mode. Exact-title capacity acquisition,
   `validate-registry`, `prune-registry`, infrastructure `finalize`, and the

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -221,8 +221,13 @@ cd resulting && npm ci && npm run test:ci
   failing suite cannot appear green.
 - A protected environment wait is active progress. Report the exact run,
   phase, and pending environment instead of presenting a silent wait.
-- A jobless stale GitHub queue record can be an inert provider artifact, but it
-  is never authority to recover data or mutate production.
+- A jobless stale GitHub queue record can be an inert provider artifact, but
+  only the idempotent capacity workflow may ignore one while active: it must
+  be an old first-attempt manual dispatch for a non-current SHA, have no jobs
+  or approvals, and be superseded by a later successful first-attempt run for
+  the same workflow and SHA. Never extend that exception to deploy, activation,
+  rollback, infrastructure, or data workflows, and never treat it as authority
+  to recover data or mutate production.
 - Deleted Entra service principals require a successful list-all,
   client-side exact-ID absence probe; a server-filter 404 is not usable
   evidence. Role-assignment IDs must also bind to their declared parent scope.

--- a/infra/azure/agents/production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/production-run-exclusivity-stan.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Purpose: block concurrent production-capable activity while ignoring only
-#          old, disabled GitHub queue records proven to have no jobs or gates.
+#          queue records proven inert by bounded GitHub evidence.
 
 REPO="${REPO:-vasilyevstan/betstan}"
 EXCLUDE_RUN_ID="${EXCLUDE_RUN_ID:-}"
@@ -80,17 +80,24 @@ while index < len(payload):
             run.get("path"),
             run.get("status"),
             run.get("updated_at"),
+            run.get("head_sha"),
+            run.get("event"),
+            run.get("run_attempt"),
         )
         if (
             not isinstance(run_id, int)
             or not isinstance(run.get("workflow_id"), int)
-            or any(not isinstance(value, str) or not value for value in values[2:])
+            or any(not isinstance(value, str) or not value for value in values[2:7])
+            or not isinstance(values[7], int)
+            or values[7] < 1
         ):
             raise SystemExit("active run metadata is malformed")
         print("\t".join(str(value) for value in values))
 PY
 
-while IFS=$'\t' read -r run_id workflow_id path status updated_at; do
+while IFS=$'\t' read -r \
+  run_id workflow_id path status updated_at head_sha event run_attempt
+do
   [[ -n "${run_id:-}" ]] || continue
   if [[ "$run_id" == "$EXCLUDE_RUN_ID" ]]; then
     continue
@@ -99,8 +106,39 @@ while IFS=$'\t' read -r run_id workflow_id path status updated_at; do
   workflow_json="$(gh api "repos/$REPO/actions/workflows/$workflow_id")"
   jobs_json="$(gh api "repos/$REPO/actions/runs/$run_id/jobs?per_page=1")"
   pending_json="$(gh api "repos/$REPO/actions/runs/$run_id/pending_deployments")"
+  master_sha=""
+  successful_runs_json='{"total_count":0,"workflow_runs":[]}'
+  if [[
+    "$path" == ".github/workflows/oci-capacity-acquire.yml" &&
+      "$status" == "queued"
+  ]]; then
+    master_sha="$(
+      gh api "repos/$REPO/git/ref/heads/master" |
+        python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+print((payload.get("object") or {}).get("sha", ""))
+'
+    )"
+    [[ "$master_sha" =~ ^[0-9a-f]{40}$ ]] || {
+      echo "Current master SHA is unavailable or malformed" >&2
+      exit 1
+    }
+    [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || {
+      echo "Run $run_id has a malformed head SHA" >&2
+      exit 1
+    }
+    successful_runs_json="$(
+      gh api \
+        "repos/$REPO/actions/workflows/$workflow_id/runs?head_sha=$head_sha&event=workflow_dispatch&status=success&per_page=100"
+    )"
+  fi
   classification="$(
-    python3 - "$workflow_json" "$jobs_json" "$pending_json" "$updated_at" \
+    python3 - "$workflow_json" "$jobs_json" "$pending_json" \
+      "$successful_runs_json" "$run_id" "$workflow_id" "$path" "$status" \
+      "$updated_at" "$head_sha" "$event" "$run_attempt" "$master_sha" \
       "$NOW_EPOCH" "$STALE_DISABLED_MIN_AGE_SECONDS" <<'PY'
 import datetime
 import json
@@ -109,23 +147,85 @@ import sys
 workflow = json.loads(sys.argv[1])
 jobs = json.loads(sys.argv[2])
 pending = json.loads(sys.argv[3])
-updated_at = datetime.datetime.fromisoformat(sys.argv[4].replace("Z", "+00:00"))
-now = datetime.datetime.fromtimestamp(int(sys.argv[5]), datetime.timezone.utc)
-minimum_age = int(sys.argv[6])
+successful_runs = json.loads(sys.argv[4])
+run_id = int(sys.argv[5])
+workflow_id = int(sys.argv[6])
+path = sys.argv[7]
+status = sys.argv[8]
+updated_at = datetime.datetime.fromisoformat(sys.argv[9].replace("Z", "+00:00"))
+head_sha = sys.argv[10]
+event = sys.argv[11]
+run_attempt = int(sys.argv[12])
+master_sha = sys.argv[13]
+now = datetime.datetime.fromtimestamp(int(sys.argv[14]), datetime.timezone.utc)
+minimum_age = int(sys.argv[15])
 state = workflow.get("state")
 job_count = jobs.get("total_count")
-if not isinstance(state, str) or not isinstance(job_count, int) or not isinstance(pending, list):
+job_entries = jobs.get("jobs")
+successful_entries = successful_runs.get("workflow_runs")
+if (
+    not isinstance(state, str)
+    or workflow.get("path") != path
+    or not isinstance(job_count, int)
+    or job_count < 0
+    or not isinstance(job_entries, list)
+    or not isinstance(pending, list)
+    or not isinstance(successful_entries, list)
+):
     raise SystemExit("production run actionability metadata is malformed")
 age_seconds = int((now - updated_at).total_seconds())
-inert = (
-    state.startswith("disabled_")
-    and job_count == 0
+jobless_and_old = (
+    job_count == 0
+    and len(job_entries) == 0
     and len(pending) == 0
     and age_seconds >= minimum_age
 )
+disabled_inert = (
+    state.startswith("disabled_")
+    and jobless_and_old
+)
+
+superseded_by = None
+if (
+    state == "active"
+    and path == ".github/workflows/oci-capacity-acquire.yml"
+    and status == "queued"
+    and event == "workflow_dispatch"
+    and run_attempt == 1
+    and head_sha != master_sha
+    and jobless_and_old
+):
+    for successful in successful_entries:
+        if not isinstance(successful, dict):
+            continue
+        try:
+            successful_id = int(successful.get("id"))
+            successful_created_at = datetime.datetime.fromisoformat(
+                successful.get("created_at", "").replace("Z", "+00:00")
+            )
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if (
+            successful_id > run_id
+            and successful_created_at > updated_at
+            and successful.get("workflow_id") == workflow_id
+            and successful.get("path") == path
+            and successful.get("head_sha") == head_sha
+            and successful.get("head_branch") == "master"
+            and successful.get("event") == event
+            and successful.get("status") == "completed"
+            and successful.get("conclusion") == "success"
+            and successful.get("run_attempt") == 1
+        ):
+            superseded_by = successful_id
+            break
+
+inert = disabled_inert or superseded_by is not None
+reason = "disabled" if disabled_inert else "superseded" if superseded_by else "none"
 print(
     f"inert={'yes' if inert else 'no'} state={state} jobs={job_count} "
-    f"pending={len(pending)} age_seconds={age_seconds}"
+    f"pending={len(pending)} age_seconds={age_seconds} reason={reason}"
+    + (f" superseded_by={superseded_by}" if superseded_by else "")
 )
 PY
   )"

--- a/infra/azure/agents/test-production-run-exclusivity-stan.sh
+++ b/infra/azure/agents/test-production-run-exclusivity-stan.sh
@@ -5,24 +5,104 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 EXCLUSIVITY="$ROOT_DIR/infra/azure/agents/production-run-exclusivity-stan.sh"
 RUN_ID=123
 WORKFLOW_ID=456
+MASTER_SHA=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+OLD_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 gh() {
   if [[ "$1" == "api" && "$2" == *"/actions/runs?status="* ]]; then
-    if [[ "${STUB_MODE:-none}" == "none" || "$2" != *"status=in_progress"* ]]; then
+    local mode="${STUB_MODE:-none}"
+    if [[ "$mode" == "none" ]]; then
       printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
       return
     fi
-    if [[ "$STUB_MODE" == "overflow" ]]; then
+    if [[ "$mode" == "overflow" && "$2" == *"status=in_progress"* ]]; then
       printf '%s\n' '{"total_count":101,"workflow_runs":[]}'
       return
     fi
+
     local branch=master
-    if [[ "$STUB_MODE" == "pr-validation" ]]; then
+    if [[ "$mode" == "pr-validation" ]]; then
       branch=dev
     fi
     local updated_at=1970-01-01T00:00:00Z
-    if [[ "$STUB_MODE" == "recent-disabled" ]]; then
-      updated_at=1970-01-01T00:33:20Z
+    if [[ "$mode" == "recent-disabled" || "$mode" == "recent-superseded-capacity" ]]; then
+      updated_at=1970-01-01T00:31:40Z
+    fi
+    local path=.github/workflows/production-build.yml
+    local run_status=in_progress
+    local event=push
+    local head_sha="$OLD_SHA"
+    local run_attempt=1
+    if [[ "$mode" == "data-active" ]]; then
+      path=.github/workflows/oci-live-data-rollout.yml
+    elif [[ "$mode" == "activation-active" ]]; then
+      path=.github/workflows/oci-live-betting-activate.yml
+    elif [[ "$mode" == "disable-active" ]]; then
+      path=.github/workflows/oci-live-betting-disable.yml
+    elif [[ "$mode" == "superseded-deploy" ]]; then
+      path=.github/workflows/oci-production-deploy.yml
+      run_status=queued
+      event=workflow_dispatch
+    elif [[ "$mode" == *capacity* ]]; then
+      path=.github/workflows/oci-capacity-acquire.yml
+      run_status=queued
+      event=workflow_dispatch
+    fi
+    if [[ "$mode" == "current-superseded-capacity" ]]; then
+      head_sha="$MASTER_SHA"
+    fi
+    if [[ "$mode" == "wrong-attempt-superseded-capacity" ]]; then
+      run_attempt=2
+    fi
+    if [[ "$2" != *"status=$run_status"* ]]; then
+      printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
+      return
+    fi
+    printf '%s\n' \
+      "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"workflow_id\":$WORKFLOW_ID,\"path\":\"$path\",\"head_branch\":\"$branch\",\"head_sha\":\"$head_sha\",\"event\":\"$event\",\"run_attempt\":$run_attempt,\"status\":\"$run_status\",\"updated_at\":\"$updated_at\"}]}"
+  elif [[ "$1" == "api" && "$2" == *"/actions/workflows/$WORKFLOW_ID/runs?"* ]]; then
+    [[ "$2" == *"event=workflow_dispatch"* ]] || {
+      echo "successful-run proof was not limited to manual dispatches" >&2
+      return 1
+    }
+    local mode="${STUB_MODE:-none}"
+    case "$mode" in
+      superseded-capacity | current-superseded-capacity | \
+        recent-superseded-capacity | pending-superseded-capacity | \
+        jobs-superseded-capacity | wrong-attempt-superseded-capacity)
+        local successful_sha="$OLD_SHA"
+        if [[ "$mode" == "current-superseded-capacity" ]]; then
+          successful_sha="$MASTER_SHA"
+        fi
+        printf '%s\n' \
+          "{\"total_count\":1,\"workflow_runs\":[{\"id\":124,\"workflow_id\":$WORKFLOW_ID,\"path\":\".github/workflows/oci-capacity-acquire.yml\",\"head_branch\":\"master\",\"head_sha\":\"$successful_sha\",\"event\":\"workflow_dispatch\",\"run_attempt\":1,\"status\":\"completed\",\"conclusion\":\"success\",\"created_at\":\"1970-01-01T00:32:30Z\"}]}"
+        ;;
+      rerun-superseded-capacity)
+        printf '%s\n' \
+          "{\"total_count\":1,\"workflow_runs\":[{\"id\":124,\"workflow_id\":$WORKFLOW_ID,\"path\":\".github/workflows/oci-capacity-acquire.yml\",\"head_branch\":\"master\",\"head_sha\":\"$OLD_SHA\",\"event\":\"workflow_dispatch\",\"run_attempt\":2,\"status\":\"completed\",\"conclusion\":\"success\",\"created_at\":\"1970-01-01T00:32:30Z\"}]}"
+        ;;
+      older-success-capacity)
+        printf '%s\n' \
+          "{\"total_count\":1,\"workflow_runs\":[{\"id\":124,\"workflow_id\":$WORKFLOW_ID,\"path\":\".github/workflows/oci-capacity-acquire.yml\",\"head_branch\":\"master\",\"head_sha\":\"$OLD_SHA\",\"event\":\"workflow_dispatch\",\"run_attempt\":1,\"status\":\"completed\",\"conclusion\":\"success\",\"created_at\":\"1969-12-31T23:59:59Z\"}]}"
+        ;;
+      earlier-id-success-capacity)
+        printf '%s\n' \
+          "{\"total_count\":1,\"workflow_runs\":[{\"id\":122,\"workflow_id\":$WORKFLOW_ID,\"path\":\".github/workflows/oci-capacity-acquire.yml\",\"head_branch\":\"master\",\"head_sha\":\"$OLD_SHA\",\"event\":\"workflow_dispatch\",\"run_attempt\":1,\"status\":\"completed\",\"conclusion\":\"success\",\"created_at\":\"1970-01-01T00:32:30Z\"}]}"
+        ;;
+      different-sha-success-capacity)
+        printf '%s\n' \
+          "{\"total_count\":1,\"workflow_runs\":[{\"id\":124,\"workflow_id\":$WORKFLOW_ID,\"path\":\".github/workflows/oci-capacity-acquire.yml\",\"head_branch\":\"master\",\"head_sha\":\"$MASTER_SHA\",\"event\":\"workflow_dispatch\",\"run_attempt\":1,\"status\":\"completed\",\"conclusion\":\"success\",\"created_at\":\"1970-01-01T00:32:30Z\"}]}"
+        ;;
+      *)
+        printf '%s\n' '{"total_count":0,"workflow_runs":[]}'
+        ;;
+    esac
+  elif [[ "$1" == "api" && "$2" == *"/git/ref/heads/master" ]]; then
+    printf '%s\n' "{\"object\":{\"sha\":\"$MASTER_SHA\"}}"
+  elif [[ "$1" == "api" && "$2" == *"/actions/workflows/$WORKFLOW_ID"* ]]; then
+    local state=active
+    if [[ "$STUB_MODE" == *disabled* ]]; then
+      state=disabled_manually
     fi
     local path=.github/workflows/production-build.yml
     if [[ "$STUB_MODE" == "data-active" ]]; then
@@ -31,23 +111,35 @@ gh() {
       path=.github/workflows/oci-live-betting-activate.yml
     elif [[ "$STUB_MODE" == "disable-active" ]]; then
       path=.github/workflows/oci-live-betting-disable.yml
+    elif [[ "$STUB_MODE" == "superseded-deploy" ]]; then
+      path=.github/workflows/oci-production-deploy.yml
+    elif [[ "$STUB_MODE" == *capacity* ]]; then
+      path=.github/workflows/oci-capacity-acquire.yml
     fi
-    printf '%s\n' \
-      "{\"total_count\":1,\"workflow_runs\":[{\"id\":$RUN_ID,\"workflow_id\":$WORKFLOW_ID,\"path\":\"$path\",\"head_branch\":\"$branch\",\"status\":\"in_progress\",\"updated_at\":\"$updated_at\"}]}"
-  elif [[ "$1" == "api" && "$2" == *"/actions/workflows/$WORKFLOW_ID"* ]]; then
-    local state=active
-    if [[ "$STUB_MODE" == *disabled* ]]; then
-      state=disabled_manually
-    fi
-    printf '%s\n' "{\"id\":$WORKFLOW_ID,\"state\":\"$state\"}"
+    printf '%s\n' "{\"id\":$WORKFLOW_ID,\"state\":\"$state\",\"path\":\"$path\"}"
   elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID/jobs"* ]]; then
     local count=1
-    if [[ "$STUB_MODE" == "stale-disabled" || "$STUB_MODE" == "recent-disabled" || "$STUB_MODE" == "pending-disabled" ]]; then
-      count=0
+    case "$STUB_MODE" in
+      stale-disabled | recent-disabled | pending-disabled | \
+        superseded-capacity | unsuperseded-capacity | \
+        current-superseded-capacity | recent-superseded-capacity | \
+        pending-superseded-capacity | wrong-attempt-superseded-capacity | \
+        rerun-superseded-capacity | older-success-capacity | \
+        earlier-id-success-capacity | different-sha-success-capacity | \
+        superseded-deploy)
+        count=0
+        ;;
+    esac
+    if [[ "$STUB_MODE" == "jobs-superseded-capacity" ]]; then
+      count=1
     fi
-    printf '%s\n' "{\"total_count\":$count,\"jobs\":[]}"
+    local jobs='[{"id":1}]'
+    if [[ "$count" == "0" ]]; then
+      jobs='[]'
+    fi
+    printf '%s\n' "{\"total_count\":$count,\"jobs\":$jobs}"
   elif [[ "$1" == "api" && "$2" == *"/actions/runs/$RUN_ID/pending_deployments"* ]]; then
-    if [[ "$STUB_MODE" == "pending-disabled" ]]; then
+    if [[ "$STUB_MODE" == "pending-disabled" || "$STUB_MODE" == "pending-superseded-capacity" ]]; then
       printf '%s\n' '[{"environment":{"id":1,"name":"production-emergency"}}]'
     else
       printf '%s\n' '[]'
@@ -58,7 +150,7 @@ gh() {
   fi
 }
 export -f gh
-export RUN_ID WORKFLOW_ID
+export RUN_ID WORKFLOW_ID MASTER_SHA OLD_SHA
 
 REPO=example/repo NOW_EPOCH=2000 "$EXCLUSIVITY" >/dev/null
 REPO=example/repo NOW_EPOCH=2000 STUB_MODE=pr-validation \
@@ -67,8 +159,17 @@ REPO=example/repo NOW_EPOCH=2000 STUB_MODE=stale-disabled \
   "$EXCLUSIVITY" >/dev/null
 REPO=example/repo NOW_EPOCH=2000 STUB_MODE=active EXCLUDE_RUN_ID=$RUN_ID \
   "$EXCLUSIVITY" >/dev/null
+REPO=example/repo NOW_EPOCH=2000 STUB_MODE=superseded-capacity \
+  "$EXCLUSIVITY" >/dev/null
 
-for mode in active data-active activation-active disable-active recent-disabled pending-disabled jobs-disabled overflow; do
+for mode in active data-active activation-active disable-active recent-disabled \
+  pending-disabled jobs-disabled overflow unsuperseded-capacity \
+  current-superseded-capacity recent-superseded-capacity \
+  pending-superseded-capacity jobs-superseded-capacity \
+  wrong-attempt-superseded-capacity rerun-superseded-capacity \
+  older-success-capacity earlier-id-success-capacity \
+  different-sha-success-capacity superseded-deploy
+do
   if REPO=example/repo NOW_EPOCH=2000 STUB_MODE="$mode" \
     "$EXCLUSIVITY" >/dev/null 2>&1; then
     echo "production exclusivity accepted unsafe mode=$mode" >&2


### PR DESCRIPTION
## Summary
- promote the reviewed superseded OCI capacity queue classification
- preserve fail-closed exclusivity for deployment, activation, rollback, infrastructure, and data workflows
- unblock exact-master capacity provenance without deleting GitHub audit history

## Source
- merged development PR #289
- exact dev SHA `70629b3cf8d7f4faf76bdc754c5d970d094af4fa`