### PR TITLE
Promote staged cached-image recovery fix

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -297,6 +297,10 @@ cd resulting && npm ci && npm run test:ci
   option terminator; it tries to export an image literally named `--`. Pass the
   validated, shell-escaped immutable reference directly and lock the exact
   remote argv in the recovery contract.
+- A successful SSH exit does not prove a complete `ctr` stdout archive. The
+  live stdout path truncated 77,824 bytes while a node-staged export was valid.
+  Validate the staged tar remotely, stream it with keepalives, compare exact
+  remote/local size and SHA-256, and remove the temporary file before upload.
 - Capture rollback evidence before any database lock or workload/data
   mutation. A zero-recovery baseline is valid only when all nine live
   references and exact deploy provenance are public GHCR digests; otherwise

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -94,6 +94,10 @@ conversation summaries are not authority.
   than an option terminator. Pass the already shell-escaped immutable image
   reference directly after the archive path and exercise that exact argv in
   the GHCR recovery contract.
+- `ctr images export -` can exit zero after delivering a truncated archive over
+  managed SSH. Stage each exact export in a unique root-owned node file,
+  traverse the tar remotely, and require identical bounded size and SHA-256
+  after transfer before deleting the node file and contacting GHCR.
 - Boot every published image against clean pinned dependencies before granting
   build authority. MongoDB index inspection returns error 26 when a collection
   has never existed; handle only that exact empty-namespace case as no indexes

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -219,12 +219,14 @@ concurrent retirement fixture isolation without masking failed suites.
    safety code, so no new infrastructure finalization is required first. It
    compares an independently captured nine-service live deployment/image-ID
    inventory to historical trusted provenance, exports those exact containerd
-   cache images over the protected Bastion tunnel, and uploads the exact
-   ARM64 manifest/config/layer blobs from each validated OCI archive without a
-   Docker load/repack cycle. It pushes only from the runner, never sends a
-   GHCR token to the node, and never silently rebuilds a historical baseline.
-   Target SSH uses the retained dedicated known-hosts
-   file and the exact instance OCID as `HostKeyAlias`. Only after anonymous
+   cache images to unique temporary node files, validates each tar remotely,
+   streams it over the protected Bastion tunnel, and requires matching bounded
+   remote/local size and SHA-256 before deleting the node copy. It uploads the
+   exact ARM64 manifest/config/layer blobs from each validated OCI archive
+   without a Docker load/repack cycle. It pushes only from the runner, never
+   sends a GHCR token to the node, and never silently rebuilds a historical
+   baseline. Target SSH uses the retained dedicated known-hosts file and the
+   exact instance OCID as `HostKeyAlias`. Only after anonymous
    remote verification of all nine recovered GHCR digests does it capture and
    upload a hash-bound transition plan plus the original RabbitMQ queue
    baseline. That upload completes before the first Deployment mutation. The

