### PR TITLE
Attest OCI Bastion key through Run Command

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -268,16 +268,19 @@ cd resulting && npm ci && npm run test:ci
 - Pin privileged helper containers as well as Actions. In particular, a
   digest-pinned `docker/setup-qemu-action` still inherits risk from a mutable
   default `tonistiigi/binfmt` image unless its `image` input is also a digest.
-- Production SSH must not use trust on first use. Derive the Bastion host key
-  from authenticated OCI session metadata and the target key from OCI Instance
-  Agent Run Command, then require strict matching. Normalize any remote
-  kubeconfig to one loopback server with inline certificates and reject exec,
-  auth-provider, token, proxy, and external-file directives before `kubectl`
-  contacts the API.
+- Production SSH must not use trust on first use. Retrieve the target key
+  through OCI Instance Agent Run Command. Use that authenticated channel to
+  observe the regional Bastion key when an ACTIVE session returns null
+  `bastion-public-host-key-info`, while preferring authenticated session
+  metadata whenever OCI supplies it. Require strict matching. Normalize any
+  remote kubeconfig to one loopback server with inline certificates and reject
+  exec, auth-provider, token, proxy, and external-file directives before
+  `kubectl` contacts the API.
 - Oracle Cloud Agent 1.61 can return successful `TEXT` output with an empty
   `text-sha256`. Keep host-key attestation fail closed by having the target emit
-  the key plus its SHA-256, requiring the exact two-line payload, and verifying
-  both that checksum and any OCI response checksum that is present.
+  the target and Bastion keys plus their SHA-256 values, requiring the exact
+  four-line payload, and verifying both checksums plus any OCI response
+  checksum that is present.
 - OCI Run Command can remain `ACCEPTED` for more than three minutes on a healthy
   agent before executing. Poll for the existing bounded five-minute window and
   distinguish acceptance latency from terminal command failure; do not retry a

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -69,12 +69,15 @@ conversation summaries are not authority.
   before retiring `ocir-pull` or deleting the exact empty OCIR repository.
 - Privileged build helpers are part of the release supply chain. Pin both the
   QEMU setup action and its `tonistiigi/binfmt` image by immutable digest.
-- Never establish production SSH trust with TOFU. Bind the Bastion host key to
-  authenticated OCI session metadata, retrieve the target host key through
-  OCI Instance Agent Run Command, and use strict host checking. Treat a remote
-  kubeconfig as untrusted input: reject executable/provider, token, proxy, and
-  external-file directives, then reconstruct one loopback-only configuration
-  from inline certificates before the first Kubernetes API request.
+- Never establish production SSH trust with TOFU. Retrieve the target key
+  through OCI Instance Agent Run Command. Have that authenticated channel also
+  observe the regional Bastion key because an ACTIVE port-forwarding session
+  may return null `bastion-public-host-key-info`; prefer authenticated session
+  metadata whenever OCI supplies it. Verify node-generated checksums and use
+  strict host checking. Treat a remote kubeconfig as untrusted input: reject
+  executable/provider, token, proxy, and external-file directives, then
+  reconstruct one loopback-only configuration from inline certificates before
+  the first Kubernetes API request.
 - Oracle Cloud Agent 1.61 can complete a `TEXT` Run Command with valid output
   while leaving `text-sha256` empty. Make the bounded command emit the host key
   and its own SHA-256, validate the exact payload shape and checksum, and still

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -62,16 +62,19 @@ remains an explicit fallback selected with `OCI_RUNTIME_MODE=oke`.
 - Only the OCI load balancer exposes ports 80/443. In k3s mode, ingress-nginx
   uses fixed NodePorts 30080/30443 and the Kubernetes API is reachable only
   through a short-lived OCI Bastion SSH session and a target-loopback tunnel.
