### PR TITLE
Fix slip startup on empty databases

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -66,6 +66,10 @@
 - Deployment provenance must bind source SHA, build/deploy attempts, infrastructure artifact digest, runtime mode, and runtime fingerprint. Rechecking current `master` immediately before mutation and commit closes the preflight-to-mutation race.
 
 ### Mongo aggregate concurrency and rolling compatibility
+- Mongo index introspection fails with `NamespaceNotFound` on a brand-new
+  database. Readiness guards may treat only error code 26 as an empty index
+  set, then create the guarded index; every other inspection error remains a
+  startup failure.
 - Raw Mongo inserts and upserts that bypass Mongoose `save()` must initialize
   `__v: 0` when later mutations rely on optimistic concurrency. Before
   mutating a historical versionless document, atomically initialize the

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -94,6 +94,10 @@ conversation summaries are not authority.
   than an option terminator. Pass the already shell-escaped immutable image
   reference directly after the archive path and exercise that exact argv in
   the GHCR recovery contract.
+- Boot every published image against clean pinned dependencies before granting
+  build authority. MongoDB index inspection returns error 26 when a collection
+  has never existed; handle only that exact empty-namespace case as no indexes
+  and keep all other readiness failures closed.
 - Capture and validate rollback evidence before acquiring a database lock or
   changing a workload. An ordinary baseline is valid only when all nine live
   references and its exact deploy provenance identify public GHCR digests;

--- a/slip/src/scripts/__test__/ensureDraftIndexes.test.ts
+++ b/slip/src/scripts/__test__/ensureDraftIndexes.test.ts
@@ -125,6 +125,18 @@ it("creates the exact guarded index only after normalization and keeps repeated 
   expect(repeated.existingIndex).toBe("matching");
 });
 
+it("creates the guarded index when the slips collection does not exist yet", async () => {
+  await Slip.collection.drop();
+
+  const report = await ensureSlipDraftIndex({ apply: true });
+
+  expect(report.ready).toBe(true);
+  expect(report.scanned).toBe(0);
+  expect(report.changed).toBe(1);
+  expect(report.existingIndex).toBe("missing");
+  expect(await guardedIndex()).toBeTruthy();
+});
+
 it("fails closed when a conflicting guarded index shape already exists", async () => {
   await Slip.collection.insertOne({
     ...buildLegacyDraft("conflict-user"),

--- a/slip/src/scripts/ensureDraftIndexes.ts
+++ b/slip/src/scripts/ensureDraftIndexes.ts
@@ -88,6 +88,21 @@ const detectExistingIndex = (indexes: any[]): DraftIndexReport["existingIndex"] 
   return "missing";
 };
 
+const listExistingIndexes = async (): Promise<any[]> => {
+  try {
+    return await Slip.collection.indexes();
+  } catch (error: unknown) {
+    if (
+      error instanceof mongoose.mongo.MongoServerError
+      && error.code === 26
+    ) {
+      return [];
+    }
+
+    throw error;
+  }
+};
+
 const countNonZeroBlocks = (
   existingIndex: DraftIndexReport["existingIndex"],
   blocking: DraftNormalizationCounts
@@ -243,7 +258,7 @@ export const ensureSlipDraftIndex = async (
   options: Partial<ParsedEnsureArgs> = {}
 ): Promise<DraftIndexReport> => {
   const apply = options.apply ?? false;
-  const existingIndex = detectExistingIndex(await Slip.collection.indexes());
+  const existingIndex = detectExistingIndex(await listExistingIndexes());
   const blocking = await scanDraftNormalization();
   const ready = existingIndex !== "conflicting" && blocking.unnormalizedDraftCount === 0;
 


### PR DESCRIPTION
## Summary
- treat only MongoDB `NamespaceNotFound` during index inspection as an empty index set
- create the guarded draft index on a brand-new slip database while retaining fail-closed behavior for every other readiness error
- add a dropped-collection regression and durable release learning

## Validation
- slip readiness/index tests: 11/11
- full slip suite: 101/101
- TypeScript no-emit check
- native ARM64 image booted against clean pinned MongoDB/RabbitMQ, remained running, and created exactly one guarded index

The previous exact image digest reproduced the empty-database startup failure on native ARM64; this is an application fix rather than a GHCR repair retry.