### PR TITLE
Validate OCI host key via stdin

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -282,6 +282,10 @@ cd resulting && npm ci && npm run test:ci
   agent before executing. Poll for the existing bounded five-minute window and
   distinguish acceptance latency from terminal command failure; do not retry a
   production workflow merely because a shorter client poll expired.
+- Validate normalized OCI host keys through `ssh-keygen` standard input, matching
+  the retained SSH public-key validation path. A runner-specific temporary-file
+  parse can reject a key whose checksummed bytes match independently attested
+  evidence.
 - Capture rollback evidence before any database lock or workload/data
   mutation. A zero-recovery baseline is valid only when all nine live
   references and exact deploy provenance are public GHCR digests; otherwise

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -83,6 +83,10 @@ conversation summaries are not authority.
   Use the bounded five-minute poll allowance already enforced by the access
   script, and inspect late command state before diagnosing agent failure or
   dispatching another production workflow.
+- Feed normalized host keys to `ssh-keygen` through standard input, as the
+  retained SSH-key validator already does. Preserve checksum, exact-line, and
+  supported-key-type validation rather than trusting a runner-specific
+  temporary-file parse result.
 - Capture and validate rollback evidence before acquiring a database lock or
   changing a workload. An ordinary baseline is valid only when all nine live
   references and its exact deploy provenance identify public GHCR digests;

--- a/infra/oci/scripts/configure-k3s-access.sh
+++ b/infra/oci/scripts/configure-k3s-access.sh
@@ -123,7 +123,7 @@ wait_active_session_id() {
 
 normalize_host_public_key() {
   local raw_key="$1"
-  local normalized key_file
+  local normalized
   normalized="$(
     awk '
       NF {
@@ -137,11 +137,11 @@ normalize_host_public_key() {
   )"
   [[ "$(wc -l <<<"$normalized" | tr -d ' ')" == "1" ]] ||
     oci_die "OCI host-key evidence did not contain exactly one supported public key"
-  key_file="$(mktemp "$WORK_DIR/.host-key.XXXXXX")"
-  printf '%s\n' "$normalized" >"$key_file"
-  ssh-keygen -l -f "$key_file" >/dev/null ||
+  [[ -n "$normalized" ]] ||
+    oci_die "OCI host-key evidence did not contain a supported public key"
+  printf '%s\n' "$normalized" |
+    ssh-keygen -l -f - >/dev/null ||
     oci_die "OCI host-key evidence is not a valid SSH public key"
-  rm -f -- "$key_file"
   printf '%s\n' "$normalized"
 }
 

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -661,6 +661,7 @@ for literal in \
   'public_key_sha256="$(printf "%s\n" "$public_key" | sha256sum' \
   'if [[ -n "$expected_sha" ]]; then' \
   '"$actual_public_key_sha256" == "$reported_public_key_sha256"' \
+  'ssh-keygen -l -f -' \
   'write_known_host "$instance_ocid" 22' \
   'StrictHostKeyChecking=yes' \
   'validate-k3s-kubeconfig.sh'; do


### PR DESCRIPTION
## Summary
- align OCI host-key validation with the existing retained-key `ssh-keygen -f -` path
- reject an empty normalized key explicitly
- preserve exact payload, checksum, supported key type, and strict host-checking gates
- document the runner-specific parser finding

## Evidence
- recovered OCI payload passed exact shape and node SHA-256 validation
- normalized payload matches the console-attested host key byte-for-byte
- exact rejected key validates through `ssh-keygen -f -`
- k3s runtime contract passes
- recovery 32906441363 stopped before Bastion session creation, export, plan, or deployment mutation