### PR TITLE
Scope recovery smoke to historical capabilities

### DIFF
--- a/.github/workflows/oci-ghcr-cache-recovery.yml
+++ b/.github/workflows/oci-ghcr-cache-recovery.yml
@@ -481,6 +481,7 @@ jobs:
           OCI_REDIRECT_URL: ${{ needs.recover.outputs.redirect_url }}
           OCI_DIAGNOSTIC_URL: ${{ needs.recover.outputs.diagnostic_url }}
           OCI_CLUSTER_CHECKS_ALREADY_PASSED: "1"
+          OCI_ALLOW_LEGACY_ADMIN_UI: "1"
           MAX_LOOPS: "3"
           SLEEP_SECONDS: "20"
           OUTPUT_DIR: artifacts/oci-ghcr-recovery-public-validation

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -306,6 +306,10 @@ cd resulting && npm ci && npm run test:ci
   to have RFC UUID shape. Accept one bounded URL-unreserved segment on either
   exact repository-bound path while still rejecting other hosts, paths,
   credentials, fragments, ports, and preselected digests.
+- Recovery smoke tests must validate capabilities the historical target
+  actually had. Keep current authorization checks strict by default, but scope
+  an explicit compatibility switch to historical recovery validation when a
+  later UI capability is independently covered by current service/client tests.
 - Capture rollback evidence before any database lock or workload/data
   mutation. A zero-recovery baseline is valid only when all nine live
   references and exact deploy provenance are public GHCR digests; otherwise

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -103,6 +103,10 @@ conversation summaries are not authority.
   guaranteed to have RFC UUID shape. Validate a bounded URL-unreserved segment
   against the exact registry, repository, and path forms rather than assuming
   either the request spelling or an identifier representation.
+- Do not apply a capability added after a historical image to that image's
+  recovery smoke. Default the current browser journey to strict persisted-role
+  checks, and allow the legacy UI only in the recovery public-validation job;
+  current client and backoffice authorization tests remain mandatory.
 - Boot every published image against clean pinned dependencies before granting
   build authority. MongoDB index inspection returns error 26 when a collection
   has never existed; handle only that exact empty-namespace case as no indexes

--- a/infra/oci/README.md
+++ b/infra/oci/README.md
@@ -236,6 +236,10 @@ concurrent retirement fixture isolation without masking failed suites.
    workflow then rebinds the nine application Deployments sequentially and
    verifies each rollout's serving ARM64 platform digest; Mongo and RabbitMQ
    are not changed.
+   Public recovery validation permits the historical baseline's legacy
+   Backoffice navigation only for that job. All ordinary validation retains
+   the strict persisted-role UI assertion, which current client and backoffice
+   authorization suites cover independently.
    Rollback-readiness and public Playwright checks then run while `ocir-pull`
    remains intact. Only after both pass does the final job remove the
    service-account reference and secret and delete the exact empty