-  The runner pins the Bastion host key from authenticated session metadata and
-  the target host key from OCI Instance Agent Run Command before either SSH
-  connection. The target command returns the key with a node-generated SHA-256
-  because Oracle Cloud Agent 1.61 can omit the response `text-sha256`; any OCI
-  checksum that is present is verified as an additional integrity boundary. A
-  healthy command may remain `ACCEPTED` for more than three minutes, so access
-  setup uses a bounded five-minute poll window. Imported k3s kubeconfigs are
-  reduced to one loopback cluster and inline certificates; executable
-  providers, tokens, proxies, and external credential files are rejected
-  before any API request.
+  The runner pins the target host key through OCI Instance Agent Run Command
+  before SSH. The same authenticated command independently observes the
+  regional Bastion ED25519 key; authenticated session metadata takes
+  precedence when OCI supplies it, while the command-attested key is the
+  fail-closed fallback because ACTIVE port-forwarding sessions can return null
+  `bastion-public-host-key-info`. The command returns both keys with
+  node-generated SHA-256 values because Oracle Cloud Agent 1.61 can omit the
+  response `text-sha256`; any OCI checksum that is present is verified as an
+  additional integrity boundary. A healthy command may remain `ACCEPTED` for
+  more than three minutes, so access setup uses a bounded five-minute poll
+  window. Imported k3s kubeconfigs are reduced to one loopback cluster and
+  inline certificates; executable providers, tokens, proxies, and external
+  credential files are rejected before any API request.
   Mongo and RabbitMQ remain `ClusterIP`.
 - The apex and `www` A records must equal exact load-balancer provenance and
   must not have a conflicting AAAA record. Canonical and diagnostic

--- a/infra/oci/scripts/configure-k3s-access.sh
+++ b/infra/oci/scripts/configure-k3s-access.sh
@@ -162,17 +162,37 @@ write_known_host() {
   chmod 600 "$output_file"
 }
 
