### PR TITLE
Accept GHCR blob upload session paths

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -301,6 +301,10 @@ cd resulting && npm ci && npm run test:ci
   live stdout path truncated 77,824 bytes while a node-staged export was valid.
   Validate the staged tar remotely, stream it with keepalives, compare exact
   remote/local size and SHA-256, and remove the temporary file before upload.
+- GHCR starts blob uploads at `/blobs/uploads/` but returns the session under
+  singular `/blobs/upload/<uuid>`. Accept both exact repository-bound forms,
+  require a UUID-shaped session, and continue rejecting other hosts, paths,
+  embedded credentials, fragments, ports, and preselected digests.
 - Capture rollback evidence before any database lock or workload/data
   mutation. A zero-recovery baseline is valid only when all nine live
   references and exact deploy provenance are public GHCR digests; otherwise

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -98,6 +98,10 @@ conversation summaries are not authority.
   managed SSH. Stage each exact export in a unique root-owned node file,
   traverse the tar remotely, and require identical bounded size and SHA-256
   after transfer before deleting the node file and contacting GHCR.
+- GHCR's successful `POST /blobs/uploads/` response uses the singular
+  `/blobs/upload/<uuid>` session path. Validate that response against the exact
+  registry, repository, path forms, and UUID rather than assuming the request
+  and response paths use the same plural spelling.
 - Boot every published image against clean pinned dependencies before granting
   build authority. MongoDB index inspection returns error 26 when a collection
   has never existed; handle only that exact empty-namespace case as no indexes

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -225,8 +225,10 @@ concurrent retirement fixture isolation without masking failed suites.
    exact ARM64 manifest/config/layer blobs from each validated OCI archive
    without a Docker load/repack cycle. It pushes only from the runner, never
    sends a GHCR token to the node, and never silently rebuilds a historical
-   baseline. Target SSH uses the retained dedicated known-hosts file and the
-   exact instance OCID as `HostKeyAlias`. Only after anonymous
+   baseline. GHCR upload sessions must remain on its exact registry/repository
+   and use a UUID-bound singular `upload` or plural `uploads` path. Target SSH
+   uses the retained dedicated known-hosts file and the exact instance OCID as
+   `HostKeyAlias`. Only after anonymous
    remote verification of all nine recovered GHCR digests does it capture and
    upload a hash-bound transition plan plus the original RabbitMQ queue
    baseline. That upload completes before the first Deployment mutation. The

--- a/infra/oci/scripts/push-oci-archive-to-ghcr.py
+++ b/infra/oci/scripts/push-oci-archive-to-ghcr.py
@@ -28,6 +28,11 @@ DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}")
 TAG_RE = re.compile(
     r"arm64-(auth|bet|backoffice|client|event|gamemaster|moderation|resulting|slip)-[0-9a-f]{40}"
 )
+UPLOAD_LOCATION_PATH_RE = re.compile(
+    rf"/v2/{re.escape(REPOSITORY)}/blobs/uploads?/"
+    r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+    r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+)
 
 
 def die(message):
@@ -209,10 +214,28 @@ def obtain_bearer_token(actor, package_token):
 def validate_upload_location(location):
     url = urllib.parse.urljoin(f"https://{REGISTRY}", location)
     parsed = urllib.parse.urlsplit(url)
-    if parsed.scheme != "https" or parsed.hostname != REGISTRY or parsed.port is not None:
+    try:
+        port = parsed.port
+    except ValueError:
         die("GHCR returned an untrusted blob-upload location")
-    if not parsed.path.startswith(f"/v2/{REPOSITORY}/blobs/uploads/"):
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != REGISTRY
+        or port is not None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+    ):
+        die("GHCR returned an untrusted blob-upload location")
+    if not UPLOAD_LOCATION_PATH_RE.fullmatch(parsed.path):
         die("GHCR returned a blob-upload location outside the target repository")
+    if any(
+        key.lower() == "digest"
+        for key, _value in urllib.parse.parse_qsl(
+            parsed.query, keep_blank_values=True
+        )
+    ):
+        die("GHCR blob-upload location already contains a digest")
     return url
 
 

--- a/infra/oci/tests/test_oci_archive_publisher.py
+++ b/infra/oci/tests/test_oci_archive_publisher.py
@@ -167,7 +167,38 @@ class ArchivePublisherTest(unittest.TestCase):
     def test_rejects_upload_location_outside_target_repository(self):
         with self.assertRaisesRegex(SystemExit, "outside the target repository"):
             PUBLISHER.validate_upload_location(
-                "https://ghcr.io/v2/vasilyevstan/other/blobs/uploads/id"
+                "https://ghcr.io/v2/vasilyevstan/other/blobs/upload/"
+                "7d8507d3-d549-4fad-9113-aaea462eeb23"
+            )
+
+    def test_accepts_ghcr_singular_upload_location(self):
+        location = (
+            "/v2/vasilyevstan/betstan-images/blobs/upload/"
+            "7d8507d3-d549-4fad-9113-aaea462eeb23"
+        )
+        self.assertEqual(
+            PUBLISHER.validate_upload_location(location),
+            f"https://ghcr.io{location}",
+        )
+
+    def test_accepts_repository_bound_plural_upload_location(self):
+        location = (
+            "https://ghcr.io/v2/vasilyevstan/betstan-images/blobs/uploads/"
+            "7d8507d3-d549-4fad-9113-aaea462eeb23?_state=fixture"
+        )
+        self.assertEqual(PUBLISHER.validate_upload_location(location), location)
+
+    def test_rejects_non_uuid_upload_location(self):
+        with self.assertRaisesRegex(SystemExit, "outside the target repository"):
+            PUBLISHER.validate_upload_location(
+                "/v2/vasilyevstan/betstan-images/blobs/upload/not-an-upload-id"
+            )
+
+    def test_rejects_upload_location_with_digest(self):
+        with self.assertRaisesRegex(SystemExit, "already contains a digest"):
+            PUBLISHER.validate_upload_location(
+                "/v2/vasilyevstan/betstan-images/blobs/upload/"
+                "7d8507d3-d549-4fad-9113-aaea462eeb23?digest=untrusted"
             )
 
 


### PR DESCRIPTION
## Summary
- accept GHCR's singular repository-bound `/blobs/upload/<uuid>` response path as well as the standard plural form
- retain strict HTTPS host, port, credentials, fragment, exact repository, UUID, and digest validation
- add direct regressions and document the observed registry contract

## Recovery evidence
Run `32929548874` proved the staged transfer fix: the `auth` archive matched the remote 59,455,488-byte size and SHA-256. It then failed safely before any manifest tag, immutable plan, Deployment mutation, or OCIR retirement because GHCR returned its documented singular upload session path. Protected k3s access cleanup passed.

## Validation
- publisher unit suite: 9/9
- focused GHCR contract suite: pass
- complete OCI contract matrix: 15/15 suites
- Python compile and `git diff --check`: pass