--- a/infra/oci/agents/oci-live-smoke.spec.js
+++ b/infra/oci/agents/oci-live-smoke.spec.js
@@ -1,6 +1,7 @@
 const { test, expect } = require('@playwright/test');
 
 test('OCI signup, logout, login, and navigation journey', async ({ page }) => {
+  const allowLegacyAdminUi = process.env.OCI_ALLOW_LEGACY_ADMIN_UI === '1';
   const suffix = `${Date.now()}${Math.floor(Math.random() * 10000)}`;
   const username = `oci-smoke-${suffix}`.slice(0, 40);
   const password = `Oc1-${suffix}`.slice(0, 20);
@@ -15,7 +16,9 @@ test('OCI signup, logout, login, and navigation journey', async ({ page }) => {
 
   await page.getByTitle('My bets').click();
   await expect(page).toHaveURL(/\/bets/);
-  await expect(page.getByTitle('Backoffice')).toHaveCount(0);
+  if (!allowLegacyAdminUi) {
+    await expect(page.getByTitle('Backoffice')).toHaveCount(0);
+  }
 
   await page.getByTitle('Log out').click();
   await expect(page.getByTitle('Log in')).toBeVisible();

--- a/infra/oci/agents/test-health-contract-stan.sh
+++ b/infra/oci/agents/test-health-contract-stan.sh
@@ -267,6 +267,8 @@ cat > "$WORK_DIR/bin/playwright" <<'STUB'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'playwright-ran\n' >> "${STUB_PLAYWRIGHT_LOG:?}"
+printf 'legacy-admin-ui=%s\n' "${OCI_ALLOW_LEGACY_ADMIN_UI:?}" \
+  >> "${STUB_PLAYWRIGHT_LOG:?}"
 STUB
 chmod +x "$WORK_DIR/bin/playwright"
 : > "$WORK_DIR/playwright.log"
@@ -299,6 +301,24 @@ OUTPUT_DIR="$WORK_DIR/public-only" \
   grep -q 'oci_validation_loop=PASS'
 grep -Fq 'playwright-ran' "$WORK_DIR/playwright.log" ||
   { echo "public-only validation skipped browser checks" >&2; exit 1; }
+grep -Fq 'legacy-admin-ui=0' "$WORK_DIR/playwright.log" ||
+  { echo "public validation did not default to strict admin UI checks" >&2; exit 1; }
+: > "$WORK_DIR/playwright.log"
+PATH="$WORK_DIR/bin:$PATH" \
+PLAYWRIGHT_BIN="$WORK_DIR/bin/playwright" \
+STUB_PLAYWRIGHT_LOG="$WORK_DIR/playwright.log" \
+OCI_PUBLIC_URL=https://betstan.xyz \
+OCI_REDIRECT_URL=https://www.betstan.xyz \
+OCI_DIAGNOSTIC_URL=https://203.0.113.10.nip.io \
+OCI_CLUSTER_CHECKS_ALREADY_PASSED=1 \
+OCI_ALLOW_LEGACY_ADMIN_UI=1 \
+MAX_LOOPS=1 \
+SLEEP_SECONDS=1 \
+OUTPUT_DIR="$WORK_DIR/legacy-public" \
+  "$OCI_DIR/agents/validation-loop-stan.sh" |
+  grep -q 'oci_validation_loop=PASS'
+grep -Fq 'legacy-admin-ui=1' "$WORK_DIR/playwright.log" ||
+  { echo "historical recovery UI control did not reach browser checks" >&2; exit 1; }
 
 if OCI_PUBLIC_URL=https://betstan.xyz \
     OCI_REDIRECT_URL=https://www.betstan.xyz \
@@ -312,5 +332,15 @@ if OCI_PUBLIC_URL=https://betstan.xyz \
   echo "validation loop accepted skipping both public and cluster checks" >&2
   exit 1
 fi
+if OCI_ALLOW_LEGACY_ADMIN_UI=unexpected \
+    OCI_PUBLIC_URL=https://betstan.xyz \
+    OCI_REDIRECT_URL=https://www.betstan.xyz \
+    OCI_DIAGNOSTIC_URL=https://203.0.113.10.nip.io \
+    MAX_LOOPS=1 \
+    SLEEP_SECONDS=1 \
+      "$OCI_DIR/agents/validation-loop-stan.sh" >/dev/null 2>&1; then
+  echo "validation loop accepted an invalid legacy admin UI control" >&2
+  exit 1
+fi
 
-echo "oci_health_fixture_contract=PASS scenarios=40"
+echo "oci_health_fixture_contract=PASS scenarios=42"

--- a/infra/oci/agents/validation-loop-stan.sh
+++ b/infra/oci/agents/validation-loop-stan.sh
@@ -13,6 +13,7 @@ PLAYWRIGHT_BIN="${PLAYWRIGHT_BIN:-$ROOT_DIR/client/node_modules/.bin/playwright}
 OCI_PUBLIC_CHECKS_ALREADY_PASSED="${OCI_PUBLIC_CHECKS_ALREADY_PASSED:-0}"
 OCI_E2E_ALREADY_PASSED="${OCI_E2E_ALREADY_PASSED:-0}"
 OCI_CLUSTER_CHECKS_ALREADY_PASSED="${OCI_CLUSTER_CHECKS_ALREADY_PASSED:-0}"
+OCI_ALLOW_LEGACY_ADMIN_UI="${OCI_ALLOW_LEGACY_ADMIN_UI:-0}"
 
 [[ "$MAX_LOOPS" =~ ^[1-9][0-9]*$ ]] || {
   echo "NO_GO validation_reason=MAX_LOOPS must be positive" >&2
@@ -28,7 +29,7 @@ OCI_CLUSTER_CHECKS_ALREADY_PASSED="${OCI_CLUSTER_CHECKS_ALREADY_PASSED:-0}"
 }
 for value in \
   OCI_PUBLIC_CHECKS_ALREADY_PASSED OCI_E2E_ALREADY_PASSED \
-  OCI_CLUSTER_CHECKS_ALREADY_PASSED; do
+  OCI_CLUSTER_CHECKS_ALREADY_PASSED OCI_ALLOW_LEGACY_ADMIN_UI; do
   [[ "${!value}" == "0" || "${!value}" == "1" ]] || {
     echo "NO_GO validation_reason=$value must be 0 or 1" >&2
     exit 1
@@ -60,6 +61,7 @@ for attempt in $(seq 1 "$MAX_LOOPS"); do
       NODE_PATH="$ROOT_DIR/client/node_modules" \
       E2E_BASE_URL="$OCI_PUBLIC_URL" \
       OCI_E2E_OUTPUT_DIR="$OUTPUT_DIR/e2e-${attempt}" \
+      OCI_ALLOW_LEGACY_ADMIN_UI="$OCI_ALLOW_LEGACY_ADMIN_UI" \
         "$PLAYWRIGHT_BIN" test --config "$OCI_DIR/agents/playwright.config.js"
     ); then
       public_ok=true

--- a/infra/oci/tests/test-ghcr-contract.sh
+++ b/infra/oci/tests/test-ghcr-contract.sh
@@ -720,6 +720,7 @@ for literal in \
   'retire-ocir:' \
   'TRANSITION_PHASE: retire' \
   'RETIRE_OCIR_REPOSITORY: "1"' \
+  'OCI_ALLOW_LEGACY_ADMIN_UI: "1"' \
   './infra/oci/agents/validation-loop-stan.sh'; do
   grep -Fq -- "$literal" "$ROOT_DIR/.github/workflows/oci-ghcr-cache-recovery.yml" ||
     fail "recovery workflow lacks resumable inputs or terminal health validation: $literal"
@@ -801,7 +802,8 @@ for artifact in ("transition-plan.tsv", "rabbitmq-baseline.txt",
     if artifact not in text:
         raise SystemExit(f"recovery transition omits immutable plan artifact: {artifact}")
 
-workflow = Path(sys.argv[1]).parents[3] / ".github/workflows/oci-ghcr-cache-recovery.yml"
+root = Path(sys.argv[1]).parents[3]
+workflow = root / ".github/workflows/oci-ghcr-cache-recovery.yml"
 workflow_text = workflow.read_text(encoding="utf-8")
 if workflow_text.index("Upload immutable pre-rebind plan before rollout") > workflow_text.index(
     "Sequentially rebind verified GHCR digests"
@@ -809,6 +811,17 @@ if workflow_text.index("Upload immutable pre-rebind plan before rollout") > work
     raise SystemExit("pre-rebind plan is not uploaded before Deployment mutation")
 if workflow_text.index("public-validate:") > workflow_text.index("retire-ocir:"):
     raise SystemExit("OCIR retirement is not deferred until public validation")
+public_validation = workflow_text.split("  public-validate:", 1)[1].split(
+    "  retire-ocir:", 1
+)[0]
+if public_validation.count('OCI_ALLOW_LEGACY_ADMIN_UI: "1"') != 1:
+    raise SystemExit("historical baseline UI compatibility is not scoped to public validation")
+smoke = root / "infra/oci/agents/oci-live-smoke.spec.js"
+smoke_text = smoke.read_text(encoding="utf-8")
+if "process.env.OCI_ALLOW_LEGACY_ADMIN_UI === '1'" not in smoke_text:
+    raise SystemExit("browser smoke does not consume the historical UI compatibility control")
+if "if (!allowLegacyAdminUi)" not in smoke_text:
+    raise SystemExit("browser smoke does not default to strict Backoffice authorization")
 if 'needs: [recover, public-validate]' not in workflow_text:
     raise SystemExit("OCIR retirement does not depend on successful public validation")
 if 'validate_run oci-infrastructure.yml "$INFRASTRUCTURE_RUN_ID" workflow_dispatch \\\n            "$SOURCE_SHA"' not in workflow_text:


### PR DESCRIPTION
## Summary
- keep ordinary browser validation strict for persisted-role Backoffice authorization
- add a fail-closed `0`/`1` compatibility control propagated explicitly to Playwright
- enable it only in the historical baseline recovery public-validation job
- cover strict default, scoped legacy mode, invalid values, and workflow scoping

## Recovery evidence
Run `32938055703` successfully published all nine exact GHCR images, uploaded the immutable transition plan, rebound every Deployment, and passed cluster/API/queue/rollback checks. Public liveness also passed. Its only failure was applying the newer role-aware navigation assertion to the older recovered image; OCIR retirement remained blocked.

Current client and backoffice authorization tests independently enforce the strict persisted-role behavior for the upcoming application deployment.

## Validation
- health fixture contract: 42 scenarios
- focused GHCR contract suite: pass
- complete OCI contract matrix: 15/15 suites
- shell/Node syntax and `git diff --check`: pass