-attest_target_host_key() {
+attest_ssh_host_keys() {
   local command_text content target command_id execution_json lifecycle_state
   local output_file expected_sha actual_sha exit_code output_type attempt
-  local public_key reported_public_key_sha256 actual_public_key_sha256
+  local target_public_key reported_target_public_key_sha256
+  local actual_target_public_key_sha256 normalized_target_public_key
+  local bastion_endpoint bastion_public_key reported_bastion_public_key_sha256
+  local actual_bastion_public_key_sha256 normalized_bastion_public_key
   local output_line_count
+  bastion_endpoint="host.bastion.${OCI_CLI_REGION}.oci.oraclecloud.com"
   command_text='set -eu
 key_file=/etc/ssh/ssh_host_ed25519_key.pub
 test -f "$key_file"
-public_key="$(cat "$key_file")"
-public_key_sha256="$(printf "%s\n" "$public_key" | sha256sum | cut -d " " -f 1)"
-printf "%s\n%s\n" "$public_key" "$public_key_sha256"'
+target_public_key="$(cat "$key_file")"
+target_public_key_sha256="$(printf "%s\n" "$target_public_key" | sha256sum | cut -d " " -f 1)"
+bastion_endpoint="'"$bastion_endpoint"'"
+bastion_public_key="$(
+  ssh-keyscan -T 10 -t ed25519 "$bastion_endpoint" 2>/dev/null |
+    while read -r _ algorithm key extra; do
+      if test "$algorithm" = "ssh-ed25519" &&
+         test -n "$key" &&
+         test -z "${extra:-}"; then
+        printf "%s %s\n" "$algorithm" "$key"
+      fi
+    done |
+    sort -u
+)"
+test "$(printf "%s\n" "$bastion_public_key" | grep -c .)" -eq 1
+bastion_public_key_sha256="$(printf "%s\n" "$bastion_public_key" | sha256sum | cut -d " " -f 1)"
+printf "%s\n%s\n%s\n%s\n" \
+  "$target_public_key" "$target_public_key_sha256" \
+  "$bastion_public_key" "$bastion_public_key_sha256"'
   content="$(
     jq -cn --arg text "$command_text" \
       '{source:{sourceType:"TEXT",text:$text},output:{outputType:"TEXT"}}'
@@ -234,22 +254,35 @@ printf "%s\n%s\n" "$public_key" "$public_key_sha256"'
   fi
 
   output_line_count="$(wc -l <"$output_file" | tr -d ' ')"
-  [[ "$output_line_count" == "2" ]] ||
-    oci_die "OCI-attested target host-key payload is incomplete"
-  public_key="$(sed -n '1p' "$output_file")"
-  reported_public_key_sha256="$(sed -n '2p' "$output_file")"
-  [[ "$reported_public_key_sha256" =~ ^[0-9a-f]{64}$ ]] ||
-    oci_die "OCI-attested target host-key payload checksum is malformed"
-  actual_public_key_sha256="$(printf '%s\n' "$public_key" | oci_sha256)"
-  [[ "$actual_public_key_sha256" == "$reported_public_key_sha256" ]] ||
-    oci_die "OCI-attested target host-key payload checksum does not match"
-  normalize_host_public_key "$public_key"
+  [[ "$output_line_count" == "4" ]] ||
+    oci_die "OCI-attested SSH host-key payload is incomplete"
+  target_public_key="$(sed -n '1p' "$output_file")"
+  reported_target_public_key_sha256="$(sed -n '2p' "$output_file")"
+  bastion_public_key="$(sed -n '3p' "$output_file")"
+  reported_bastion_public_key_sha256="$(sed -n '4p' "$output_file")"
+  [[ "$reported_target_public_key_sha256" =~ ^[0-9a-f]{64}$ &&
+     "$reported_bastion_public_key_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+    oci_die "OCI-attested SSH host-key payload checksum is malformed"
+  actual_target_public_key_sha256="$(
+    printf '%s\n' "$target_public_key" | oci_sha256
+  )"
+  actual_bastion_public_key_sha256="$(
+    printf '%s\n' "$bastion_public_key" | oci_sha256
+  )"
+  [[ "$actual_target_public_key_sha256" == "$reported_target_public_key_sha256" &&
+     "$actual_bastion_public_key_sha256" == "$reported_bastion_public_key_sha256" ]] ||
+    oci_die "OCI-attested SSH host-key payload checksum does not match"
+  normalized_target_public_key="$(normalize_host_public_key "$target_public_key")"
+  normalized_bastion_public_key="$(normalize_host_public_key "$bastion_public_key")"
+  printf '%s\t%s\n' "$normalized_target_public_key" "$normalized_bastion_public_key"
 }
 
 session_connection_metadata() {
   local session_id="$1"
   local target_port="$2"
-  local session expected_endpoint expected_command actual_command public_key
+  local attested_public_key="$3"
+  local session expected_endpoint expected_command actual_command
+  local api_public_key public_key
   expected_endpoint="host.bastion.${OCI_CLI_REGION}.oci.oraclecloud.com"
   expected_command="ssh -i <privateKey> -N -L <localPort>:${instance_private_ip}:${target_port} -p 22 ${session_id}@${expected_endpoint}"
   session="$(oci bastion session get --session-id "$session_id")"
@@ -269,11 +302,23 @@ session_connection_metadata() {
   actual_command="$(jq -r '.data."ssh-metadata".command // empty' <<<"$session")"
   [[ "$actual_command" == "$expected_command" ]] ||
     oci_die "OCI Bastion SSH metadata differs from the requested port forward"
-  public_key="$(
-    normalize_host_public_key "$(
-      jq -r '.data."bastion-public-host-key-info" // empty' <<<"$session"
-    )"
+  api_public_key="$(
+    jq -r '
+      .data."bastion-public-host-key-info" as $key_info |
+      if ($key_info | type) == "object" then
+        $key_info."public-host-key" // empty
+      elif ($key_info | type) == "string" then
+        $key_info
+      else
+        empty
+      end
+    ' <<<"$session"
   )"
+  if [[ -n "$api_public_key" ]]; then
+    public_key="$(normalize_host_public_key "$api_public_key")"
+  else
+    public_key="$attested_public_key"
+  fi
   printf '%s\t%s\n' "$expected_endpoint" "$public_key"
 }
 
@@ -391,6 +436,8 @@ oci_require_vars \
   OCI_COMPARTMENT_OCID OCI_CLI_REGION OCI_K3S_SSH_PRIVATE_KEY \
   RUNNER_PUBLIC_IPV4
 oci_require_ocid OCI_COMPARTMENT_OCID
