### PR TITLE
Accept opaque GHCR upload identifiers

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -302,9 +302,10 @@ cd resulting && npm ci && npm run test:ci
   Validate the staged tar remotely, stream it with keepalives, compare exact
   remote/local size and SHA-256, and remove the temporary file before upload.
 - GHCR starts blob uploads at `/blobs/uploads/` but returns the session under
-  singular `/blobs/upload/<uuid>`. Accept both exact repository-bound forms,
-  require a UUID-shaped session, and continue rejecting other hosts, paths,
-  embedded credentials, fragments, ports, and preselected digests.
+  singular `/blobs/upload/<id>`. The identifier is opaque and is not guaranteed
+  to have RFC UUID shape. Accept one bounded URL-unreserved segment on either
+  exact repository-bound path while still rejecting other hosts, paths,
+  credentials, fragments, ports, and preselected digests.
 - Capture rollback evidence before any database lock or workload/data
   mutation. A zero-recovery baseline is valid only when all nine live
   references and exact deploy provenance are public GHCR digests; otherwise

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -99,9 +99,10 @@ conversation summaries are not authority.
   traverse the tar remotely, and require identical bounded size and SHA-256
   after transfer before deleting the node file and contacting GHCR.
 - GHCR's successful `POST /blobs/uploads/` response uses the singular
-  `/blobs/upload/<uuid>` session path. Validate that response against the exact
-  registry, repository, path forms, and UUID rather than assuming the request
-  and response paths use the same plural spelling.
+  `/blobs/upload/<id>` session path, and the identifier is opaque rather than
+  guaranteed to have RFC UUID shape. Validate a bounded URL-unreserved segment
+  against the exact registry, repository, and path forms rather than assuming
+  either the request spelling or an identifier representation.
 - Boot every published image against clean pinned dependencies before granting
   build authority. MongoDB index inspection returns error 26 when a collection
   has never existed; handle only that exact empty-namespace case as no indexes

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -225,10 +225,11 @@ concurrent retirement fixture isolation without masking failed suites.
    exact ARM64 manifest/config/layer blobs from each validated OCI archive
    without a Docker load/repack cycle. It pushes only from the runner, never
    sends a GHCR token to the node, and never silently rebuilds a historical
-   baseline. GHCR upload sessions must remain on its exact registry/repository
-   and use a UUID-bound singular `upload` or plural `uploads` path. Target SSH
-   uses the retained dedicated known-hosts file and the exact instance OCID as
-   `HostKeyAlias`. Only after anonymous
+   baseline. GHCR upload sessions must remain on its exact registry/repository,
+   use a singular `upload` or plural `uploads` path, and end in one bounded
+   URL-unreserved opaque identifier. Target SSH uses the retained dedicated
+   known-hosts file and the exact instance OCID as `HostKeyAlias`. Only after
+   anonymous
    remote verification of all nine recovered GHCR digests does it capture and
    upload a hash-bound transition plan plus the original RabbitMQ queue
    baseline. That upload completes before the first Deployment mutation. The

--- a/infra/oci/scripts/push-oci-archive-to-ghcr.py
+++ b/infra/oci/scripts/push-oci-archive-to-ghcr.py
@@ -30,8 +30,7 @@ TAG_RE = re.compile(
 )
 UPLOAD_LOCATION_PATH_RE = re.compile(
     rf"/v2/{re.escape(REPOSITORY)}/blobs/uploads?/"
-    r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
-    r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+    r"[A-Za-z0-9][A-Za-z0-9._~-]{15,255}"
 )
 
 

--- a/infra/oci/tests/test_oci_archive_publisher.py
+++ b/infra/oci/tests/test_oci_archive_publisher.py
@@ -181,17 +181,17 @@ class ArchivePublisherTest(unittest.TestCase):
             f"https://ghcr.io{location}",
         )
 
-    def test_accepts_repository_bound_plural_upload_location(self):
+    def test_accepts_repository_bound_plural_opaque_upload_location(self):
         location = (
             "https://ghcr.io/v2/vasilyevstan/betstan-images/blobs/uploads/"
-            "7d8507d3-d549-4fad-9113-aaea462eeb23?_state=fixture"
+            "69f8c65d6a764a91b691129282804c79?_state=fixture"
         )
         self.assertEqual(PUBLISHER.validate_upload_location(location), location)
 
-    def test_rejects_non_uuid_upload_location(self):
+    def test_rejects_short_upload_location(self):
         with self.assertRaisesRegex(SystemExit, "outside the target repository"):
             PUBLISHER.validate_upload_location(
-                "/v2/vasilyevstan/betstan-images/blobs/upload/not-an-upload-id"
+                "/v2/vasilyevstan/betstan-images/blobs/upload/short"
             )
 
     def test_rejects_upload_location_with_digest(self):


### PR DESCRIPTION
## Summary
- treat the GHCR upload-session identifier as opaque instead of requiring RFC UUID formatting
- allow exactly one 16-256 character URL-unreserved segment under the already validated exact registry/repository upload path
- retain all host, path, credential, port, fragment, and digest protections

## Recovery evidence
Run `32933647165` again failed before PUT/manifest publication, immutable planning, Deployment mutation, or OCIR retirement. This isolates the remaining mismatch to the server-generated identifier representation; protected k3s cleanup passed and the exact historical tag remains absent.

## Validation
- publisher tests: 9/9
- focused GHCR contract suite: pass
- complete OCI contract matrix: 15/15 suites
- Python compile and `git diff --check`: pass
