### PR TITLE
Promote terminal recovery artifact fix

### DIFF
--- a/.github/workflows/oci-ghcr-cache-recovery.yml
+++ b/.github/workflows/oci-ghcr-cache-recovery.yml
@@ -620,6 +620,23 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ghcr-cache-recovery-${{ inputs.baseline_source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: artifacts/ghcr-cache-recovery
+          path: |
+            artifacts/ghcr-cache-recovery/SHA256SUMS
+            artifacts/ghcr-cache-recovery/auth.env
+            artifacts/ghcr-cache-recovery/backoffice.env
+            artifacts/ghcr-cache-recovery/bet.env
+            artifacts/ghcr-cache-recovery/client.env
+            artifacts/ghcr-cache-recovery/event.env
+            artifacts/ghcr-cache-recovery/gamemaster.env
+            artifacts/ghcr-cache-recovery/images.tsv
+            artifacts/ghcr-cache-recovery/moderation.env
+            artifacts/ghcr-cache-recovery/rabbitmq-baseline.txt
+            artifacts/ghcr-cache-recovery/rebind-provenance.env
+            artifacts/ghcr-cache-recovery/recovery-evidence.env
+            artifacts/ghcr-cache-recovery/resulting.env
+            artifacts/ghcr-cache-recovery/slip.env
+            artifacts/ghcr-cache-recovery/transition-plan-evidence.env
+            artifacts/ghcr-cache-recovery/transition-plan.tsv
+            artifacts/ghcr-cache-recovery/transition-provenance.env
           if-no-files-found: error
           retention-days: 30

--- a/infra/oci/tests/test-ghcr-contract.sh
+++ b/infra/oci/tests/test-ghcr-contract.sh
@@ -838,6 +838,34 @@ for credential in (
         raise SystemExit(
             f"OCIR retirement lacks required step-scoped OCI credential: {credential}"
         )
+terminal_upload = workflow_text.split(
+    "      - name: Upload first-attempt recovery provenance", 1
+)[1]
+terminal_paths = [
+    line.strip()
+    for line in terminal_upload.splitlines()
+    if line.strip().startswith("artifacts/ghcr-cache-recovery/")
+]
+expected_terminal_paths = {
+    "artifacts/ghcr-cache-recovery/SHA256SUMS",
+    *(f"artifacts/ghcr-cache-recovery/{service}.env" for service in (
+        "auth", "bet", "backoffice", "client", "event", "gamemaster",
+        "moderation", "resulting", "slip",
+    )),
+    "artifacts/ghcr-cache-recovery/images.tsv",
+    "artifacts/ghcr-cache-recovery/rabbitmq-baseline.txt",
+    "artifacts/ghcr-cache-recovery/rebind-provenance.env",
+    "artifacts/ghcr-cache-recovery/recovery-evidence.env",
+    "artifacts/ghcr-cache-recovery/transition-plan-evidence.env",
+    "artifacts/ghcr-cache-recovery/transition-plan.tsv",
+    "artifacts/ghcr-cache-recovery/transition-provenance.env",
+}
+if len(terminal_paths) != len(set(terminal_paths)):
+    raise SystemExit("terminal recovery authority contains duplicate paths")
+if set(terminal_paths) != expected_terminal_paths:
+    raise SystemExit("terminal recovery authority does not match its exact checksum-bound file set")
+if "          path: artifacts/ghcr-cache-recovery\n" in terminal_upload:
+    raise SystemExit("terminal recovery authority still uploads unbound diagnostics")
 if 'validate_run oci-infrastructure.yml "$INFRASTRUCTURE_RUN_ID" workflow_dispatch \\\n            "$SOURCE_SHA"' not in workflow_text:
     raise SystemExit("cache recovery is not bound to baseline infrastructure provenance")
 


### PR DESCRIPTION
## Summary
Promote the checksum-bound terminal recovery artifact fix from `dev` to `master` so the protected live-data rollout can consume a regenerated recovery authority.

## Validation
- PR #329 checks passed
- `bash infra/oci/tests/test-ghcr-contract.sh`
- `git diff --check`

## Production safety
The failed dry-run stopped before database lock acquisition or mutation. This promotion changes only recovery artifact packaging and its contract test.