+[[ "$OCI_CLI_REGION" =~ ^[a-z0-9-]+$ ]] ||
+  oci_die "OCI_CLI_REGION contains unsupported characters"
 oci_validate_public_ipv4 "$RUNNER_PUBLIC_IPV4" ||
   oci_die "RUNNER_PUBLIC_IPV4 must be a globally routable IPv4"
 validate_local_port OCI_K3S_LOCAL_SSH_PORT "$OCI_K3S_LOCAL_SSH_PORT"
@@ -540,7 +587,10 @@ actual_target_ssh_public_key_sha256="$(
 [[ "$actual_target_ssh_public_key_sha256" == \
    "$expected_target_ssh_public_key_sha256" ]] ||
   oci_die "target SSH private key does not match acquisition provenance"
-target_host_public_key="$(attest_target_host_key)"
+attested_host_keys="$(attest_ssh_host_keys)"
+IFS=$'\t' read -r target_host_public_key bastion_host_public_key <<<"$attested_host_keys"
+[[ -n "$target_host_public_key" && -n "$bastion_host_public_key" ]] ||
+  oci_die "OCI-attested SSH host-key evidence is incomplete"
 write_known_host "$instance_ocid" 22 "$target_host_public_key" "$target_known_hosts"
 
 oci bastion session create-port-forwarding \
@@ -557,9 +607,12 @@ oci bastion session create-port-forwarding \
 ssh_session_id="$(
   wait_active_session_id "$bastion_ocid" "$ssh_session_name"
 )"
-IFS=$'\t' read -r bastion_endpoint bastion_host_public_key < <(
-  session_connection_metadata "$ssh_session_id" 22
-)
+session_metadata="$(
+  session_connection_metadata "$ssh_session_id" 22 "$bastion_host_public_key"
+)"
+IFS=$'\t' read -r bastion_endpoint bastion_host_public_key <<<"$session_metadata"
+[[ -n "$bastion_endpoint" && -n "$bastion_host_public_key" ]] ||
+  oci_die "OCI Bastion connection metadata is incomplete"
 write_known_host "$bastion_endpoint" 22 "$bastion_host_public_key" "$bastion_known_hosts"
 write_session_state
 

--- a/infra/oci/tests/test-k3s-runtime-contract.sh
+++ b/infra/oci/tests/test-k3s-runtime-contract.sh
@@ -656,11 +656,16 @@ grep -Fq '(( OCI_INSTANCE_COMMAND_POLL_ATTEMPTS <= 150 ))' \
   fail "k3s finalization weakens the attested target host-key policy"
 for literal in \
   '.data."bastion-public-host-key-info"' \
+  '$key_info."public-host-key"' \
   'oci instance-agent command create' \
   'oci instance-agent command-execution get' \
-  'public_key_sha256="$(printf "%s\n" "$public_key" | sha256sum' \
+  'ssh-keyscan -T 10 -t ed25519 "$bastion_endpoint"' \
+  'target_public_key_sha256="$(printf "%s\n" "$target_public_key" | sha256sum' \
+  'bastion_public_key_sha256="$(printf "%s\n" "$bastion_public_key" | sha256sum' \
+  'printf "%s\n%s\n%s\n%s\n"' \
   'if [[ -n "$expected_sha" ]]; then' \
-  '"$actual_public_key_sha256" == "$reported_public_key_sha256"' \
+  '"$actual_target_public_key_sha256" == "$reported_target_public_key_sha256"' \
+  '"$actual_bastion_public_key_sha256" == "$reported_bastion_public_key_sha256"' \
   'ssh-keygen -l -f -' \
   'write_known_host "$instance_ocid" 22' \
   'StrictHostKeyChecking=yes' \


### PR DESCRIPTION
## Summary
- attest both target and regional Bastion SSH keys through authenticated OCI Run Command
- prefer OCI session host-key metadata when present and fail closed to the command-attested key when ACTIVE sessions return null
- verify exact four-line checksummed payload and preserve strict host-key checking

## Validation
- live OCI node probe matched the independently observed regional ED25519 key
- `infra/oci/tests/test-k3s-runtime-contract.sh`
- `infra/oci/tests/run-contracts.sh` (15/15 suites)