### PR TITLE
Fix OCI host-key output integrity

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -274,6 +274,10 @@ cd resulting && npm ci && npm run test:ci
   kubeconfig to one loopback server with inline certificates and reject exec,
   auth-provider, token, proxy, and external-file directives before `kubectl`
   contacts the API.
+- Oracle Cloud Agent 1.61 can return successful `TEXT` output with an empty
+  `text-sha256`. Keep host-key attestation fail closed by having the target emit
+  the key plus its SHA-256, requiring the exact two-line payload, and verifying
+  both that checksum and any OCI response checksum that is present.
 - Capture rollback evidence before any database lock or workload/data
   mutation. A zero-recovery baseline is valid only when all nine live
   references and exact deploy provenance are public GHCR digests; otherwise

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -75,6 +75,10 @@ conversation summaries are not authority.
   kubeconfig as untrusted input: reject executable/provider, token, proxy, and
   external-file directives, then reconstruct one loopback-only configuration
   from inline certificates before the first Kubernetes API request.
+- Oracle Cloud Agent 1.61 can complete a `TEXT` Run Command with valid output
+  while leaving `text-sha256` empty. Make the bounded command emit the host key
+  and its own SHA-256, validate the exact payload shape and checksum, and still
+  require OCI's response checksum to match whenever OCI supplies one.
 - Capture and validate rollback evidence before acquiring a database lock or
   changing a workload. An ordinary baseline is valid only when all nine live
   references and its exact deploy provenance identify public GHCR digests;

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -64,9 +64,12 @@ remains an explicit fallback selected with `OCI_RUNTIME_MODE=oke`.
   through a short-lived OCI Bastion SSH session and a target-loopback tunnel.
   The runner pins the Bastion host key from authenticated session metadata and
   the target host key from OCI Instance Agent Run Command before either SSH
-  connection. Imported k3s kubeconfigs are reduced to one loopback cluster and
-  inline certificates; executable providers, tokens, proxies, and external
-  credential files are rejected before any API request.
+  connection. The target command returns the key with a node-generated SHA-256
+  because Oracle Cloud Agent 1.61 can omit the response `text-sha256`; any OCI
+  checksum that is present is verified as an additional integrity boundary.
+  Imported k3s kubeconfigs are reduced to one loopback cluster and inline
+  certificates; executable providers, tokens, proxies, and external credential
+  files are rejected before any API request.
   Mongo and RabbitMQ remain `ClusterIP`.
 - The apex and `www` A records must equal exact load-balancer provenance and
   must not have a conflicting AAAA record. Canonical and diagnostic

--- a/infra/oci/scripts/configure-k3s-access.sh
+++ b/infra/oci/scripts/configure-k3s-access.sh
@@ -165,9 +165,14 @@ write_known_host() {
 attest_target_host_key() {
   local command_text content target command_id execution_json lifecycle_state
   local output_file expected_sha actual_sha exit_code output_type attempt
+  local public_key reported_public_key_sha256 actual_public_key_sha256
+  local output_line_count
   command_text='set -eu
-test -f /etc/ssh/ssh_host_ed25519_key.pub
-cat /etc/ssh/ssh_host_ed25519_key.pub'
+key_file=/etc/ssh/ssh_host_ed25519_key.pub
+test -f "$key_file"
+public_key="$(cat "$key_file")"
+public_key_sha256="$(printf "%s\n" "$public_key" | sha256sum | cut -d " " -f 1)"
+printf "%s\n%s\n" "$public_key" "$public_key_sha256"'
   content="$(
     jq -cn --arg text "$command_text" \
       '{source:{sourceType:"TEXT",text:$text},output:{outputType:"TEXT"}}'
@@ -216,15 +221,29 @@ cat /etc/ssh/ssh_host_ed25519_key.pub'
   output_type="$(jq -r '.data.content."output-type" // empty' "$execution_json")"
   exit_code="$(jq -r '.data.content."exit-code" // empty' "$execution_json")"
   expected_sha="$(jq -r '.data.content."text-sha256" // empty' "$execution_json")"
-  [[ "$output_type" == "TEXT" && "$exit_code" == "0" &&
-     "$expected_sha" =~ ^[0-9a-f]{64}$ ]] ||
+  [[ "$output_type" == "TEXT" && "$exit_code" == "0" ]] ||
     oci_die "OCI-attested target host-key response is incomplete"
   output_file="$WORK_DIR/target-host-key-output"
   jq -j '.data.content.text // empty' "$execution_json" >"$output_file"
-  actual_sha="$(oci_sha256 <"$output_file")"
-  [[ "$actual_sha" == "$expected_sha" ]] ||
-    oci_die "OCI-attested target host-key output checksum does not match"
-  normalize_host_public_key "$(cat "$output_file")"
+  if [[ -n "$expected_sha" ]]; then
+    [[ "$expected_sha" =~ ^[0-9a-f]{64}$ ]] ||
+      oci_die "OCI-attested target host-key response checksum is malformed"
+    actual_sha="$(oci_sha256 <"$output_file")"
+    [[ "$actual_sha" == "$expected_sha" ]] ||
+      oci_die "OCI-attested target host-key output checksum does not match"
+  fi
+
+  output_line_count="$(wc -l <"$output_file" | tr -d ' ')"
+  [[ "$output_line_count" == "2" ]] ||
+    oci_die "OCI-attested target host-key payload is incomplete"
+  public_key="$(sed -n '1p' "$output_file")"
+  reported_public_key_sha256="$(sed -n '2p' "$output_file")"
+  [[ "$reported_public_key_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+    oci_die "OCI-attested target host-key payload checksum is malformed"
+  actual_public_key_sha256="$(printf '%s\n' "$public_key" | oci_sha256)"
+  [[ "$actual_public_key_sha256" == "$reported_public_key_sha256" ]] ||
+    oci_die "OCI-attested target host-key payload checksum does not match"
+  normalize_host_public_key "$public_key"
 }
 
 session_connection_metadata() {

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -652,6 +652,9 @@ for literal in \
   '.data."bastion-public-host-key-info"' \
   'oci instance-agent command create' \
   'oci instance-agent command-execution get' \
+  'public_key_sha256="$(printf "%s\n" "$public_key" | sha256sum' \
+  'if [[ -n "$expected_sha" ]]; then' \
+  '"$actual_public_key_sha256" == "$reported_public_key_sha256"' \
   'write_known_host "$instance_ocid" 22' \
   'StrictHostKeyChecking=yes' \
   'validate-k3s-kubeconfig.sh'; do


### PR DESCRIPTION
## Summary
- support Oracle Cloud Agent 1.61 responses that omit `text-sha256`
- require a node-generated host-key SHA-256 and exact two-line payload
- keep verifying OCI response checksums whenever present
- document the production finding

## Evidence
- `infra/oci/tests/test-k3s-runtime-contract.sh` passes
- production read-only Run Command probe returned `SUCCEEDED`, verified the payload SHA-256, and validated the SSH public key
- failed recovery run 32897264674 stopped before image export, plan creation, or deployment mutation