### PR TITLE
Fix k3s cached image export argv

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -289,6 +289,10 @@ cd resulting && npm ci && npm run test:ci
   the retained SSH public-key validation path. A runner-specific temporary-file
   parse can reject a key whose checksummed bytes match independently attested
   evidence.
+- k3s `ctr images export` does not consume a post-output `--` as a generic
+  option terminator; it tries to export an image literally named `--`. Pass the
+  validated, shell-escaped immutable reference directly and lock the exact
+  remote argv in the recovery contract.
 - Capture rollback evidence before any database lock or workload/data
   mutation. A zero-recovery baseline is valid only when all nine live
   references and exact deploy provenance are public GHCR digests; otherwise

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -90,6 +90,10 @@ conversation summaries are not authority.
   retained SSH-key validator already does. Preserve checksum, exact-line, and
   supported-key-type validation rather than trusting a runner-specific
   temporary-file parse result.
+- k3s `ctr images export` treats a post-output `--` as an image name rather
+  than an option terminator. Pass the already shell-escaped immutable image
+  reference directly after the archive path and exercise that exact argv in
+  the GHCR recovery contract.
 - Capture and validate rollback evidence before acquiring a database lock or
   changing a workload. An ordinary baseline is valid only when all nine live
   references and its exact deploy provenance identify public GHCR digests;

--- a/infra/oci/scripts/recover-k3s-cached-images.sh
+++ b/infra/oci/scripts/recover-k3s-cached-images.sh
@@ -160,7 +160,7 @@ for service in "${SERVICES[@]}"; do
     printf -v remote_ref '%q' "$old_ref"
     archive="$archive_dir/${service}.tar"
     ssh "${ssh_options[@]}" "${K3S_SSH_USER}@127.0.0.1" \
-      "sudo k3s ctr -n k8s.io images export - -- $remote_ref" > "$archive"
+      "sudo k3s ctr -n k8s.io images export - $remote_ref" > "$archive"
     [[ -s "$archive" && ! -L "$archive" ]] ||
       oci_die "containerd cache export did not produce a regular OCI archive"
     OCI_ARCHIVE_FILE="$archive" \

--- a/infra/oci/tests/test-ghcr-contract.sh
+++ b/infra/oci/tests/test-ghcr-contract.sh
@@ -600,6 +600,12 @@ grep -Fq 'containerd-cache' "$OCI_DIR/scripts/recover-k3s-cached-images.sh" ||
   fail "exact cached-image recovery path is missing"
 grep -Fq 'push-oci-archive-to-ghcr.py' "$OCI_DIR/scripts/recover-k3s-cached-images.sh" ||
   fail "cache recovery does not use the exact OCI archive publisher"
+grep -Fq '"sudo k3s ctr -n k8s.io images export - $remote_ref"' \
+  "$OCI_DIR/scripts/recover-k3s-cached-images.sh" ||
+  fail "cache recovery does not pass the exact image reference in the ctr export argv"
+! grep -Eq 'ctr -n k8s\.io images export - --' \
+  "$OCI_DIR/scripts/recover-k3s-cached-images.sh" ||
+  fail "cache recovery passes an unsupported option terminator as a ctr image name"
 if grep -Eq 'docker (load|tag|push)' "$OCI_DIR/scripts/recover-k3s-cached-images.sh"; then
   fail "cache recovery still depends on digest-changing Docker conversion"
 fi


### PR DESCRIPTION
## Summary
- remove the unsupported post-output `--` from `k3s ctr images export`
- pass only the validated shell-escaped immutable image reference
- add an exact argv regression and durable operational learning

## Validation
- live strict-Bastion probe exported 59,455,488 bytes from the cached OCIR image
- `infra/oci/tests/test-ghcr-contract.sh`
- `infra/oci/tests/run-contracts.sh` (15/15 suites)
- temporary managed SSH session and allowlist cleaned