### PR TITLE
Promote OCIR retirement authentication fix

### DIFF
--- a/.github/workflows/oci-ghcr-cache-recovery.yml
+++ b/.github/workflows/oci-ghcr-cache-recovery.yml
@@ -590,6 +590,11 @@ jobs:
 
       - name: Retire OCIR credentials and empty repository after public validation
         env:
+          OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}
+          OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}
+          OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}
+          OCI_CLI_REGION: ${{ vars.OCI_REGION }}
           RECOVERY_DIR: artifacts/ghcr-cache-recovery
           OUTPUT_DIR: artifacts/ghcr-cache-recovery
           INFRA_PROVENANCE_FILE: artifacts/infrastructure/provenance.env

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -310,6 +310,11 @@ cd resulting && npm ci && npm run test:ci
   actually had. Keep current authorization checks strict by default, but scope
   an explicit compatibility switch to historical recovery validation when a
   later UI capability is independently covered by current service/client tests.
+- GitHub Actions step-scoped OCI credentials do not persist into later steps.
+  Every OCI CLI step must map the reviewed user, tenancy, fingerprint,
+  private-key content, and region explicitly; otherwise a noninteractive run
+  may report only `Abort:`. Lock the complete credential mapping in a workflow
+  contract rather than relying on an earlier authenticated step.
 - Capture rollback evidence before any database lock or workload/data
   mutation. A zero-recovery baseline is valid only when all nine live
   references and exact deploy provenance are public GHCR digests; otherwise

--- a/infra/oci/LESSONS_LEARNED.md
+++ b/infra/oci/LESSONS_LEARNED.md
@@ -107,6 +107,11 @@ conversation summaries are not authority.
   recovery smoke. Default the current browser journey to strict persisted-role
   checks, and allow the legacy UI only in the recovery public-validation job;
   current client and backoffice authorization tests remain mandatory.
+- GitHub Actions step-scoped OCI credentials do not carry into a later step.
+  Every step that invokes OCI CLI must explicitly receive the reviewed user,
+  tenancy, fingerprint, private-key content, and region variables. Otherwise
+  a noninteractive runner can emit only `Abort:` instead of an actionable
+  authentication error; enforce the complete mapping in workflow contracts.
 - Boot every published image against clean pinned dependencies before granting
   build authority. MongoDB index inspection returns error 26 when a collection
   has never existed; handle only that exact empty-namespace case as no indexes

--- a/infra/oci/tests/test-ghcr-contract.sh
+++ b/infra/oci/tests/test-ghcr-contract.sh
@@ -824,6 +824,20 @@ if "if (!allowLegacyAdminUi)" not in smoke_text:
     raise SystemExit("browser smoke does not default to strict Backoffice authorization")
 if 'needs: [recover, public-validate]' not in workflow_text:
     raise SystemExit("OCIR retirement does not depend on successful public validation")
+retirement = workflow_text.split(
+    "      - name: Retire OCIR credentials and empty repository after public validation", 1
+)[1].split("      - name: Close retained protected k3s access", 1)[0]
+for credential in (
+    "OCI_CLI_USER: ${{ vars.OCI_CI_USER_OCID }}",
+    "OCI_CLI_TENANCY: ${{ vars.OCI_TENANCY_OCID }}",
+    "OCI_CLI_FINGERPRINT: ${{ vars.OCI_CI_KEY_FINGERPRINT }}",
+    "OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CI_PRIVATE_KEY_PEM }}",
+    "OCI_CLI_REGION: ${{ vars.OCI_REGION }}",
+):
+    if credential not in retirement:
+        raise SystemExit(
+            f"OCIR retirement lacks required step-scoped OCI credential: {credential}"
+        )
 if 'validate_run oci-infrastructure.yml "$INFRASTRUCTURE_RUN_ID" workflow_dispatch \\\n            "$SOURCE_SHA"' not in workflow_text:
     raise SystemExit("cache recovery is not bound to baseline infrastructure provenance")
 


### PR DESCRIPTION
## Summary
- promote the scoped OCI authentication fix for terminal legacy registry retirement
- include the workflow regression contract and durable operational learning

## Validation
- PR #326 checks passed
- `bash infra/oci/tests/test-ghcr-contract.sh`