--- a/infra/oci/scripts/recover-k3s-cached-images.sh
+++ b/infra/oci/scripts/recover-k3s-cached-images.sh
@@ -130,6 +130,8 @@ ssh_options=(
   -o IdentitiesOnly=yes
   -o PasswordAuthentication=no
   -o PreferredAuthentications=publickey
+  -o ServerAliveCountMax=3
+  -o ServerAliveInterval=30
   -o UserKnownHostsFile="$K3S_SSH_KNOWN_HOSTS"
   -o HostKeyAlias="$K3S_SSH_HOST_KEY_ALIAS"
   -o StrictHostKeyChecking=yes
@@ -140,9 +142,34 @@ adopted_count=0
 archive_dir="$(mktemp -d)"
 anonymous_docker_config="$(mktemp -d)"
 chmod 700 "$archive_dir" "$anonymous_docker_config"
-cleanup() { rm -rf "$archive_dir" "$anonymous_docker_config"; }
+remote_archive=""
+cleanup_remote_archive() {
+  local remote_archive_q
+  [[ -n "$remote_archive" ]] || return 0
+  printf -v remote_archive_q '%q' "$remote_archive"
+  if ! ssh "${ssh_options[@]}" "${K3S_SSH_USER}@127.0.0.1" \
+      "sudo rm -f -- $remote_archive_q && sudo test ! -e $remote_archive_q" \
+      >/dev/null; then
+    return 1
+  fi
+  remote_archive=""
+}
+cleanup() {
+  local status=$?
+  local cleanup_failed=0
+  trap - EXIT
+  set +e
+  cleanup_remote_archive >/dev/null 2>&1 || cleanup_failed=1
+  rm -rf "$archive_dir" "$anonymous_docker_config" || cleanup_failed=1
+  if [[ "$status" == "0" && "$cleanup_failed" != "0" ]]; then
+    echo "ERROR: cache recovery temporary archives could not be fully removed" >&2
+    exit 1
+  fi
+  exit "$status"
+}
 trap cleanup EXIT
 export DOCKER_CONFIG="$anonymous_docker_config"
+printf 'service\tmode\tbytes\tsha256\n' > "$OUTPUT_DIR/archive-transfers.tsv"
 for service in "${SERVICES[@]}"; do
   live_row="$(awk -F '\t' -v service="$service" '$1 == service { print; exit }' "$LIVE_IMAGES_FILE")"
   trusted_row="$(awk -F '\t' -v service="$service" '$1 == service { print; exit }' "$TRUSTED_LEGACY_IMAGES_FILE")"
@@ -158,11 +185,50 @@ for service in "${SERVICES[@]}"; do
       oci_die "unable to determine whether the recovered GHCR exact tag exists: $service"
     fi
     printf -v remote_ref '%q' "$old_ref"
+    remote_archive="/tmp/betstan-ghcr-cache-${RECOVERY_RUN_ID}-${RECOVERY_RUN_ATTEMPT}-${service}-$$.tar"
+    printf -v remote_archive_q '%q' "$remote_archive"
     archive="$archive_dir/${service}.tar"
+    remote_metadata="$archive_dir/${service}.remote"
+    if ! ssh "${ssh_options[@]}" "${K3S_SSH_USER}@127.0.0.1" \
+        "sudo rm -f -- $remote_archive_q &&
+         sudo install -o root -g root -m 600 /dev/null $remote_archive_q &&
+         sudo k3s ctr -n k8s.io images export $remote_archive_q $remote_ref &&
+         sudo test -s $remote_archive_q &&
+         sudo stat -c '%u:%g:%a' $remote_archive_q | grep -qx '0:0:600' &&
+         sudo tar -tf $remote_archive_q >/dev/null &&
+         sudo stat -c '%s' $remote_archive_q &&
+         sudo sha256sum $remote_archive_q" > "$remote_metadata"; then
+      oci_die "containerd cache export did not produce a complete remote OCI archive"
+    fi
+    [[ "$(wc -l < "$remote_metadata" | tr -d ' ')" == "2" ]] ||
+      oci_die "containerd cache export metadata has an unexpected shape"
+    remote_size="$(sed -n '1p' "$remote_metadata")"
+    read -r remote_sha256 remote_sha_path remote_sha_extra < <(
+      sed -n '2p' "$remote_metadata"
+    )
+    [[ "$remote_size" =~ ^[1-9][0-9]*$ ]] ||
+      oci_die "containerd cache export size is invalid"
+    (( remote_size <= 4000000000 )) ||
+      oci_die "containerd cache export exceeds the bounded recovery size"
+    [[ "$remote_sha256" =~ ^[0-9a-f]{64}$ &&
+       "$remote_sha_path" == "$remote_archive" &&
+       -z "${remote_sha_extra:-}" ]] ||
+      oci_die "containerd cache export digest evidence is invalid"
     ssh "${ssh_options[@]}" "${K3S_SSH_USER}@127.0.0.1" \
-      "sudo k3s ctr -n k8s.io images export - $remote_ref" > "$archive"
+      "sudo cat -- $remote_archive_q" > "$archive"
     [[ -s "$archive" && ! -L "$archive" ]] ||
       oci_die "containerd cache export did not produce a regular OCI archive"
+    local_size="$(wc -c < "$archive" | tr -d ' ')"
+    local_sha256="$(oci_sha256 < "$archive")"
+    [[ "$local_size" == "$remote_size" &&
+       "$local_sha256" == "$remote_sha256" ]] ||
+      oci_die "containerd cache archive changed during protected transfer"
+    printf '%s\tstaged\t%s\t%s\n' \
+      "$service" "$local_size" "$local_sha256" \
+      >> "$OUTPUT_DIR/archive-transfers.tsv"
+    cleanup_remote_archive ||
+      oci_die "containerd cache temporary archive could not be removed"
+    rm -f -- "$remote_metadata"
     OCI_ARCHIVE_FILE="$archive" \
       GHCR_TARGET_TAG="$(application_registry_tag "$service" "$SOURCE_SHA")" \
       EXPECTED_PLATFORM_DIGEST="$old_platform_digest" \

--- a/infra/oci/tests/test-ghcr-contract.sh
+++ b/infra/oci/tests/test-ghcr-contract.sh
@@ -600,12 +600,27 @@ grep -Fq 'containerd-cache' "$OCI_DIR/scripts/recover-k3s-cached-images.sh" ||
   fail "exact cached-image recovery path is missing"
 grep -Fq 'push-oci-archive-to-ghcr.py' "$OCI_DIR/scripts/recover-k3s-cached-images.sh" ||
   fail "cache recovery does not use the exact OCI archive publisher"
-grep -Fq '"sudo k3s ctr -n k8s.io images export - $remote_ref"' \
+grep -Fq 'sudo k3s ctr -n k8s.io images export $remote_archive_q $remote_ref' \
   "$OCI_DIR/scripts/recover-k3s-cached-images.sh" ||
-  fail "cache recovery does not pass the exact image reference in the ctr export argv"
-! grep -Eq 'ctr -n k8s\.io images export - --' \
+  fail "cache recovery does not stage the exact image reference on the node"
+! grep -Eq 'ctr -n k8s\.io images export -([[:space:]]|")' \
   "$OCI_DIR/scripts/recover-k3s-cached-images.sh" ||
-  fail "cache recovery passes an unsupported option terminator as a ctr image name"
+  fail "cache recovery uses the truncating ctr stdout export path"
+for literal in \
+  'sudo install -o root -g root -m 600 /dev/null $remote_archive_q' \
+  "grep -qx '0:0:600'" \
+  'sudo tar -tf $remote_archive_q' \
+  'sudo sha256sum $remote_archive_q' \
+  'sudo cat -- $remote_archive_q' \
+  'local_size" == "$remote_size' \
+  'local_sha256" == "$remote_sha256' \
+  'cleanup_remote_archive' \
+  'archive-transfers.tsv' \
+  '-o ServerAliveCountMax=3' \
+  '-o ServerAliveInterval=30'; do
+  grep -Fq -- "$literal" "$OCI_DIR/scripts/recover-k3s-cached-images.sh" ||
+    fail "cache recovery lacks staged archive transfer contract: $literal"
+done
 if grep -Eq 'docker (load|tag|push)' "$OCI_DIR/scripts/recover-k3s-cached-images.sh"; then
   fail "cache recovery still depends on digest-changing Docker conversion"
 fi


### PR DESCRIPTION
## Summary
Promote the validated cached-image recovery transport fix from `dev` to `master`.

The recovery now stages each exact containerd export in a root-only node file, validates it remotely, proves identical size and SHA-256 after protected transfer, and removes the node copy before GHCR publication.

## Evidence
- feature PR #314 merged to `dev`
- full OCI contract matrix: 15/15 suites
- feature PR branch policy, OCI validation, service coverage, and quality gates passed
